### PR TITLE
Resync with mempalace-py @ 963c04c

### DIFF
--- a/.claude/commands/resync-py.md
+++ b/.claude/commands/resync-py.md
@@ -1,7 +1,7 @@
 # Resync mempalace-rs with mempalace-py
 
-Analyse all commits in `./mempalace-py` since the last recorded sync commit and port the
-applicable changes to this Rust codebase.
+Analyse all commits in `./mempalace-py` since the last recorded sync commit and port the applicable changes to this
+Rust codebase.
 
 ## How to use
 
@@ -15,17 +15,34 @@ You can optionally pass a base commit to diff from:
 /resync-py [base-commit]
 ```
 
-If no commit is given, look it up from the git log of this repo — the most recent commit
-whose message references a `mempalace-py` commit hash or contains "resync"/"parity" is a
-good heuristic.
+If no commit is given, look it up from the git log of this repo — the most recent commit whose message references a
+`mempalace-py` commit hash or contains "resync"/"parity" is a good heuristic.
 
 ## Instructions
 
 ### Phase 1 — Discover what changed in Python
 
-1. Run `git log --oneline <base-commit>..HEAD` inside `./mempalace-py` to list all new commits.
-2. Run `git diff <base-commit>..HEAD` inside `./mempalace-py` to see the full diff.
-3. Group changes by theme: security, features, bug fixes, documentation, tests.
+`mempalace-py` lives at `./mempalace-py` relative to this repo's root. Use `git -C ./mempalace-py` to run git commands
+inside it without changing directory.
+
+1. Pull the latest `main` so you are diffing against current upstream:
+
+   ```bash
+   git -C ./mempalace-py fetch origin
+   git -C ./mempalace-py checkout main
+   git -C ./mempalace-py pull --ff-only
+   ```
+
+2. Record the HEAD commit — this becomes the **target hash** in `.claude/local/sync-<date>.md`:
+
+   ```bash
+   git -C ./mempalace-py rev-parse HEAD
+   ```
+
+3. Run `git -C ./mempalace-py log --oneline <base-commit>..HEAD` to list all new commits.
+4. Run `git -C ./mempalace-py diff <base-commit>..HEAD --stat -- mempalace/` first (the full diff can exceed 30 KB).
+   Then diff each interesting file individually.
+5. Group changes by theme: security, features, bug fixes, documentation, tests.
 
 ### Phase 2 — Determine what's applicable to Rust
 
@@ -102,4 +119,26 @@ Ports: <bullet list of what was ported>
 - Python `except Exception` → Rust already uses typed errors, no change needed
 - Python `logger.exception()` → Rust `eprintln!` to stderr (MCP servers must not pollute stdout)
 - Python `chromadb.get(limit=10000)` unbounded query guards → Rust SQL `LIMIT` clauses
-- Python `hashlib.md5(usedforsecurity=False)` → Rust `uuid::Uuid::new_v4()` (no change needed)
+- Python `hashlib.md5(usedforsecurity=False)` in the **miner** (source_file+chunk_index hash) → Rust `uuid::Uuid::new_v4()`
+  (no change needed)
+- Python `hashlib.md5(content.encode())` for **deterministic/idempotent MCP IDs** → add the `md5` crate and use
+  `md5::compute`. This is a distinct case from the miner pattern above.
+
+## Turso API gotchas
+
+- `row.get(idx)` returns `Result<T, Error>`, **not** `Option<T>`. Use `.ok()` for nullable columns: `row.get(0).ok()`.
+- `Option<T>` can be passed directly in `turso::params![]`; `None` becomes SQL `NULL`.
+- Comparing OS mtimes as `f64` triggers `clippy::float_cmp` (pedantic). The comparison is correct because both values
+  originate from the same OS syscall — suppress with `#[allow(clippy::float_cmp)]` and a comment.
+
+## Schema migration pattern
+
+When adding a nullable column to an existing table, do **both**:
+
+1. Add the column to the `CREATE TABLE IF NOT EXISTS` DDL (for new databases).
+2. In `ensure_schema`, call `ALTER TABLE … ADD COLUMN` and discard the error — idempotent for existing databases (column
+   already present) and new ones (DDL already added it).
+
+```rust
+let _ = conn.execute("ALTER TABLE drawers ADD COLUMN new_col REAL", ()).await;
+```

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 mempalace.yaml
+mempalace-py
 
 # Claude local
 .claude/local

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -990,9 +990,9 @@ dependencies = [
 
 [[package]]
 name = "md5"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
 name = "memchr"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -989,6 +989,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1010,6 +1016,7 @@ dependencies = [
  "chrono",
  "clap",
  "ignore",
+ "md5",
  "regex",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ unwrap_used = "deny"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
 ignore = "0.4"
-md5 = "0.7"
+md5 = "0.8"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ unwrap_used = "deny"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
 ignore = "0.4"
+md5 = "0.7"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -631,7 +631,7 @@ mod tests {
         assert!(
             result["drawer_id"]
                 .as_str()
-                .unwrap()
+                .expect("drawer_id must be a string")
                 .starts_with("drawer_personal_notes_")
         );
         assert!(
@@ -669,7 +669,9 @@ mod tests {
             "content": content,
         });
         let result = tool_add_drawer(&conn, &args).await;
-        let id = result["drawer_id"].as_str().unwrap();
+        let id = result["drawer_id"]
+            .as_str()
+            .expect("drawer_id must be a string");
 
         let digest = md5::compute(content.as_bytes());
         let hex = format!("{digest:x}");

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -296,25 +296,6 @@ async fn tool_add_drawer(conn: &Connection, args: &Value) -> Value {
     let hex = format!("{digest:x}");
     let id = format!("drawer_{wing}_{room}_{}", &hex[..16]);
 
-    // If the drawer already exists, return success without re-inserting.
-    if let Ok(rows) = query_all(
-        conn,
-        "SELECT 1 FROM drawers WHERE id = ?1 LIMIT 1",
-        [id.clone()],
-    )
-    .await
-    {
-        if !rows.is_empty() {
-            return json!({
-                "success": true,
-                "reason": "already_exists",
-                "drawer_id": id,
-                "wing": wing,
-                "room": room,
-            });
-        }
-    }
-
     let params = drawer::DrawerParams {
         id: &id,
         wing,
@@ -331,8 +312,17 @@ async fn tool_add_drawer(conn: &Connection, args: &Value) -> Value {
         source_mtime: None,
     };
 
+    // Branch on add_drawer's bool rather than doing a separate SELECT first.
+    // The INSERT OR IGNORE inside add_drawer is atomic, so this is race-free.
     match drawer::add_drawer(conn, &params).await {
-        Ok(_) => json!({"success": true, "drawer_id": id, "wing": wing, "room": room}),
+        Ok(true) => json!({"success": true, "drawer_id": id, "wing": wing, "room": room}),
+        Ok(false) => json!({
+            "success": true,
+            "reason": "already_exists",
+            "drawer_id": id,
+            "wing": wing,
+            "room": room,
+        }),
         Err(e) => json!({"success": false, "error": e.to_string()}),
     }
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -290,26 +290,31 @@ async fn tool_add_drawer(conn: &Connection, args: &Value) -> Value {
         return json!({"success": false, "error": "wing, room, and content are required", "public": true});
     }
 
-    // Reject if a highly-similar drawer already exists (mirrors Python behaviour).
-    if let Ok(results) = search::search_memories(conn, content, None, None, 5).await {
-        let dups: Vec<Value> = results
-            .iter()
-            .filter(|r| r.relevance > 3.0)
-            .map(|r| {
-                let preview = if r.text.len() > 200 {
-                    format!("{}...", &r.text[..200])
-                } else {
-                    r.text.clone()
-                };
-                json!({"wing": r.wing, "room": r.room, "content": preview})
-            })
-            .collect();
-        if !dups.is_empty() {
-            return json!({"success": false, "reason": "duplicate", "matches": dups});
+    // Deterministic ID: same content in the same wing/room always produces the
+    // same ID, making the call idempotent (mirrors Python mcp_server behaviour).
+    let digest = md5::compute(content.as_bytes());
+    let hex = format!("{digest:x}");
+    let id = format!("drawer_{wing}_{room}_{}", &hex[..16]);
+
+    // If the drawer already exists, return success without re-inserting.
+    if let Ok(rows) = query_all(
+        conn,
+        "SELECT 1 FROM drawers WHERE id = ?1 LIMIT 1",
+        [id.clone()],
+    )
+    .await
+    {
+        if !rows.is_empty() {
+            return json!({
+                "success": true,
+                "reason": "already_exists",
+                "drawer_id": id,
+                "wing": wing,
+                "room": room,
+            });
         }
     }
 
-    let id = Uuid::new_v4().to_string();
     let params = drawer::DrawerParams {
         id: &id,
         wing,
@@ -323,6 +328,7 @@ async fn tool_add_drawer(conn: &Connection, args: &Value) -> Value {
         chunk_index: 0,
         added_by,
         ingest_mode: "mcp",
+        source_mtime: None,
     };
 
     match drawer::add_drawer(conn, &params).await {
@@ -599,5 +605,116 @@ async fn tool_diary_read(conn: &Connection, args: &Value) -> Value {
             })
         }
         Err(e) => json!({"error": e.to_string()}),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn test_conn() -> (turso::Database, turso::Connection) {
+        crate::test_helpers::test_db().await
+    }
+
+    // --- tool_add_drawer ---
+
+    #[tokio::test]
+    async fn add_drawer_inserts_and_returns_success() {
+        let (_db, conn) = test_conn().await;
+        let args = json!({
+            "wing": "personal",
+            "room": "notes",
+            "content": "the quick brown fox jumps over the lazy dog",
+        });
+        let result = tool_add_drawer(&conn, &args).await;
+        assert_eq!(result["success"], true);
+        assert!(
+            result["drawer_id"]
+                .as_str()
+                .unwrap()
+                .starts_with("drawer_personal_notes_")
+        );
+        assert!(
+            result.get("reason").is_none(),
+            "fresh insert must not carry a reason"
+        );
+    }
+
+    #[tokio::test]
+    async fn add_drawer_idempotent_returns_already_exists() {
+        let (_db, conn) = test_conn().await;
+        let args = json!({
+            "wing": "personal",
+            "room": "notes",
+            "content": "idempotent content for testing",
+        });
+        let first = tool_add_drawer(&conn, &args).await;
+        assert_eq!(first["success"], true);
+
+        let second = tool_add_drawer(&conn, &args).await;
+        assert_eq!(second["success"], true);
+        assert_eq!(second["reason"], "already_exists");
+        // The same deterministic ID must be returned both times.
+        assert_eq!(first["drawer_id"], second["drawer_id"]);
+    }
+
+    #[tokio::test]
+    async fn add_drawer_deterministic_id_same_content() {
+        let (_db, conn) = test_conn().await;
+        // Verify the ID is derived from md5(content) and matches our expectation.
+        let content = "fn main() { println!(\"hello\"); }";
+        let args = json!({
+            "wing": "proj",
+            "room": "code",
+            "content": content,
+        });
+        let result = tool_add_drawer(&conn, &args).await;
+        let id = result["drawer_id"].as_str().unwrap();
+
+        let digest = md5::compute(content.as_bytes());
+        let hex = format!("{digest:x}");
+        let expected = format!("drawer_proj_code_{}", &hex[..16]);
+        assert_eq!(id, expected);
+    }
+
+    #[tokio::test]
+    async fn add_drawer_different_content_different_id() {
+        let (_db, conn) = test_conn().await;
+        let ra = tool_add_drawer(
+            &conn,
+            &json!({"wing": "w", "room": "r", "content": "first piece of content"}),
+        )
+        .await;
+        let rb = tool_add_drawer(
+            &conn,
+            &json!({"wing": "w", "room": "r", "content": "second piece of content"}),
+        )
+        .await;
+        assert_ne!(ra["drawer_id"], rb["drawer_id"]);
+    }
+
+    #[tokio::test]
+    async fn add_drawer_missing_required_fields_returns_error() {
+        let (_db, conn) = test_conn().await;
+
+        // Missing content
+        let r = tool_add_drawer(&conn, &json!({"wing": "w", "room": "r"})).await;
+        assert_eq!(r["success"], false);
+
+        // Missing wing
+        let r = tool_add_drawer(
+            &conn,
+            &json!({"room": "r", "content": "some text here for testing"}),
+        )
+        .await;
+        assert_eq!(r["success"], false);
+
+        // Missing room
+        let r = tool_add_drawer(
+            &conn,
+            &json!({"wing": "w", "content": "some text here for testing"}),
+        )
+        .await;
+        assert_eq!(r["success"], false);
     }
 }

--- a/src/palace/convo_miner.rs
+++ b/src/palace/convo_miner.rs
@@ -312,6 +312,7 @@ pub async fn mine_convos(
                         chunk_index: chunk.chunk_index,
                         added_by: &opts.agent,
                         ingest_mode: "convos",
+                        source_mtime: None,
                     },
                 )
                 .await?;

--- a/src/palace/drawer.rs
+++ b/src/palace/drawer.rs
@@ -114,12 +114,17 @@ fn is_stop_word(word: &str) -> bool {
     )
 }
 
-/// Return the stored `source_mtime` for the first drawer from `source_file`,
-/// or `None` when the file has never been mined or has no stored mtime.
+/// Return the agreed-upon `source_mtime` for all drawers from `source_file`,
+/// or `None` when the file has never been mined or its mtime cannot be trusted.
+///
+/// A multi-chunk file produces multiple drawer rows.  All chunks written in the
+/// same mine pass share an identical mtime, so this function verifies that every
+/// row carries the same non-NULL value.  Any NULL or disagreement between rows
+/// signals that the data is inconsistent and the file should be re-mined.
 async fn stored_mtime(conn: &Connection, source_file: &str) -> Result<Option<f64>> {
     let rows = db::query_all(
         conn,
-        "SELECT source_mtime FROM drawers WHERE source_file = ?1 LIMIT 1",
+        "SELECT source_mtime FROM drawers WHERE source_file = ?1",
         turso::params![source_file],
     )
     .await?;
@@ -128,9 +133,22 @@ async fn stored_mtime(conn: &Connection, source_file: &str) -> Result<Option<f64
         return Ok(None);
     }
 
-    // `source_mtime` is nullable — older drawers won't have it set.
-    // `get()` returns Err when the column value is NULL, so map to None.
-    Ok(rows[0].get(0).ok())
+    let mut agreed: Option<f64> = None;
+    for row in &rows {
+        // `get()` returns Err for NULL — map to None and force a re-mine.
+        let Some(m): Option<f64> = row.get(0).ok() else {
+            return Ok(None);
+        };
+        // mtime values come from the OS (no floating-point arithmetic), so
+        // bitwise equality is safe for detecting inconsistency between rows.
+        #[allow(clippy::float_cmp)]
+        let disagrees = agreed.is_some_and(|a| a != m);
+        if disagrees {
+            return Ok(None);
+        }
+        agreed = Some(m);
+    }
+    Ok(agreed)
 }
 
 /// Return the modification time of a file as seconds since the Unix epoch.
@@ -417,6 +435,36 @@ mod async_tests {
         .expect("insert");
 
         assert!(!file_already_mined(&conn, &path).await.expect("check"));
+    }
+
+    /// When two chunks of the same file disagree on their stored mtime, the
+    /// file must be re-mined (inconsistent state should never happen in
+    /// practice but the guard ensures correctness).
+    #[tokio::test]
+    async fn file_already_mined_disagreeing_mtimes_returns_false() {
+        let (_db, conn) = crate::test_helpers::test_db().await;
+        let tmp = tempfile::NamedTempFile::new().expect("tmp file");
+        let path = tmp.path().to_string_lossy().to_string();
+
+        conn.execute(
+            "INSERT INTO drawers (id, wing, room, content, source_file, source_mtime) \
+             VALUES ('chunk0', 'w', 'r', 'c0', ?1, 1000.0)",
+            turso::params![path.as_str()],
+        )
+        .await
+        .expect("insert chunk0");
+        conn.execute(
+            "INSERT INTO drawers (id, wing, room, content, source_file, source_mtime) \
+             VALUES ('chunk1', 'w', 'r', 'c1', ?1, 2000.0)",
+            turso::params![path.as_str()],
+        )
+        .await
+        .expect("insert chunk1");
+
+        assert!(
+            !file_already_mined(&conn, &path).await.expect("check"),
+            "disagreeing mtimes must trigger re-mine"
+        );
     }
 }
 

--- a/src/palace/drawer.rs
+++ b/src/palace/drawer.rs
@@ -472,11 +472,19 @@ mod async_tests {
 ///
 /// Returns `true` when the drawer was inserted, `false` when a drawer with the
 /// same `id` already exists (idempotent — no error is raised).
+///
+/// The INSERT and word indexing are wrapped in a savepoint so that a failed
+/// `index_words` call rolls back the drawer too, leaving no unsearchable
+/// orphans.  Savepoints nest correctly if the caller is already inside a
+/// transaction.
 pub async fn add_drawer(conn: &Connection, p: &DrawerParams<'_>) -> Result<bool> {
     // SQLite only has i64 integers, so we cast chunk_index (usize) to i32 at the SQL boundary.
     #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
     let chunk_index_sql = p.chunk_index as i32;
-    let result = conn
+
+    conn.execute("SAVEPOINT add_drawer", ()).await?;
+
+    let rows_affected = conn
         .execute(
             "INSERT OR IGNORE INTO drawers \
              (id, wing, room, content, source_file, chunk_index, added_by, ingest_mode, source_mtime) \
@@ -493,12 +501,32 @@ pub async fn add_drawer(conn: &Connection, p: &DrawerParams<'_>) -> Result<bool>
                 p.source_mtime
             ],
         )
-        .await?;
+        .await;
 
-    if result > 0 {
-        index_words(conn, p.id, p.content).await?;
-        Ok(true)
-    } else {
-        Ok(false)
+    let rows_affected = match rows_affected {
+        Ok(n) => n,
+        Err(e) => {
+            let _ = conn.execute("ROLLBACK TO SAVEPOINT add_drawer", ()).await;
+            let _ = conn.execute("RELEASE SAVEPOINT add_drawer", ()).await;
+            return Err(e.into());
+        }
+    };
+
+    if rows_affected == 0 {
+        // Already exists — nothing was written; release the savepoint and report.
+        conn.execute("RELEASE SAVEPOINT add_drawer", ()).await?;
+        return Ok(false);
+    }
+
+    match index_words(conn, p.id, p.content).await {
+        Ok(()) => {
+            conn.execute("RELEASE SAVEPOINT add_drawer", ()).await?;
+            Ok(true)
+        }
+        Err(e) => {
+            let _ = conn.execute("ROLLBACK TO SAVEPOINT add_drawer", ()).await;
+            let _ = conn.execute("RELEASE SAVEPOINT add_drawer", ()).await;
+            Err(e)
+        }
     }
 }

--- a/src/palace/drawer.rs
+++ b/src/palace/drawer.rs
@@ -362,7 +362,7 @@ mod async_tests {
         );
     }
 
-    /// Drawers mined before mtime tracking was added have NULL source_mtime.
+    /// Drawers mined before mtime tracking was added have NULL `source_mtime`.
     /// They must be re-mined so the mtime gets recorded.
     #[tokio::test]
     async fn file_already_mined_null_mtime_returns_false() {

--- a/src/palace/drawer.rs
+++ b/src/palace/drawer.rs
@@ -114,15 +114,61 @@ fn is_stop_word(word: &str) -> bool {
     )
 }
 
-/// Check if a file has already been mined.
-pub async fn file_already_mined(conn: &Connection, source_file: &str) -> Result<bool> {
+/// Return the stored `source_mtime` for the first drawer from `source_file`,
+/// or `None` when the file has never been mined or has no stored mtime.
+async fn stored_mtime(conn: &Connection, source_file: &str) -> Result<Option<f64>> {
     let rows = db::query_all(
         conn,
-        "SELECT 1 FROM drawers WHERE source_file = ?1 LIMIT 1",
+        "SELECT source_mtime FROM drawers WHERE source_file = ?1 LIMIT 1",
         turso::params![source_file],
     )
     .await?;
-    Ok(!rows.is_empty())
+
+    if rows.is_empty() {
+        return Ok(None);
+    }
+
+    // `source_mtime` is nullable — older drawers won't have it set.
+    // `get()` returns Err when the column value is NULL, so map to None.
+    Ok(rows[0].get(0).ok())
+}
+
+/// Return the modification time of a file as seconds since the Unix epoch.
+///
+/// Returns `None` when the file cannot be stat-ed or the platform does not
+/// support modification times.
+fn file_mtime(path: &str) -> Option<f64> {
+    std::fs::metadata(path)
+        .ok()?
+        .modified()
+        .ok()?
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .ok()
+        .map(|d| d.as_secs_f64())
+}
+
+/// Check whether a file has already been mined *and is unchanged* since it was
+/// last filed.
+///
+/// Returns `false` (triggering a re-mine) when:
+/// - No drawer for the file exists.
+/// - The drawer was created before `source_mtime` tracking was added (NULL).
+/// - The file's current mtime differs from the stored mtime (file was modified).
+pub async fn file_already_mined(conn: &Connection, source_file: &str) -> Result<bool> {
+    let Some(stored) = stored_mtime(conn, source_file).await? else {
+        return Ok(false);
+    };
+
+    let Some(current) = file_mtime(source_file) else {
+        return Ok(false);
+    };
+
+    // Both values are produced by the same OS syscall (stat mtime) converted to
+    // f64 via `as_secs_f64()` — bitwise equality is the correct check here.
+    // An epsilon comparison would incorrectly treat genuinely-equal timestamps
+    // as different.
+    #[allow(clippy::float_cmp)]
+    Ok(stored == current)
 }
 
 /// Parameters for inserting a drawer into the palace.
@@ -143,6 +189,10 @@ pub struct DrawerParams<'a> {
     pub added_by: &'a str,
     /// Ingestion mode: `"projects"` or `"convos"`.
     pub ingest_mode: &'a str,
+    /// Modification time of the source file at mine time (seconds since Unix
+    /// epoch).  `None` for drawers that have no on-disk source (e.g. MCP or
+    /// conversation imports).
+    pub source_mtime: Option<f64>,
 }
 
 #[cfg(test)]
@@ -210,6 +260,7 @@ mod async_tests {
             chunk_index: 0,
             added_by: "test",
             ingest_mode: "projects",
+            source_mtime: None,
         };
         let inserted = add_drawer(&conn, &p).await.expect("add_drawer");
         assert!(inserted);
@@ -236,11 +287,40 @@ mod async_tests {
             chunk_index: 0,
             added_by: "test",
             ingest_mode: "projects",
+            source_mtime: None,
         };
         let first = add_drawer(&conn, &p).await.expect("first insert");
         assert!(first);
         let second = add_drawer(&conn, &p).await.expect("second insert");
         assert!(!second);
+    }
+
+    #[tokio::test]
+    async fn add_drawer_stores_mtime() {
+        let (_db, conn) = crate::test_helpers::test_db().await;
+        let p = DrawerParams {
+            id: "mt1",
+            wing: "w",
+            room: "r",
+            content: "content with mtime",
+            source_file: "mtime_test.rs",
+            chunk_index: 0,
+            added_by: "test",
+            ingest_mode: "projects",
+            source_mtime: Some(1_700_000_000.5),
+        };
+        add_drawer(&conn, &p).await.expect("add_drawer");
+
+        let rows = crate::db::query_all(
+            &conn,
+            "SELECT source_mtime FROM drawers WHERE id = ?1",
+            turso::params!["mt1"],
+        )
+        .await
+        .expect("query");
+        assert_eq!(rows.len(), 1);
+        let stored: Option<f64> = rows[0].get(0).ok();
+        assert_eq!(stored, Some(1_700_000_000.5));
     }
 
     #[tokio::test]
@@ -270,35 +350,100 @@ mod async_tests {
         assert_eq!(rows.len(), 2);
     }
 
+    // --- file_already_mined tests ---
+
     #[tokio::test]
-    async fn file_already_mined_returns_correctly() {
+    async fn file_already_mined_no_row_returns_false() {
         let (_db, conn) = crate::test_helpers::test_db().await;
         assert!(
             !file_already_mined(&conn, "nonexistent.rs")
                 .await
                 .expect("check")
         );
+    }
 
+    /// Drawers mined before mtime tracking was added have NULL source_mtime.
+    /// They must be re-mined so the mtime gets recorded.
+    #[tokio::test]
+    async fn file_already_mined_null_mtime_returns_false() {
+        let (_db, conn) = crate::test_helpers::test_db().await;
         conn.execute(
-            "INSERT INTO drawers (id, wing, room, content, source_file) VALUES ('fm1', 'w', 'r', 'c', 'exists.rs')",
+            "INSERT INTO drawers (id, wing, room, content, source_file) \
+             VALUES ('fm_null', 'w', 'r', 'c', 'exists.rs')",
             (),
         )
         .await
         .expect("insert");
 
-        assert!(file_already_mined(&conn, "exists.rs").await.expect("check"));
+        // NULL mtime → treat as not yet mined (forces re-mine to record mtime).
+        assert!(!file_already_mined(&conn, "exists.rs").await.expect("check"));
+    }
+
+    /// A drawer whose stored mtime matches the file's current mtime is skipped.
+    #[tokio::test]
+    async fn file_already_mined_matching_mtime_returns_true() {
+        let (_db, conn) = crate::test_helpers::test_db().await;
+        let tmp = tempfile::NamedTempFile::new().expect("tmp file");
+        let path = tmp.path().to_string_lossy().to_string();
+        let mtime = file_mtime(&path).expect("mtime");
+
+        conn.execute(
+            "INSERT INTO drawers (id, wing, room, content, source_file, source_mtime) \
+             VALUES ('fm_match', 'w', 'r', 'c', ?1, ?2)",
+            turso::params![path.as_str(), mtime],
+        )
+        .await
+        .expect("insert");
+
+        assert!(file_already_mined(&conn, &path).await.expect("check"));
+    }
+
+    /// A drawer whose stored mtime differs from the file's current mtime must be
+    /// re-mined (the file was modified after it was last filed).
+    #[tokio::test]
+    async fn file_already_mined_stale_mtime_returns_false() {
+        let (_db, conn) = crate::test_helpers::test_db().await;
+        let tmp = tempfile::NamedTempFile::new().expect("tmp file");
+        let path = tmp.path().to_string_lossy().to_string();
+        // Store an obviously wrong mtime.
+        let stale_mtime: f64 = 0.0;
+
+        conn.execute(
+            "INSERT INTO drawers (id, wing, room, content, source_file, source_mtime) \
+             VALUES ('fm_stale', 'w', 'r', 'c', ?1, ?2)",
+            turso::params![path.as_str(), stale_mtime],
+        )
+        .await
+        .expect("insert");
+
+        assert!(!file_already_mined(&conn, &path).await.expect("check"));
     }
 }
 
 /// Add a drawer and index its words.
+///
+/// Returns `true` when the drawer was inserted, `false` when a drawer with the
+/// same `id` already exists (idempotent — no error is raised).
 pub async fn add_drawer(conn: &Connection, p: &DrawerParams<'_>) -> Result<bool> {
     // SQLite only has i64 integers, so we cast chunk_index (usize) to i32 at the SQL boundary.
     #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
     let chunk_index_sql = p.chunk_index as i32;
     let result = conn
         .execute(
-            "INSERT OR IGNORE INTO drawers (id, wing, room, content, source_file, chunk_index, added_by, ingest_mode) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
-            turso::params![p.id, p.wing, p.room, p.content, p.source_file, chunk_index_sql, p.added_by, p.ingest_mode],
+            "INSERT OR IGNORE INTO drawers \
+             (id, wing, room, content, source_file, chunk_index, added_by, ingest_mode, source_mtime) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            turso::params![
+                p.id,
+                p.wing,
+                p.room,
+                p.content,
+                p.source_file,
+                chunk_index_sql,
+                p.added_by,
+                p.ingest_mode,
+                p.source_mtime
+            ],
         )
         .await?;
 

--- a/src/palace/miner.rs
+++ b/src/palace/miner.rs
@@ -201,6 +201,14 @@ pub async fn mine(conn: &Connection, project_dir: &Path, opts: &MineParams) -> R
         let drawers_added = chunks.len();
 
         if !opts.dry_run {
+            // Capture mtime now so all chunks from the same file share the
+            // same recorded timestamp.
+            let source_mtime: Option<f64> = std::fs::metadata(filepath)
+                .ok()
+                .and_then(|m| m.modified().ok())
+                .and_then(|t| t.duration_since(std::time::SystemTime::UNIX_EPOCH).ok())
+                .map(|d| d.as_secs_f64());
+
             for chunk in &chunks {
                 let id = format!(
                     "drawer_{wing}_{room}_{}",
@@ -217,6 +225,7 @@ pub async fn mine(conn: &Connection, project_dir: &Path, opts: &MineParams) -> R
                         chunk_index: chunk.chunk_index,
                         added_by: &opts.agent,
                         ingest_mode: "projects",
+                        source_mtime,
                     },
                 )
                 .await?;

--- a/src/palace/search.rs
+++ b/src/palace/search.rs
@@ -185,6 +185,7 @@ mod async_tests {
                 chunk_index: 0,
                 added_by: "test",
                 ingest_mode: "projects",
+                source_mtime: None,
             },
         )
         .await
@@ -201,6 +202,7 @@ mod async_tests {
                 chunk_index: 0,
                 added_by: "test",
                 ingest_mode: "projects",
+                source_mtime: None,
             },
         )
         .await

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -15,6 +15,7 @@ CREATE TABLE IF NOT EXISTS drawers (
     added_by TEXT DEFAULT 'mempalace',
     ingest_mode TEXT,
     extract_mode TEXT,
+    source_mtime REAL,
     filed_at TEXT DEFAULT (datetime('now'))
 );
 
@@ -70,7 +71,19 @@ CREATE TABLE IF NOT EXISTS compressed (
 ";
 
 /// Create all tables and indexes if they don't already exist.
+///
+/// Also runs lightweight migrations for existing databases (columns that were
+/// added after initial release).  Each migration is expected to be idempotent —
+/// `SQLite` returns an error when a column already exists, which we deliberately
+/// ignore.
 pub async fn ensure_schema(conn: &Connection) -> Result<()> {
     conn.execute_batch(SCHEMA).await?;
+
+    // Migration: add source_mtime column (introduced to support re-mining
+    // modified files).  Silently ignored for databases that already have it.
+    let _ = conn
+        .execute("ALTER TABLE drawers ADD COLUMN source_mtime REAL", ())
+        .await;
+
     Ok(())
 }


### PR DESCRIPTION
## Summary

- **Re-mine modified files**: adds `source_mtime REAL` to the `drawers` schema so the project miner detects on-disk changes. `file_already_mined` now compares stored vs current mtime — NULL mtime or a mismatch forces a re-mine. Includes a backwards-compatible `ALTER TABLE` migration for existing databases.
- **Idempotent MCP `add_drawer`**: replaces the random UUID and similarity duplicate-check with a deterministic MD5-content ID (`drawer_{wing}_{room}_{md5(content)[:16]}`). Replaying the same call returns `{"success": true, "reason": "already_exists"}` instead of an error or a duplicate drawer.
- Adds the `md5 = "0.8"` crate for the deterministic ID.
- Updates `resync-py.md` with process notes and API gotchas from this session.

Ports from mempalace-py [`71736a3..963c04c`](https://github.com/milla-jovovich/mempalace/compare/71736a3..963c04c).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Track file modification times to skip re-processing unchanged files.
  * Deterministic drawer IDs derived from content for repeatable inserts.

* **Bug Fixes**
  * Replace similarity-based duplicate rejection with insert-or-ignore idempotency and clearer existence checks.
  * Ensure consistent per-file timestamps during ingestion to avoid stale data.

* **Chores**
  * Add content-hash dependency, ignore local Python repo, and migrate schema to store mtimes.

* **Tests**
  * Add coverage for idempotency, deterministic IDs, and mtime cases.

* **Documentation**
  * Expanded resync/migration guidance and implementation gotchas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->