### PR TITLE
Add ad-hoc signing for macOS builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,10 @@ jobs:
 
       - run: cargo build --release
 
+      - name: Ad-hoc sign binary (macOS)
+        if: runner.os == 'macOS'
+        run: codesign --sign - --force --deep target/release/mempalace
+
       - id: artifact-name
         run: |-
           os=$(echo "${{ runner.os }}" | tr '[:upper:]' '[:lower:]')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Ad-hoc sign binary (macOS)
         if: runner.os == 'macOS'
-        run: codesign --sign - --force --deep target/release/mempalace
+        run: codesign --sign - --force target/release/mempalace
 
       - id: artifact-name
         run: |-


### PR DESCRIPTION
## Summary

- Adds an ad-hoc `codesign` step to the macOS build in `build.yml`
- Runs only on macOS runners (`if: runner.os == 'macOS'`)
- Partially mitigates Gatekeeper blocking downloaded binaries; users may still need `xattr -d com.apple.quarantine mempalace` on first launch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented code signing for macOS binaries to enhance compatibility and security on macOS platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->