### PR TITLE
Allow multiple processes to open the database concurrently

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["command-line-utilities", "database"]
 rust-version = "1.85"
 
 [lints.rust]
-unsafe_code = "forbid"
+unsafe_code = "deny"
 warnings = "deny"
 
 [lints.clippy]

--- a/src/db.rs
+++ b/src/db.rs
@@ -11,19 +11,10 @@ use crate::error::Result;
 /// For file-backed databases, WAL journal mode is enabled for better concurrency
 /// and crash recovery when multiple MCP clients write simultaneously.
 /// In-memory databases skip the WAL pragma since it is not applicable.
-#[allow(unsafe_code)]
+///
+/// Callers are expected to have set `LIMBO_DISABLE_FILE_LOCK` before the Tokio
+/// runtime starts (see `main()`).
 pub async fn open_db(path: &str) -> Result<(Database, Connection)> {
-    // Disable turso/limbo's exclusive file lock so multiple processes (e.g.
-    // concurrent MCP servers or CLI commands) can access the same database.
-    // WAL mode provides the necessary concurrency control at the protocol level.
-    // See: https://github.com/bunkerlab-net/mempalace/issues/9
-    //
-    // SAFETY: set_var is unsafe due to thread-safety concerns, but this runs
-    // before any other threads access the environment.
-    unsafe {
-        std::env::set_var("LIMBO_DISABLE_FILE_LOCK", "1");
-    }
-
     let db = Builder::new_local(path)
         .experimental_triggers(true)
         .build()

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,5 +1,7 @@
 //! Database connection helpers for the embedded turso/SQLite engine.
 
+use std::time::Duration;
+
 use turso::{Builder, Connection, Database};
 
 use crate::error::Result;
@@ -9,7 +11,19 @@ use crate::error::Result;
 /// For file-backed databases, WAL journal mode is enabled for better concurrency
 /// and crash recovery when multiple MCP clients write simultaneously.
 /// In-memory databases skip the WAL pragma since it is not applicable.
+#[allow(unsafe_code)]
 pub async fn open_db(path: &str) -> Result<(Database, Connection)> {
+    // Disable turso/limbo's exclusive file lock so multiple processes (e.g.
+    // concurrent MCP servers or CLI commands) can access the same database.
+    // WAL mode provides the necessary concurrency control at the protocol level.
+    // See: https://github.com/bunkerlab-net/mempalace/issues/9
+    //
+    // SAFETY: set_var is unsafe due to thread-safety concerns, but this runs
+    // before any other threads access the environment.
+    unsafe {
+        std::env::set_var("LIMBO_DISABLE_FILE_LOCK", "1");
+    }
+
     let db = Builder::new_local(path)
         .experimental_triggers(true)
         .build()
@@ -25,6 +39,10 @@ pub async fn open_db(path: &str) -> Result<(Database, Connection)> {
         let mut wal_rows = conn.query("PRAGMA journal_mode=WAL", ()).await?;
         while wal_rows.next().await?.is_some() {}
     }
+
+    // Allow waiting up to 5 seconds for write locks when another process is
+    // writing, instead of failing immediately.
+    conn.busy_timeout(Duration::from_secs(5))?;
 
     Ok((db, conn))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,14 +18,31 @@ use clap::Parser;
 use cli::{Cli, Command};
 use config::MempalaceConfig;
 
-#[tokio::main]
-async fn main() {
-    let cli = Cli::parse();
-
-    if let Err(e) = run(cli).await {
-        eprintln!("error: {e}");
-        std::process::exit(1);
+// Disable turso/limbo's exclusive file lock before the Tokio runtime spawns
+// worker threads. This allows multiple mempalace processes (e.g. concurrent
+// MCP servers or CLI commands) to open the same database concurrently; WAL
+// mode provides the concurrency control at the protocol level.
+// See: https://github.com/bunkerlab-net/mempalace/issues/9
+//
+// SAFETY: set_var is unsafe because it is not thread-safe, but this runs
+// before the Tokio runtime is built and before any other threads exist.
+#[allow(unsafe_code)]
+fn main() {
+    unsafe {
+        std::env::set_var("LIMBO_DISABLE_FILE_LOCK", "1");
     }
+
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("failed to build tokio runtime")
+        .block_on(async {
+            let cli = Cli::parse();
+            if let Err(e) = run(cli).await {
+                eprintln!("error: {e}");
+                std::process::exit(1);
+            }
+        });
 }
 
 /// Open the palace DB, ensuring schema exists. Returns `(db, conn, path)`.

--- a/tests/concurrent_access.rs
+++ b/tests/concurrent_access.rs
@@ -1,3 +1,26 @@
+// NOTE: This is a binary crate (no `[lib]` target), so integration tests
+// cannot import `db::open_db` directly. The helpers below replicate its
+// setup (experimental_triggers, WAL pragma, busy_timeout) so the same
+// production code path is exercised without duplicating the logic.
+
+async fn open_db_setup(path_str: &str) -> (turso::Database, turso::Connection) {
+    use std::time::Duration;
+    let db = turso::Builder::new_local(path_str)
+        .experimental_triggers(true)
+        .build()
+        .await
+        .expect("db open failed");
+    let conn = db.connect().expect("connect failed");
+    let mut rows = conn
+        .query("PRAGMA journal_mode=WAL", ())
+        .await
+        .expect("WAL pragma failed");
+    while rows.next().await.expect("row error").is_some() {}
+    conn.busy_timeout(Duration::from_secs(5))
+        .expect("busy_timeout failed");
+    (db, conn)
+}
+
 /// Verify that multiple processes can open the same database file concurrently
 /// when `LIMBO_DISABLE_FILE_LOCK` is set. Regression test for
 /// <https://github.com/bunkerlab-net/mempalace/issues/9>
@@ -8,22 +31,16 @@ async fn two_connections_to_same_file() {
     let db_path = dir.path().join("palace.db");
     let path_str = db_path.to_str().expect("non-utf8 path");
 
-    // Disable turso's exclusive file lock (same as open_db does at runtime).
+    // In production, main() sets this before the Tokio runtime starts.
+    // Replicate that here since tests have no main().
     unsafe {
         std::env::set_var("LIMBO_DISABLE_FILE_LOCK", "1");
     }
 
     // First "process" opens the database and holds the connection.
-    let db1 = turso::Builder::new_local(path_str)
-        .build()
-        .await
-        .expect("first open failed");
-    let conn1 = db1.connect().expect("first connect failed");
-    let mut rows = conn1
-        .query("PRAGMA journal_mode=WAL", ())
-        .await
-        .expect("WAL pragma failed");
-    while rows.next().await.expect("row error").is_some() {}
+    let (db1, conn1) = open_db_setup(path_str).await;
+    // Keep db1 alive so the lock stays held for the duration of the test.
+    let _db1 = db1;
 
     conn1
         .execute(
@@ -34,11 +51,7 @@ async fn two_connections_to_same_file() {
         .expect("create table failed");
 
     // Second "process" opens the same file — this would fail without the fix.
-    let db2 = turso::Builder::new_local(path_str)
-        .build()
-        .await
-        .expect("second open failed — file lock not disabled?");
-    let conn2 = db2.connect().expect("second connect failed");
+    let (_db2, conn2) = open_db_setup(path_str).await;
 
     conn2
         .execute(

--- a/tests/concurrent_access.rs
+++ b/tests/concurrent_access.rs
@@ -61,3 +61,64 @@ async fn two_connections_to_same_file() {
     let val: String = row.get(0).expect("get column failed");
     assert_eq!(val, "hello");
 }
+
+/// Verify that a second open of the same database file fails with a locking
+/// error when `LIMBO_DISABLE_FILE_LOCK` is not set. This confirms that the
+/// positive test above is actually testing something meaningful.
+///
+/// POSIX `fcntl` locks are per-process, so opening the file twice from the
+/// same process does not produce a conflict. A subprocess is used to hold the
+/// lock while the parent attempts a second open.
+///
+/// Child-process protocol (invoked via `_MEMPALACE_TEST_LOCK_PATH`):
+///   exit 0 — open was blocked by the lock (expected)
+///   exit 1 — open succeeded despite the lock (unexpected)
+#[allow(unsafe_code)]
+#[tokio::test]
+async fn second_open_fails_without_lock_disabled() {
+    // --- Child-process path -------------------------------------------
+    // When spawned as the lock-probe, try to open the file and report
+    // whether the lock blocked us. Exit immediately so the test harness
+    // does not run further tests in this subprocess.
+    if let Ok(path) = std::env::var("_MEMPALACE_TEST_LOCK_PATH") {
+        let blocked = turso::Builder::new_local(&path).build().await.is_err();
+        std::process::exit(i32::from(!blocked));
+    }
+
+    // --- Parent-process path ------------------------------------------
+    let dir = tempfile::tempdir().expect("failed to create temp dir");
+    let db_path = dir.path().join("palace.db");
+    let path_str = db_path.to_str().expect("non-utf8 path");
+
+    // Ensure the escape-hatch env var is absent so turso acquires its
+    // default exclusive file lock.
+    //
+    // SAFETY: remove_var is unsafe due to thread-safety, but this runs
+    // before any other threads access the environment in this process.
+    unsafe {
+        std::env::remove_var("LIMBO_DISABLE_FILE_LOCK");
+    }
+
+    // Open the database; this acquires an exclusive fcntl lock on the file.
+    let _db1 = turso::Builder::new_local(path_str)
+        .build()
+        .await
+        .expect("first open failed");
+
+    // Spawn a child process that tries to open the same file without the
+    // env-var escape hatch. Exit code 0 means the lock correctly blocked it.
+    let current_exe = std::env::current_exe().expect("failed to get current exe");
+    let status = std::process::Command::new(current_exe)
+        .env("_MEMPALACE_TEST_LOCK_PATH", path_str)
+        .env_remove("LIMBO_DISABLE_FILE_LOCK")
+        // Filter to this test so the child harness does not run other tests
+        // before hitting the early-exit branch above.
+        .args(["second_open_fails_without_lock_disabled"])
+        .status()
+        .expect("failed to spawn child process");
+
+    assert!(
+        status.success(),
+        "second open should have been blocked by the exclusive file lock"
+    );
+}

--- a/tests/concurrent_access.rs
+++ b/tests/concurrent_access.rs
@@ -21,58 +21,70 @@ async fn open_db_setup(path_str: &str) -> (turso::Database, turso::Connection) {
     (db, conn)
 }
 
+fn current_thread_runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("failed to build tokio runtime")
+}
+
 /// Verify that multiple processes can open the same database file concurrently
 /// when `LIMBO_DISABLE_FILE_LOCK` is set. Regression test for
 /// <https://github.com/bunkerlab-net/mempalace/issues/9>
 #[allow(unsafe_code)]
-#[tokio::test]
-async fn two_connections_to_same_file() {
-    let dir = tempfile::tempdir().expect("failed to create temp dir");
-    let db_path = dir.path().join("palace.db");
-    let path_str = db_path.to_str().expect("non-utf8 path");
-
-    // In production, main() sets this before the Tokio runtime starts.
-    // Replicate that here since tests have no main().
+#[test]
+fn two_connections_to_same_file() {
+    // Set the env var before the runtime starts so no other thread can be
+    // reading the environment concurrently — mirrors what main() does.
+    //
+    // SAFETY: this is the only thread in the process at this point; the
+    // Tokio runtime is started on the next line.
     unsafe {
         std::env::set_var("LIMBO_DISABLE_FILE_LOCK", "1");
     }
 
-    // First "process" opens the database and holds the connection.
-    let (db1, conn1) = open_db_setup(path_str).await;
-    // Keep db1 alive so the lock stays held for the duration of the test.
-    let _db1 = db1;
+    current_thread_runtime().block_on(async {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let db_path = dir.path().join("palace.db");
+        let path_str = db_path.to_str().expect("non-utf8 path");
 
-    conn1
-        .execute(
-            "CREATE TABLE IF NOT EXISTS test_table (id TEXT PRIMARY KEY, val TEXT)",
-            (),
-        )
-        .await
-        .expect("create table failed");
+        // First "process" opens the database and holds the connection.
+        let (db1, conn1) = open_db_setup(path_str).await;
+        // Keep db1 alive so the lock stays held for the duration of the test.
+        let _db1 = db1;
 
-    // Second "process" opens the same file — this would fail without the fix.
-    let (_db2, conn2) = open_db_setup(path_str).await;
+        conn1
+            .execute(
+                "CREATE TABLE IF NOT EXISTS test_table (id TEXT PRIMARY KEY, val TEXT)",
+                (),
+            )
+            .await
+            .expect("create table failed");
 
-    conn2
-        .execute(
-            "INSERT INTO test_table (id, val) VALUES ('k1', 'hello')",
-            (),
-        )
-        .await
-        .expect("insert from second connection failed");
+        // Second "process" opens the same file — this would fail without the fix.
+        let (_db2, conn2) = open_db_setup(path_str).await;
 
-    // Verify the first connection can read the write.
-    let mut read_rows = conn1
-        .query("SELECT val FROM test_table WHERE id = 'k1'", ())
-        .await
-        .expect("select failed");
-    let row = read_rows
-        .next()
-        .await
-        .expect("row error")
-        .expect("expected one row");
-    let val: String = row.get(0).expect("get column failed");
-    assert_eq!(val, "hello");
+        conn2
+            .execute(
+                "INSERT INTO test_table (id, val) VALUES ('k1', 'hello')",
+                (),
+            )
+            .await
+            .expect("insert from second connection failed");
+
+        // Verify the first connection can read the write.
+        let mut read_rows = conn1
+            .query("SELECT val FROM test_table WHERE id = 'k1'", ())
+            .await
+            .expect("select failed");
+        let row = read_rows
+            .next()
+            .await
+            .expect("row error")
+            .expect("expected one row");
+        let val: String = row.get(0).expect("get column failed");
+        assert_eq!(val, "hello");
+    });
 }
 
 /// Verify that a second open of the same database file fails with a locking
@@ -87,51 +99,54 @@ async fn two_connections_to_same_file() {
 ///   exit 0 — open was blocked by the lock (expected)
 ///   exit 1 — open succeeded despite the lock (unexpected)
 #[allow(unsafe_code)]
-#[tokio::test]
-async fn second_open_fails_without_lock_disabled() {
+#[test]
+fn second_open_fails_without_lock_disabled() {
     // --- Child-process path -------------------------------------------
     // When spawned as the lock-probe, try to open the file and report
     // whether the lock blocked us. Exit immediately so the test harness
     // does not run further tests in this subprocess.
     if let Ok(path) = std::env::var("_MEMPALACE_TEST_LOCK_PATH") {
-        let blocked = turso::Builder::new_local(&path).build().await.is_err();
+        let blocked = current_thread_runtime()
+            .block_on(async { turso::Builder::new_local(&path).build().await.is_err() });
         std::process::exit(i32::from(!blocked));
     }
 
     // --- Parent-process path ------------------------------------------
-    let dir = tempfile::tempdir().expect("failed to create temp dir");
-    let db_path = dir.path().join("palace.db");
-    let path_str = db_path.to_str().expect("non-utf8 path");
-
-    // Ensure the escape-hatch env var is absent so turso acquires its
-    // default exclusive file lock.
+    // Remove the env var before the runtime starts so no other thread can
+    // be reading the environment concurrently — mirrors what main() does.
     //
-    // SAFETY: remove_var is unsafe due to thread-safety, but this runs
-    // before any other threads access the environment in this process.
+    // SAFETY: this is the only thread in the process at this point; the
+    // Tokio runtime is started on the next line.
     unsafe {
         std::env::remove_var("LIMBO_DISABLE_FILE_LOCK");
     }
 
-    // Open the database; this acquires an exclusive fcntl lock on the file.
-    let _db1 = turso::Builder::new_local(path_str)
-        .build()
-        .await
-        .expect("first open failed");
+    current_thread_runtime().block_on(async {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let db_path = dir.path().join("palace.db");
+        let path_str = db_path.to_str().expect("non-utf8 path");
 
-    // Spawn a child process that tries to open the same file without the
-    // env-var escape hatch. Exit code 0 means the lock correctly blocked it.
-    let current_exe = std::env::current_exe().expect("failed to get current exe");
-    let status = std::process::Command::new(current_exe)
-        .env("_MEMPALACE_TEST_LOCK_PATH", path_str)
-        .env_remove("LIMBO_DISABLE_FILE_LOCK")
-        // Filter to this test so the child harness does not run other tests
-        // before hitting the early-exit branch above.
-        .args(["second_open_fails_without_lock_disabled"])
-        .status()
-        .expect("failed to spawn child process");
+        // Open the database; this acquires an exclusive fcntl lock on the file.
+        let _db1 = turso::Builder::new_local(path_str)
+            .build()
+            .await
+            .expect("first open failed");
 
-    assert!(
-        status.success(),
-        "second open should have been blocked by the exclusive file lock"
-    );
+        // Spawn a child process that tries to open the same file without the
+        // env-var escape hatch. Exit code 0 means the lock correctly blocked it.
+        let current_exe = std::env::current_exe().expect("failed to get current exe");
+        let status = std::process::Command::new(current_exe)
+            .env("_MEMPALACE_TEST_LOCK_PATH", path_str)
+            .env_remove("LIMBO_DISABLE_FILE_LOCK")
+            // Filter to this test so the child harness does not run other tests
+            // before hitting the early-exit branch above.
+            .args(["second_open_fails_without_lock_disabled"])
+            .status()
+            .expect("failed to spawn child process");
+
+        assert!(
+            status.success(),
+            "second open should have been blocked by the exclusive file lock"
+        );
+    });
 }

--- a/tests/concurrent_access.rs
+++ b/tests/concurrent_access.rs
@@ -1,0 +1,63 @@
+/// Verify that multiple processes can open the same database file concurrently
+/// when `LIMBO_DISABLE_FILE_LOCK` is set. Regression test for
+/// <https://github.com/bunkerlab-net/mempalace/issues/9>
+#[allow(unsafe_code)]
+#[tokio::test]
+async fn two_connections_to_same_file() {
+    let dir = tempfile::tempdir().expect("failed to create temp dir");
+    let db_path = dir.path().join("palace.db");
+    let path_str = db_path.to_str().expect("non-utf8 path");
+
+    // Disable turso's exclusive file lock (same as open_db does at runtime).
+    unsafe {
+        std::env::set_var("LIMBO_DISABLE_FILE_LOCK", "1");
+    }
+
+    // First "process" opens the database and holds the connection.
+    let db1 = turso::Builder::new_local(path_str)
+        .build()
+        .await
+        .expect("first open failed");
+    let conn1 = db1.connect().expect("first connect failed");
+    let mut rows = conn1
+        .query("PRAGMA journal_mode=WAL", ())
+        .await
+        .expect("WAL pragma failed");
+    while rows.next().await.expect("row error").is_some() {}
+
+    conn1
+        .execute(
+            "CREATE TABLE IF NOT EXISTS test_table (id TEXT PRIMARY KEY, val TEXT)",
+            (),
+        )
+        .await
+        .expect("create table failed");
+
+    // Second "process" opens the same file — this would fail without the fix.
+    let db2 = turso::Builder::new_local(path_str)
+        .build()
+        .await
+        .expect("second open failed — file lock not disabled?");
+    let conn2 = db2.connect().expect("second connect failed");
+
+    conn2
+        .execute(
+            "INSERT INTO test_table (id, val) VALUES ('k1', 'hello')",
+            (),
+        )
+        .await
+        .expect("insert from second connection failed");
+
+    // Verify the first connection can read the write.
+    let mut read_rows = conn1
+        .query("SELECT val FROM test_table WHERE id = 'k1'", ())
+        .await
+        .expect("select failed");
+    let row = read_rows
+        .next()
+        .await
+        .expect("row error")
+        .expect("expected one row");
+    let val: String = row.get(0).expect("get column failed");
+    assert_eq!(val, "hello");
+}

--- a/tests/concurrent_access.rs
+++ b/tests/concurrent_access.rs
@@ -49,9 +49,8 @@ fn two_connections_to_same_file() {
         let path_str = db_path.to_str().expect("non-utf8 path");
 
         // First "process" opens the database and holds the connection.
-        let (db1, conn1) = open_db_setup(path_str).await;
-        // Keep db1 alive so the lock stays held for the duration of the test.
-        let _db1 = db1;
+        // Keep _db1 alive so the lock stays held for the duration of the test.
+        let (_db1, conn1) = open_db_setup(path_str).await;
 
         conn1
             .execute(

--- a/tests/concurrent_access.rs
+++ b/tests/concurrent_access.rs
@@ -1,26 +1,3 @@
-// NOTE: This is a binary crate (no `[lib]` target), so integration tests
-// cannot import `db::open_db` directly. The helpers below replicate its
-// setup (experimental_triggers, WAL pragma, busy_timeout) so the same
-// production code path is exercised without duplicating the logic.
-
-async fn open_db_setup(path_str: &str) -> (turso::Database, turso::Connection) {
-    use std::time::Duration;
-    let db = turso::Builder::new_local(path_str)
-        .experimental_triggers(true)
-        .build()
-        .await
-        .expect("db open failed");
-    let conn = db.connect().expect("connect failed");
-    let mut rows = conn
-        .query("PRAGMA journal_mode=WAL", ())
-        .await
-        .expect("WAL pragma failed");
-    while rows.next().await.expect("row error").is_some() {}
-    conn.busy_timeout(Duration::from_secs(5))
-        .expect("busy_timeout failed");
-    (db, conn)
-}
-
 fn current_thread_runtime() -> tokio::runtime::Runtime {
     tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -28,61 +5,62 @@ fn current_thread_runtime() -> tokio::runtime::Runtime {
         .expect("failed to build tokio runtime")
 }
 
-/// Verify that multiple processes can open the same database file concurrently
-/// when `LIMBO_DISABLE_FILE_LOCK` is set. Regression test for
-/// <https://github.com/bunkerlab-net/mempalace/issues/9>
-#[allow(unsafe_code)]
+/// Verify that a process with `LIMBO_DISABLE_FILE_LOCK` set can open the
+/// database even while another process holds the exclusive file lock.
+/// Regression test for <https://github.com/bunkerlab-net/mempalace/issues/9>
+///
+/// POSIX `fcntl` locks are per-process, so a cross-process test is required
+/// to exercise real locking behaviour. The parent opens normally (acquiring
+/// the lock); the child is spawned with `LIMBO_DISABLE_FILE_LOCK=1` and must
+/// succeed.
+///
+/// Child-process protocol (invoked via `_MEMPALACE_TEST_OPEN_PATH`):
+///   exit 0 — open succeeded (expected)
+///   exit 1 — open failed (unexpected)
 #[test]
 fn two_connections_to_same_file() {
-    // Set the env var before the runtime starts so no other thread can be
-    // reading the environment concurrently — mirrors what main() does.
-    //
-    // SAFETY: this is the only thread in the process at this point; the
-    // Tokio runtime is started on the next line.
-    unsafe {
-        std::env::set_var("LIMBO_DISABLE_FILE_LOCK", "1");
+    // --- Child-process path -------------------------------------------
+    // Spawned with LIMBO_DISABLE_FILE_LOCK=1. Try to open the file and
+    // report success or failure. Exit immediately so the test harness
+    // does not run further tests in this subprocess.
+    if let Ok(path) = std::env::var("_MEMPALACE_TEST_OPEN_PATH") {
+        let ok = current_thread_runtime()
+            .block_on(async { turso::Builder::new_local(&path).build().await.is_ok() });
+        std::process::exit(i32::from(!ok));
     }
 
+    // --- Parent-process path ------------------------------------------
+    // Open the database normally (no LIMBO_DISABLE_FILE_LOCK), which
+    // acquires an exclusive fcntl lock. Then spawn a child with the env
+    // var set and confirm it can open the same file.
     current_thread_runtime().block_on(async {
         let dir = tempfile::tempdir().expect("failed to create temp dir");
         let db_path = dir.path().join("palace.db");
         let path_str = db_path.to_str().expect("non-utf8 path");
 
-        // First "process" opens the database and holds the connection.
-        // Keep _db1 alive so the lock stays held for the duration of the test.
-        let (_db1, conn1) = open_db_setup(path_str).await;
-
-        conn1
-            .execute(
-                "CREATE TABLE IF NOT EXISTS test_table (id TEXT PRIMARY KEY, val TEXT)",
-                (),
-            )
+        // Open the database; this acquires an exclusive fcntl lock on the file.
+        let _db = turso::Builder::new_local(path_str)
+            .build()
             .await
-            .expect("create table failed");
+            .expect("parent open failed");
 
-        // Second "process" opens the same file — this would fail without the fix.
-        let (_db2, conn2) = open_db_setup(path_str).await;
+        // Spawn a child with LIMBO_DISABLE_FILE_LOCK=1 that tries to open the
+        // same file while the parent holds the lock.
+        // Exit code 0 means it succeeded (expected).
+        let current_exe = std::env::current_exe().expect("failed to get current exe");
+        let status = std::process::Command::new(current_exe)
+            .env("_MEMPALACE_TEST_OPEN_PATH", path_str)
+            .env("LIMBO_DISABLE_FILE_LOCK", "1")
+            // Filter to this test so the child harness does not run other tests
+            // before hitting the early-exit branch above.
+            .args(["two_connections_to_same_file"])
+            .status()
+            .expect("failed to spawn child process");
 
-        conn2
-            .execute(
-                "INSERT INTO test_table (id, val) VALUES ('k1', 'hello')",
-                (),
-            )
-            .await
-            .expect("insert from second connection failed");
-
-        // Verify the first connection can read the write.
-        let mut read_rows = conn1
-            .query("SELECT val FROM test_table WHERE id = 'k1'", ())
-            .await
-            .expect("select failed");
-        let row = read_rows
-            .next()
-            .await
-            .expect("row error")
-            .expect("expected one row");
-        let val: String = row.get(0).expect("get column failed");
-        assert_eq!(val, "hello");
+        assert!(
+            status.success(),
+            "open with LIMBO_DISABLE_FILE_LOCK=1 should succeed even with another process holding the lock"
+        );
     });
 }
 
@@ -97,7 +75,6 @@ fn two_connections_to_same_file() {
 /// Child-process protocol (invoked via `_MEMPALACE_TEST_LOCK_PATH`):
 ///   exit 0 — open was blocked by the lock (expected)
 ///   exit 1 — open succeeded despite the lock (unexpected)
-#[allow(unsafe_code)]
 #[test]
 fn second_open_fails_without_lock_disabled() {
     // --- Child-process path -------------------------------------------
@@ -111,15 +88,6 @@ fn second_open_fails_without_lock_disabled() {
     }
 
     // --- Parent-process path ------------------------------------------
-    // Remove the env var before the runtime starts so no other thread can
-    // be reading the environment concurrently — mirrors what main() does.
-    //
-    // SAFETY: this is the only thread in the process at this point; the
-    // Tokio runtime is started on the next line.
-    unsafe {
-        std::env::remove_var("LIMBO_DISABLE_FILE_LOCK");
-    }
-
     current_thread_runtime().block_on(async {
         let dir = tempfile::tempdir().expect("failed to create temp dir");
         let db_path = dir.path().join("palace.db");

--- a/tests/concurrent_access.rs
+++ b/tests/concurrent_access.rs
@@ -17,6 +17,7 @@ fn current_thread_runtime() -> tokio::runtime::Runtime {
 /// Child-process protocol (invoked via `_MEMPALACE_TEST_OPEN_PATH`):
 ///   exit 0 — open succeeded (expected)
 ///   exit 1 — open failed (unexpected)
+#[allow(unsafe_code)]
 #[test]
 fn two_connections_to_same_file() {
     // --- Child-process path -------------------------------------------
@@ -30,6 +31,16 @@ fn two_connections_to_same_file() {
     }
 
     // --- Parent-process path ------------------------------------------
+    // Ensure the env var is not set so the parent acquires a real fcntl
+    // lock. Without this, an externally set LIMBO_DISABLE_FILE_LOCK would
+    // cause the parent to skip locking and make the test a no-op.
+    //
+    // SAFETY: nextest runs each integration test in its own subprocess, so
+    // no other threads exist at this point.
+    unsafe {
+        std::env::remove_var("LIMBO_DISABLE_FILE_LOCK");
+    }
+
     // Open the database normally (no LIMBO_DISABLE_FILE_LOCK), which
     // acquires an exclusive fcntl lock. Then spawn a child with the env
     // var set and confirm it can open the same file.

--- a/tests/concurrent_access.rs
+++ b/tests/concurrent_access.rs
@@ -86,6 +86,7 @@ fn two_connections_to_same_file() {
 /// Child-process protocol (invoked via `_MEMPALACE_TEST_LOCK_PATH`):
 ///   exit 0 — open was blocked by the lock (expected)
 ///   exit 1 — open succeeded despite the lock (unexpected)
+#[allow(unsafe_code)]
 #[test]
 fn second_open_fails_without_lock_disabled() {
     // --- Child-process path -------------------------------------------
@@ -99,6 +100,16 @@ fn second_open_fails_without_lock_disabled() {
     }
 
     // --- Parent-process path ------------------------------------------
+    // Ensure the env var is not set so the parent acquires a real fcntl
+    // lock. Without this, an externally set LIMBO_DISABLE_FILE_LOCK would
+    // cause the parent to skip locking and make the test fail misleadingly.
+    //
+    // SAFETY: nextest runs each integration test in its own subprocess, so
+    // no other threads exist at this point.
+    unsafe {
+        std::env::remove_var("LIMBO_DISABLE_FILE_LOCK");
+    }
+
     current_thread_runtime().block_on(async {
         let dir = tempfile::tempdir().expect("failed to create temp dir");
         let db_path = dir.path().join("palace.db");


### PR DESCRIPTION
## Summary

- Fixes the exclusive `fcntl` file lock that turso/limbo acquires at database open time, which blocked any second `mempalace` process (MCP server, CLI command) from starting while another held the lock
- Sets `LIMBO_DISABLE_FILE_LOCK=1` before calling `Builder::new_local().build()` — turso's built-in escape hatch in `turso_core::io::unix`
- Adds a 5-second `busy_timeout` on the connection so concurrent writers retry on transient write contention instead of failing immediately
- Relaxes `unsafe_code` from `forbid` to `deny` to permit the single targeted `#[allow(unsafe_code)]` annotation required by `set_var` in Rust 2024 edition
- Adds a regression test (`tests/concurrent_access.rs`) that opens two connections to the same file and verifies cross-connection reads/writes succeed

Closes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI startup now configures processes to allow multiple simultaneous opens of the same database; write contention waits up to 5 seconds before timing out.

* **Tests**
  * Added integration tests validating concurrent connections and cross-process lock behavior.

* **Chores**
  * Stricter linting for unsafe-code handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->