### PR TITLE
Embed git short SHA in version and artifact names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,8 @@ jobs:
       - id: artifact-name
         run: |-
           os=$(echo "${{ runner.os }}" | tr '[:upper:]' '[:lower:]')
-          echo "name=mempalace-$os-${{ matrix.arch }}" >> "$GITHUB_OUTPUT"
+          sha=$(git rev-parse --short HEAD)
+          echo "name=mempalace-$os-${{ matrix.arch }}-$sha" >> "$GITHUB_OUTPUT"
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:

--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,16 @@
+/// Build script: embeds the current git short SHA as the `GIT_SHORT_SHA` env var.
+/// Falls back to `"unknown"` when git is unavailable.
 fn main() {
-    let output = std::process::Command::new("git")
+    let sha = std::process::Command::new("git")
         .args(["rev-parse", "--short", "HEAD"])
         .output()
-        .expect("failed to run git");
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .unwrap_or_else(|| "unknown".to_string());
 
-    assert!(output.status.success(), "git rev-parse failed");
-
-    let sha = String::from_utf8_lossy(&output.stdout);
     println!("cargo:rustc-env=GIT_SHORT_SHA={}", sha.trim());
     println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/refs/heads");
+    println!("cargo:rerun-if-changed=.git/packed-refs");
 }

--- a/build.rs
+++ b/build.rs
@@ -7,9 +7,11 @@ fn main() {
         .ok()
         .filter(|output| output.status.success())
         .and_then(|output| String::from_utf8(output.stdout).ok())
-        .unwrap_or_else(|| "unknown".to_string());
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_owned());
 
-    println!("cargo:rustc-env=GIT_SHORT_SHA={}", sha.trim());
+    println!("cargo:rustc-env=GIT_SHORT_SHA={sha}");
     println!("cargo:rerun-if-changed=.git/HEAD");
     println!("cargo:rerun-if-changed=.git/refs/heads");
     println!("cargo:rerun-if-changed=.git/packed-refs");

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,12 @@
+fn main() {
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .expect("failed to run git");
+
+    assert!(output.status.success(), "git rev-parse failed");
+
+    let sha = String::from_utf8_lossy(&output.stdout);
+    println!("cargo:rustc-env=GIT_SHORT_SHA={}", sha.trim());
+    println!("cargo:rerun-if-changed=.git/HEAD");
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -15,7 +15,7 @@ use clap::{Parser, Subcommand};
 #[derive(Parser)]
 #[command(
     name = "mempalace",
-    version,
+    version = concat!(env!("CARGO_PKG_VERSION"), "-", env!("GIT_SHORT_SHA")),
     about = "A memory palace for AI assistants"
 )]
 pub struct Cli {


### PR DESCRIPTION
## Summary

- Add `build.rs` to bake the git short SHA into the binary at compile time via `cargo:rustc-env=GIT_SHORT_SHA`
- `--version` now reports `<version>-<sha>` (e.g. `0.1.0-abc1234`) so any binary is traceable to its exact commit
- Build workflow artifact names include the short SHA via `git rev-parse --short HEAD`, keeping artifact names consistent with what the binary reports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build artifacts now include a short commit SHA in their file names for clearer build identification.
  * Builds embed the short commit SHA into the produced binaries so the exact commit is visible.
  * CLI version output now appends the short commit SHA to the package version shown by --version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->