### PR TITLE
Resync with mempalace-py @ a036b43

### DIFF
--- a/.claude/commands/resync-py.md
+++ b/.claude/commands/resync-py.md
@@ -28,7 +28,7 @@ use `git -C ./mempalace-py` to run git commands inside it without changing direc
 1. Advance the submodule to the latest upstream `main`:
 
    ```bash
-   git submodule update --remote mempalace-py
+   git submodule update --init --remote mempalace-py
    ```
 
 2. Record the HEAD commit — this becomes the **target hash** in the commit message:

--- a/.claude/commands/resync-py.md
+++ b/.claude/commands/resync-py.md
@@ -22,18 +22,16 @@ If no commit is given, look it up from the git log of this repo — the most rec
 
 ### Phase 1 — Discover what changed in Python
 
-`mempalace-py` lives at `./mempalace-py` relative to this repo's root. Use `git -C ./mempalace-py` to run git commands
-inside it without changing directory.
+`mempalace-py` is a git submodule at `./mempalace-py`. Use `git submodule update` to advance it, then
+use `git -C ./mempalace-py` to run git commands inside it without changing directory.
 
-1. Pull the latest `main` so you are diffing against current upstream:
+1. Advance the submodule to the latest upstream `main`:
 
    ```bash
-   git -C ./mempalace-py fetch origin
-   git -C ./mempalace-py checkout main
-   git -C ./mempalace-py pull --ff-only
+   git submodule update --remote mempalace-py
    ```
 
-2. Record the HEAD commit — this becomes the **target hash** in `.claude/local/sync-<date>.md`:
+2. Record the HEAD commit — this becomes the **target hash** in the commit message:
 
    ```bash
    git -C ./mempalace-py rev-parse HEAD
@@ -90,6 +88,12 @@ Run `cargo test` and `cargo clippy` after all units are complete.
 
 ### Phase 6 — Commit
 
+Stage the updated submodule pointer alongside the Rust changes, then commit:
+
+```bash
+git add mempalace-py
+```
+
 Commit with a message like:
 
 ```text
@@ -121,8 +125,9 @@ Ports: <bullet list of what was ported>
 - Python `chromadb.get(limit=10000)` unbounded query guards → Rust SQL `LIMIT` clauses
 - Python `hashlib.md5(usedforsecurity=False)` in the **miner** (source_file+chunk_index hash) → Rust `uuid::Uuid::new_v4()`
   (no change needed)
-- Python `hashlib.md5(content.encode())` for **deterministic/idempotent MCP IDs** → add the `md5` crate and use
-  `md5::compute`. This is a distinct case from the miner pattern above.
+- Python `hashlib.sha256(...)` for **deterministic/idempotent MCP IDs** (add_drawer, diary entries) → use the `sha2`
+  crate: `sha2::Sha256::digest(input.as_bytes())`, format the output bytes as lowercase hex via `fold`/`write!`.
+  The `md5` crate has been removed; do not re-introduce it.
 
 ## Turso API gotchas
 

--- a/.claude/commands/resync-py.md
+++ b/.claude/commands/resync-py.md
@@ -1,6 +1,6 @@
 # Resync mempalace-rs with mempalace-py
 
-Analyse all commits in `./mempalace-py` since the last recorded sync commit and port the applicable changes to this
+Analyse all commits in `./mempalace-py` since the last pinned submodule commit and port the applicable changes to this
 Rust codebase.
 
 ## How to use
@@ -9,38 +9,48 @@ Rust codebase.
 /resync-py
 ```
 
-You can optionally pass a base commit to diff from:
-
-```bash
-/resync-py [base-commit]
-```
-
-If no commit is given, look it up from the git log of this repo — the most recent commit whose message references a
-`mempalace-py` commit hash or contains "resync"/"parity" is a good heuristic.
-
 ## Instructions
 
 ### Phase 1 — Discover what changed in Python
 
-`mempalace-py` is a git submodule at `./mempalace-py`. Use `git submodule update` to advance it, then
-use `git -C ./mempalace-py` to run git commands inside it without changing directory.
+`mempalace-py` is a git submodule at `./mempalace-py`. Advance it to the latest upstream `main`, then diff to find the
+old and new commit hashes.
 
-1. Advance the submodule to the latest upstream `main`:
+1. Record the current (old) submodule commit:
+
+   ```bash
+   git submodule status mempalace-py
+   ```
+
+2. Advance the submodule:
 
    ```bash
    git submodule update --init --remote mempalace-py
    ```
 
-2. Record the HEAD commit — this becomes the **target hash** in the commit message:
+3. Use `git diff` to confirm the old → new pointer:
 
    ```bash
-   git -C ./mempalace-py rev-parse HEAD
+   git diff mempalace-py
    ```
 
-3. Run `git -C ./mempalace-py log --oneline <base-commit>..HEAD` to list all new commits.
-4. Run `git -C ./mempalace-py diff <base-commit>..HEAD --stat -- mempalace/` first (the full diff can exceed 30 KB).
+   The `-Subproject commit <old>` / `+Subproject commit <new>` lines give you both hashes.
+
+4. List all new commits:
+
+   ```bash
+   git -C ./mempalace-py log --oneline <old>..<new>
+   ```
+
+5. Diff the interesting directory (check stat first; full diff can exceed 30 KB):
+
+   ```bash
+   git -C ./mempalace-py diff <old>..<new> --stat -- mempalace/
+   ```
+
    Then diff each interesting file individually.
-5. Group changes by theme: security, features, bug fixes, documentation, tests.
+
+6. Group changes by theme: security, features, bug fixes, documentation, tests.
 
 ### Phase 2 — Determine what's applicable to Rust
 
@@ -73,7 +83,7 @@ Present the plan grouped into work units before writing any code.
 ### Phase 4 — Implement
 
 Work through the plan unit by unit. After each unit, verify with `cargo build`.
-Run `cargo test` and `cargo clippy` after all units are complete.
+Run `cargo nextest run` and `cargo clippy --all-targets --all-features` after all units are complete.
 
 ### Phase 5 — Update documentation
 
@@ -83,12 +93,10 @@ Run `cargo test` and `cargo clippy` after all units are complete.
    - Conversation format list
    - Architecture tree (new files)
    - Differences table
-3. Record the new sync commit in a comment or commit message so the next
-   `/resync-py` knows where to start.
 
 ### Phase 6 — Commit
 
-Stage the updated submodule pointer alongside the Rust changes, then commit:
+Stage the updated submodule pointer alongside the Rust changes:
 
 ```bash
 git add mempalace-py

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 mempalace.yaml
-mempalace-py
 
 # Claude local
 .claude/local

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "mempalace-py"]
+	path = mempalace-py
+	url = https://github.com/milla-jovovich/mempalace.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -30,7 +30,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -219,6 +219,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "branches"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,7 +344,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -406,6 +415,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,6 +431,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -485,6 +509,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,6 +533,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -740,6 +784,15 @@ checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
  "itoa",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -989,12 +1042,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "md5"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
-
-[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1016,11 +1063,11 @@ dependencies = [
  "chrono",
  "clap",
  "ignore",
- "md5",
  "regex",
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "tempfile",
  "thiserror",
  "tokio",
@@ -1207,7 +1254,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -1578,6 +1625,17 @@ name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest",
+]
 
 [[package]]
 name = "sharded-slab"
@@ -2092,7 +2150,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,9 +745,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -843,12 +843,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1825,9 +1825,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,11 @@ unwrap_used = "deny"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
 ignore = "0.4"
-md5 = "0.8"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
+sha2 = "0.11"
 thiserror = "2"
 tokio = { version = "1", features = [
   "rt-multi-thread",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 repository = "https://github.com/bunkerlab-net/mempalace"
 keywords = ["mcp", "memory", "ai", "sqlite", "llm"]
 categories = ["command-line-utilities", "database"]
-rust-version = "1.85"
+rust-version = "1.88"
 
 [lints.rust]
 unsafe_code = "deny"

--- a/src/cli/split.rs
+++ b/src/cli/split.rs
@@ -5,6 +5,8 @@ use regex::Regex;
 
 use crate::error::Result;
 
+const MAX_SPLIT_FILE_SIZE: u64 = 500 * 1024 * 1024; // 500 MB safety limit
+
 /// Find lines where true new sessions begin (Claude Code v header not followed by context restore).
 fn find_session_boundaries(lines: &[&str]) -> Vec<usize> {
     let mut boundaries = Vec::new();
@@ -101,8 +103,7 @@ fn split_file(
     sanitize_re: &Regex,
     multi_underscore: &Regex,
 ) -> Result<usize> {
-    const MAX_SIZE: u64 = 500 * 1024 * 1024; // 500 MB safety limit
-    if fs::metadata(path).is_ok_and(|m| m.len() > MAX_SIZE) {
+    if fs::metadata(path).is_ok_and(|m| m.len() > MAX_SPLIT_FILE_SIZE) {
         println!("  SKIP: {} exceeds 500 MB limit", path.display());
         return Ok(0);
     }
@@ -197,6 +198,10 @@ pub fn run(
             continue;
         }
 
+        if fs::metadata(&path).is_ok_and(|m| m.len() > MAX_SPLIT_FILE_SIZE) {
+            println!("  SKIP: {} exceeds 500 MB limit", path.display());
+            continue;
+        }
         let content = fs::read_to_string(&path).unwrap_or_default();
         let lines: Vec<&str> = content.lines().collect();
         let boundaries = find_session_boundaries(&lines);

--- a/src/cli/split.rs
+++ b/src/cli/split.rs
@@ -101,6 +101,11 @@ fn split_file(
     sanitize_re: &Regex,
     multi_underscore: &Regex,
 ) -> Result<usize> {
+    const MAX_SIZE: u64 = 500 * 1024 * 1024; // 500 MB safety limit
+    if fs::metadata(path).is_ok_and(|m| m.len() > MAX_SIZE) {
+        println!("  SKIP: {} exceeds 500 MB limit", path.display());
+        return Ok(0);
+    }
     let content = fs::read_to_string(path).unwrap_or_default();
     let lines: Vec<&str> = content.lines().collect();
     let mut boundaries = find_session_boundaries(&lines);

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -14,6 +14,9 @@ use turso::Connection;
 
 use crate::error::Result;
 
+const SUPPORTED_PROTOCOL_VERSIONS: &[&str] =
+    &["2025-11-25", "2025-06-18", "2025-03-26", "2024-11-05"];
+
 /// Run the MCP server: read JSON-RPC 2.0 requests from stdin, write responses to stdout.
 pub async fn run(conn: &Connection) -> Result<()> {
     let stdin = tokio::io::stdin();
@@ -68,15 +71,26 @@ async fn handle_request(conn: &Connection, request: &Value) -> Option<Value> {
     let req_id = request.get("id").cloned().unwrap_or(Value::Null);
 
     match method {
-        "initialize" => Some(json!({
-            "jsonrpc": "2.0",
-            "id": req_id,
-            "result": {
-                "protocolVersion": "2024-11-05",
-                "capabilities": {"tools": {}},
-                "serverInfo": {"name": "mempalace", "version": env!("CARGO_PKG_VERSION")},
-            }
-        })),
+        "initialize" => {
+            let client_version = params
+                .get("protocolVersion")
+                .and_then(|v| v.as_str())
+                .unwrap_or(SUPPORTED_PROTOCOL_VERSIONS[SUPPORTED_PROTOCOL_VERSIONS.len() - 1]);
+            let negotiated = if SUPPORTED_PROTOCOL_VERSIONS.contains(&client_version) {
+                client_version
+            } else {
+                SUPPORTED_PROTOCOL_VERSIONS[0]
+            };
+            Some(json!({
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "result": {
+                    "protocolVersion": negotiated,
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "mempalace", "version": env!("CARGO_PKG_VERSION")},
+                }
+            }))
+        }
 
         "notifications/initialized" => None,
 
@@ -91,7 +105,11 @@ async fn handle_request(conn: &Connection, request: &Value) -> Option<Value> {
 
         "tools/call" => {
             let tool_name = params.get("name").and_then(|n| n.as_str()).unwrap_or("");
-            let tool_args = params.get("arguments").cloned().unwrap_or(json!({}));
+            let tool_args = params
+                .get("arguments")
+                .filter(|v| !v.is_null())
+                .cloned()
+                .unwrap_or(json!({}));
 
             let result = tools::dispatch(conn, tool_name, &tool_args).await;
 

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -72,12 +72,13 @@ async fn handle_request(conn: &Connection, request: &Value) -> Option<Value> {
 
     match method {
         "initialize" => {
-            let client_version = params
-                .get("protocolVersion")
-                .and_then(|v| v.as_str())
-                .unwrap_or(SUPPORTED_PROTOCOL_VERSIONS[SUPPORTED_PROTOCOL_VERSIONS.len() - 1]);
-            let negotiated = if SUPPORTED_PROTOCOL_VERSIONS.contains(&client_version) {
-                client_version
+            let client_version = params.get("protocolVersion").and_then(|v| v.as_str());
+            let negotiated = if let Some(cv) = client_version {
+                if SUPPORTED_PROTOCOL_VERSIONS.contains(&cv) {
+                    cv
+                } else {
+                    SUPPORTED_PROTOCOL_VERSIONS[0]
+                }
             } else {
                 SUPPORTED_PROTOCOL_VERSIONS[0]
             };

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -146,24 +146,25 @@ fn sanitize_opt_name(value: &str, field_name: &str) -> Result<Option<String>, Va
     sanitize_name(value, field_name).map(Some)
 }
 
-/// Validate drawer/diary content.  Returns `Some(error_json)` if invalid.
-fn sanitize_content(value: &str) -> Option<Value> {
-    if value.trim().is_empty() {
-        return Some(
+/// Validate drawer/diary content.  Returns `Ok(trimmed)` if valid, or `Err(error_json)` if not.
+fn sanitize_content(value: &str) -> Result<String, Value> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(
             json!({"success": false, "error": "content must be a non-empty string", "public": true}),
         );
     }
-    if value.len() > 100_000 {
-        return Some(
+    if trimmed.len() > 100_000 {
+        return Err(
             json!({"success": false, "error": "content exceeds maximum length of 100,000 characters", "public": true}),
         );
     }
-    if value.contains('\x00') {
-        return Some(
+    if trimmed.contains('\x00') {
+        return Err(
             json!({"success": false, "error": "content contains null bytes", "public": true}),
         );
     }
-    None
+    Ok(trimmed.to_string())
 }
 
 /// Append a write-operation entry to `~/.mempalace/wal/write_log.jsonl`.
@@ -429,9 +430,10 @@ async fn tool_add_drawer(conn: &Connection, args: &Value) -> Value {
         Ok(v) => v,
         Err(e) => return e,
     };
-    if let Some(err) = sanitize_content(content) {
-        return err;
-    }
+    let content = match sanitize_content(content) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
 
     // Deterministic ID: sha256(wing+room+content) so the same content in
     // the same wing/room always produces the same ID, making the call idempotent.
@@ -460,7 +462,7 @@ async fn tool_add_drawer(conn: &Connection, args: &Value) -> Value {
         id: &id,
         wing: &wing,
         room: &room,
-        content,
+        content: &content,
         source_file: if source_file.is_empty() {
             ""
         } else {
@@ -739,9 +741,10 @@ async fn tool_diary_write(conn: &Connection, args: &Value) -> Value {
         Ok(v) => v,
         Err(e) => return e,
     };
-    if let Some(err) = sanitize_content(entry) {
-        return err;
-    }
+    let entry = match sanitize_content(entry) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
 
     let wing = format!("wing_{}", agent_name.to_lowercase().replace(' ', "_"));
     let now = Utc::now();
@@ -763,12 +766,12 @@ async fn tool_diary_write(conn: &Connection, args: &Value) -> Value {
     match conn
         .execute(
             "INSERT OR IGNORE INTO drawers (id, wing, room, content, source_file, chunk_index, added_by, ingest_mode, extract_mode) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
-            turso::params![id.as_str(), wing.as_str(), "diary", entry, "", 0i32, agent_name.as_str(), "diary", topic.as_str()],
+            turso::params![id.as_str(), wing.as_str(), "diary", entry.as_str(), "", 0i32, agent_name.as_str(), "diary", topic.as_str()],
         )
         .await
     {
         Ok(_) => {
-            let _ = drawer::index_words(conn, &id, entry).await;
+            let _ = drawer::index_words(conn, &id, &entry).await;
             json!({
                 "success": true,
                 "entry_id": id,

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -135,6 +135,17 @@ fn sanitize_name(value: &str, field_name: &str) -> Result<String, Value> {
     Ok(v.to_string())
 }
 
+/// Validate an optional name filter.
+///
+/// Returns `Ok(None)` if the value is empty/whitespace-only, `Ok(Some(trimmed))`
+/// if valid, or `Err(error_json)` if the non-empty value fails `sanitize_name`.
+fn sanitize_opt_name(value: &str, field_name: &str) -> Result<Option<String>, Value> {
+    if value.trim().is_empty() {
+        return Ok(None);
+    }
+    sanitize_name(value, field_name).map(Some)
+}
+
 /// Validate drawer/diary content.  Returns `Some(error_json)` if invalid.
 fn sanitize_content(value: &str) -> Option<Value> {
     if value.trim().is_empty() {
@@ -158,63 +169,68 @@ fn sanitize_content(value: &str) -> Option<Value> {
 /// Append a write-operation entry to `~/.mempalace/wal/write_log.jsonl`.
 ///
 /// Failures are non-fatal: logged to stderr so the server stays alive even if
-/// the WAL directory is unwritable.
-fn wal_log(operation: &str, params: &Value) {
-    let wal_dir = crate::config::config_dir().join("wal");
+/// the WAL directory is unwritable.  I/O is offloaded to `spawn_blocking` so
+/// the async worker thread is not stalled by filesystem calls.
+async fn wal_log(operation: &str, params: Value) {
+    let operation = operation.to_string();
+    let _ = tokio::task::spawn_blocking(move || {
+        let wal_dir = crate::config::config_dir().join("wal");
 
-    // Create directory with restrictive permissions atomically on Unix.
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::DirBuilderExt as _;
-        if std::fs::DirBuilder::new()
-            .recursive(true)
-            .mode(0o700)
-            .create(&wal_dir)
-            .is_err()
+        // Create directory with restrictive permissions atomically on Unix.
+        #[cfg(unix)]
         {
+            use std::os::unix::fs::DirBuilderExt as _;
+            if std::fs::DirBuilder::new()
+                .recursive(true)
+                .mode(0o700)
+                .create(&wal_dir)
+                .is_err()
+            {
+                eprintln!("WAL: could not create {}", wal_dir.display());
+                return;
+            }
+        }
+        #[cfg(not(unix))]
+        if std::fs::create_dir_all(&wal_dir).is_err() {
             eprintln!("WAL: could not create {}", wal_dir.display());
             return;
         }
-    }
-    #[cfg(not(unix))]
-    if std::fs::create_dir_all(&wal_dir).is_err() {
-        eprintln!("WAL: could not create {}", wal_dir.display());
-        return;
-    }
 
-    let wal_file = wal_dir.join("write_log.jsonl");
-    let entry = json!({
-        "timestamp": Utc::now().to_rfc3339(),
-        "operation": operation,
-        "params": params,
-    });
-    let mut line = serde_json::to_string(&entry).unwrap_or_default();
-    line.push('\n');
+        let wal_file = wal_dir.join("write_log.jsonl");
+        let entry = json!({
+            "timestamp": Utc::now().to_rfc3339(),
+            "operation": operation,
+            "params": params,
+        });
+        let mut line = serde_json::to_string(&entry).unwrap_or_default();
+        line.push('\n');
 
-    // Open with restrictive mode atomically on Unix.
-    #[cfg(unix)]
-    let open_result = {
-        use std::os::unix::fs::OpenOptionsExt as _;
-        std::fs::OpenOptions::new()
+        // Open with restrictive mode atomically on Unix.
+        #[cfg(unix)]
+        let open_result = {
+            use std::os::unix::fs::OpenOptionsExt as _;
+            std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .mode(0o600)
+                .open(&wal_file)
+        };
+        #[cfg(not(unix))]
+        let open_result = std::fs::OpenOptions::new()
             .create(true)
             .append(true)
-            .mode(0o600)
-            .open(&wal_file)
-    };
-    #[cfg(not(unix))]
-    let open_result = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&wal_file);
+            .open(&wal_file);
 
-    match open_result {
-        Ok(mut file) => {
-            if let Err(e) = file.write_all(line.as_bytes()) {
-                eprintln!("WAL write failed: {e}");
+        match open_result {
+            Ok(mut file) => {
+                if let Err(e) = file.write_all(line.as_bytes()) {
+                    eprintln!("WAL write failed: {e}");
+                }
             }
+            Err(e) => eprintln!("WAL write failed: {e}"),
         }
-        Err(e) => eprintln!("WAL write failed: {e}"),
-    }
+    })
+    .await;
 }
 
 async fn tool_status(conn: &Connection) -> Value {
@@ -275,20 +291,23 @@ async fn tool_list_wings(conn: &Connection) -> Value {
 }
 
 async fn tool_list_rooms(conn: &Connection, args: &Value) -> Value {
-    let wing = str_arg(args, "wing");
+    let wing = match sanitize_opt_name(str_arg(args, "wing"), "wing") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
 
-    let rows = if wing.is_empty() {
+    let rows = if let Some(ref w) = wing {
         query_all(
             conn,
-            "SELECT room, COUNT(*) as cnt FROM drawers GROUP BY room",
-            (),
+            "SELECT room, COUNT(*) as cnt FROM drawers WHERE wing = ? GROUP BY room",
+            [w.as_str()],
         )
         .await
     } else {
         query_all(
             conn,
-            "SELECT room, COUNT(*) as cnt FROM drawers WHERE wing = ? GROUP BY room",
-            [wing.to_string()],
+            "SELECT room, COUNT(*) as cnt FROM drawers GROUP BY room",
+            (),
         )
         .await
     };
@@ -301,7 +320,7 @@ async fn tool_list_rooms(conn: &Connection, args: &Value) -> Value {
                 let count: i64 = row.get(1).unwrap_or(0);
                 rooms.insert(room, count);
             }
-            json!({"wing": if wing.is_empty() { "all" } else { wing }, "rooms": rooms})
+            json!({"wing": wing.as_deref().unwrap_or("all"), "rooms": rooms})
         }
         Err(e) => json!({"error": e.to_string()}),
     }
@@ -333,21 +352,13 @@ async fn tool_get_taxonomy(conn: &Connection) -> Value {
 async fn tool_search(conn: &Connection, args: &Value) -> Value {
     let query = str_arg(args, "query");
     let limit = usize::try_from(int_arg(args, "limit", 5)).unwrap_or(5);
-    let wing = {
-        let w = str_arg(args, "wing");
-        if w.is_empty() {
-            None
-        } else {
-            Some(w.to_string())
-        }
+    let wing = match sanitize_opt_name(str_arg(args, "wing"), "wing") {
+        Ok(v) => v,
+        Err(e) => return e,
     };
-    let room = {
-        let r = str_arg(args, "room");
-        if r.is_empty() {
-            None
-        } else {
-            Some(r.to_string())
-        }
+    let room = match sanitize_opt_name(str_arg(args, "room"), "room") {
+        Ok(v) => v,
+        Err(e) => return e,
     };
 
     match search::search_memories(conn, query, wing.as_deref(), room.as_deref(), limit).await {
@@ -422,7 +433,7 @@ async fn tool_add_drawer(conn: &Connection, args: &Value) -> Value {
         return err;
     }
 
-    // Deterministic ID: sha256(wing+room+content[:100]) so the same content in
+    // Deterministic ID: sha256(wing+room+content) so the same content in
     // the same wing/room always produces the same ID, making the call idempotent.
     let hash = sha2::Sha256::digest(format!("{wing}\u{1f}{room}\u{1f}{content}").as_bytes());
     let hex: String = hash.iter().fold(String::new(), |mut s, b| {
@@ -434,7 +445,7 @@ async fn tool_add_drawer(conn: &Connection, args: &Value) -> Value {
     let content_preview: String = content.chars().take(200).collect();
     wal_log(
         "add_drawer",
-        &json!({
+        json!({
             "drawer_id": id,
             "wing": wing,
             "room": room,
@@ -442,7 +453,8 @@ async fn tool_add_drawer(conn: &Connection, args: &Value) -> Value {
             "content_length": content.len(),
             "content_preview": content_preview,
         }),
-    );
+    )
+    .await;
 
     let params = drawer::DrawerParams {
         id: &id,
@@ -481,7 +493,7 @@ async fn tool_delete_drawer(conn: &Connection, args: &Value) -> Value {
         return json!({"success": false, "error": "drawer_id is required", "public": true});
     }
 
-    wal_log("delete_drawer", &json!({"drawer_id": drawer_id}));
+    wal_log("delete_drawer", json!({"drawer_id": drawer_id})).await;
 
     match conn
         .execute("DELETE FROM drawers WHERE id = ?", [drawer_id.to_string()])
@@ -502,7 +514,10 @@ async fn tool_delete_drawer(conn: &Connection, args: &Value) -> Value {
 }
 
 async fn tool_kg_query(conn: &Connection, args: &Value) -> Value {
-    let entity = str_arg(args, "entity");
+    let entity = match sanitize_name(str_arg(args, "entity"), "entity") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
     let as_of = {
         let a = str_arg(args, "as_of");
         if a.is_empty() {
@@ -516,7 +531,7 @@ async fn tool_kg_query(conn: &Connection, args: &Value) -> Value {
         if d.is_empty() { "both" } else { d }
     };
 
-    match kg::query::query_entity(conn, entity, as_of.as_deref(), direction).await {
+    match kg::query::query_entity(conn, &entity, as_of.as_deref(), direction).await {
         Ok(facts) => {
             let count = facts.len();
             json!({"entity": entity, "as_of": as_of, "facts": facts, "count": count})
@@ -561,14 +576,15 @@ async fn tool_kg_add(conn: &Connection, args: &Value) -> Value {
 
     wal_log(
         "kg_add",
-        &json!({
+        json!({
             "subject": subject,
             "predicate": predicate,
             "object": object,
             "valid_from": valid_from,
             "source_closet": source_closet,
         }),
-    );
+    )
+    .await;
 
     match kg::add_triple(
         conn,
@@ -622,8 +638,9 @@ async fn tool_kg_invalidate(conn: &Connection, args: &Value) -> Value {
 
     wal_log(
         "kg_invalidate",
-        &json!({"subject": subject, "predicate": predicate, "object": object, "ended": ended}),
-    );
+        json!({"subject": subject, "predicate": predicate, "object": object, "ended": ended}),
+    )
+    .await;
 
     match kg::invalidate(conn, &subject, &predicate, &object, ended.as_deref()).await {
         Ok(()) => json!({
@@ -636,13 +653,9 @@ async fn tool_kg_invalidate(conn: &Connection, args: &Value) -> Value {
 }
 
 async fn tool_kg_timeline(conn: &Connection, args: &Value) -> Value {
-    let entity = {
-        let e = str_arg(args, "entity");
-        if e.is_empty() {
-            None
-        } else {
-            Some(e.to_string())
-        }
+    let entity = match sanitize_opt_name(str_arg(args, "entity"), "entity") {
+        Ok(v) => v,
+        Err(e) => return e,
     };
 
     match kg::query::timeline(conn, entity.as_deref()).await {
@@ -666,31 +679,26 @@ async fn tool_kg_stats(conn: &Connection) -> Value {
 }
 
 async fn tool_traverse(conn: &Connection, args: &Value) -> Value {
-    let start_room = str_arg(args, "start_room");
+    let start_room = match sanitize_name(str_arg(args, "start_room"), "start_room") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
     let max_hops = usize::try_from(int_arg(args, "max_hops", 2)).unwrap_or(2);
 
-    match graph::traverse(conn, start_room, max_hops).await {
+    match graph::traverse(conn, &start_room, max_hops).await {
         Ok(results) => json!(results),
         Err(e) => json!({"error": e.to_string()}),
     }
 }
 
 async fn tool_find_tunnels(conn: &Connection, args: &Value) -> Value {
-    let wing_a = {
-        let w = str_arg(args, "wing_a");
-        if w.is_empty() {
-            None
-        } else {
-            Some(w.to_string())
-        }
+    let wing_a = match sanitize_opt_name(str_arg(args, "wing_a"), "wing_a") {
+        Ok(v) => v,
+        Err(e) => return e,
     };
-    let wing_b = {
-        let w = str_arg(args, "wing_b");
-        if w.is_empty() {
-            None
-        } else {
-            Some(w.to_string())
-        }
+    let wing_b = match sanitize_opt_name(str_arg(args, "wing_b"), "wing_b") {
+        Ok(v) => v,
+        Err(e) => return e,
     };
 
     match graph::find_tunnels(conn, wing_a.as_deref(), wing_b.as_deref()).await {
@@ -729,13 +737,14 @@ async fn tool_diary_write(conn: &Connection, args: &Value) -> Value {
     let entry_preview: String = entry.chars().take(200).collect();
     wal_log(
         "diary_write",
-        &json!({
+        json!({
             "agent_name": agent_name,
             "topic": topic,
             "entry_id": id,
             "entry_preview": entry_preview,
         }),
-    );
+    )
+    .await;
 
     // Use direct SQL to also set extract_mode (topic) which DrawerParams doesn't support
     match conn
@@ -859,7 +868,7 @@ mod tests {
     #[tokio::test]
     async fn add_drawer_deterministic_id_same_content() {
         let (_db, conn) = test_conn().await;
-        // Verify the ID is derived from sha256(wing+room+content[:100])[:24].
+        // Verify the ID is derived from sha256(wing+room+content)[:24].
         let content = "fn main() { println!(\"hello\"); }";
         let args = json!({
             "wing": "proj",
@@ -871,8 +880,7 @@ mod tests {
             .as_str()
             .expect("drawer_id must be a string");
 
-        let content_prefix: String = content.chars().take(100).collect();
-        let hash = sha2::Sha256::digest(format!("proj\u{1f}code\u{1f}{content_prefix}").as_bytes());
+        let hash = sha2::Sha256::digest(format!("proj\u{1f}code\u{1f}{content}").as_bytes());
         let hex: String = hash.iter().fold(String::new(), |mut s, b| {
             use std::fmt::Write as _;
             let _ = write!(s, "{b:02x}");

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -379,8 +379,8 @@ async fn tool_check_duplicate(conn: &Connection, args: &Value) -> Value {
                 .iter()
                 .filter(|r| r.relevance > 3.0) // high word overlap
                 .map(|r| {
-                    let preview = if r.text.len() > 200 {
-                        format!("{}...", &r.text[..200])
+                    let preview = if r.text.chars().count() > 200 {
+                        format!("{}...", r.text.chars().take(200).collect::<String>())
                     } else {
                         r.text.clone()
                     };
@@ -765,9 +765,10 @@ async fn tool_diary_read(conn: &Connection, args: &Value) -> Value {
     let agent_name = str_arg(args, "agent_name");
     let last_n = int_arg(args, "last_n", 10);
 
-    if agent_name.is_empty() {
-        return json!({"error": "agent_name is required", "public": true});
-    }
+    let agent_name = match sanitize_name(agent_name, "agent_name") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
 
     let wing = format!("wing_{}", agent_name.to_lowercase().replace(' ', "_"));
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -488,15 +488,18 @@ async fn tool_add_drawer(conn: &Connection, args: &Value) -> Value {
 }
 
 async fn tool_delete_drawer(conn: &Connection, args: &Value) -> Value {
-    let drawer_id = str_arg(args, "drawer_id");
-    if drawer_id.is_empty() {
-        return json!({"success": false, "error": "drawer_id is required", "public": true});
+    let drawer_id = match sanitize_name(str_arg(args, "drawer_id"), "drawer_id") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    if !drawer_id.starts_with("drawer_") {
+        return json!({"success": false, "error": "drawer_id has invalid format", "public": true});
     }
 
     wal_log("delete_drawer", json!({"drawer_id": drawer_id})).await;
 
     match conn
-        .execute("DELETE FROM drawers WHERE id = ?", [drawer_id.to_string()])
+        .execute("DELETE FROM drawers WHERE id = ?", [drawer_id.as_str()])
         .await
     {
         Ok(_) => {
@@ -504,7 +507,7 @@ async fn tool_delete_drawer(conn: &Connection, args: &Value) -> Value {
             let _ = conn
                 .execute(
                     "DELETE FROM drawer_words WHERE drawer_id = ?",
-                    [drawer_id.to_string()],
+                    [drawer_id.as_str()],
                 )
                 .await;
             json!({"success": true, "drawer_id": drawer_id})
@@ -569,6 +572,9 @@ async fn tool_kg_add(conn: &Connection, args: &Value) -> Value {
         Ok(v) => v,
         Err(e) => return e,
     };
+    // `sanitize_name` intentionally restricts objects to [a-zA-Z0-9_ .'-].
+    // If KG identifiers ever need ':', '@', or '/' (e.g. for namespaced IRIs),
+    // introduce a dedicated `sanitize_kg_object` rather than relaxing this one.
     let object = match sanitize_name(object, "object") {
         Ok(v) => v,
         Err(e) => return e,
@@ -719,7 +725,14 @@ async fn tool_diary_write(conn: &Connection, args: &Value) -> Value {
     let entry = str_arg(args, "entry");
     let topic = {
         let t = str_arg(args, "topic");
-        if t.is_empty() { "general" } else { t }
+        if t.is_empty() {
+            "general".to_string()
+        } else {
+            match sanitize_name(t, "topic") {
+                Ok(v) => v,
+                Err(e) => return e,
+            }
+        }
     };
 
     let agent_name = match sanitize_name(agent_name, "agent_name") {
@@ -750,7 +763,7 @@ async fn tool_diary_write(conn: &Connection, args: &Value) -> Value {
     match conn
         .execute(
             "INSERT OR IGNORE INTO drawers (id, wing, room, content, source_file, chunk_index, added_by, ingest_mode, extract_mode) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
-            turso::params![id.as_str(), wing.as_str(), "diary", entry, "", 0i32, agent_name.as_str(), "diary", topic],
+            turso::params![id.as_str(), wing.as_str(), "diary", entry, "", 0i32, agent_name.as_str(), "diary", topic.as_str()],
         )
         .await
     {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -421,7 +421,7 @@ async fn tool_add_drawer(conn: &Connection, args: &Value) -> Value {
     // Deterministic ID: sha256(wing+room+content[:100]) so the same content in
     // the same wing/room always produces the same ID, making the call idempotent.
     let content_prefix: String = content.chars().take(100).collect();
-    let hash = sha2::Sha256::digest(format!("{wing}{room}{content_prefix}").as_bytes());
+    let hash = sha2::Sha256::digest(format!("{wing}\u{1f}{room}\u{1f}{content_prefix}").as_bytes());
     let hex: String = hash.iter().fold(String::new(), |mut s, b| {
         use std::fmt::Write as _;
         let _ = write!(s, "{b:02x}");
@@ -862,7 +862,7 @@ mod tests {
             .expect("drawer_id must be a string");
 
         let content_prefix: String = content.chars().take(100).collect();
-        let hash = sha2::Sha256::digest(format!("projcode{content_prefix}").as_bytes());
+        let hash = sha2::Sha256::digest(format!("proj\u{1f}code\u{1f}{content_prefix}").as_bytes());
         let hex: String = hash.iter().fold(String::new(), |mut s, b| {
             use std::fmt::Write as _;
             let _ = write!(s, "{b:02x}");

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -126,7 +126,7 @@ fn sanitize_name(value: &str, field_name: &str) -> Result<String, Value> {
     }
     if !v
         .chars()
-        .all(|c| c.is_alphanumeric() || matches!(c, '_' | ' ' | '.' | '\'' | '-'))
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | ' ' | '.' | '\'' | '-'))
     {
         return Err(
             json!({"success": false, "error": format!("{field_name} contains invalid characters"), "public": true}),
@@ -424,15 +424,13 @@ async fn tool_add_drawer(conn: &Connection, args: &Value) -> Value {
 
     // Deterministic ID: sha256(wing+room+content[:100]) so the same content in
     // the same wing/room always produces the same ID, making the call idempotent.
-    let content_prefix: String = content.chars().take(100).collect();
-    let hash = sha2::Sha256::digest(format!("{wing}\u{1f}{room}\u{1f}{content_prefix}").as_bytes());
+    let hash = sha2::Sha256::digest(format!("{wing}\u{1f}{room}\u{1f}{content}").as_bytes());
     let hex: String = hash.iter().fold(String::new(), |mut s, b| {
         use std::fmt::Write as _;
         let _ = write!(s, "{b:02x}");
         s
     });
     let id = format!("drawer_{wing}_{room}_{}", &hex[..24]);
-
     let content_preview: String = content.chars().take(200).collect();
     wal_log(
         "add_drawer",

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -154,7 +154,7 @@ fn sanitize_content(value: &str) -> Result<String, Value> {
             json!({"success": false, "error": "content must be a non-empty string", "public": true}),
         );
     }
-    if trimmed.len() > 100_000 {
+    if trimmed.chars().count() > 100_000 {
         return Err(
             json!({"success": false, "error": "content exceeds maximum length of 100,000 characters", "public": true}),
         );

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -97,28 +97,30 @@ fn int_arg(args: &Value, key: &str, default: i64) -> i64 {
 
 /// Validate a wing/room/entity name.  Returns `Some(error_json)` if invalid.
 ///
-/// Rejects: empty, >128 chars, path traversal (`..`, `/`, `\`), null bytes,
-/// and characters outside `[a-zA-Z0-9_ .'-]`.  First character must be ASCII
-/// alphanumeric.
-fn sanitize_name(value: &str, field_name: &str) -> Option<Value> {
+/// Validates and trims `value`.
+///
+/// Returns `Ok(trimmed)` on success, or `Err(error_json)` if the value is
+/// empty, too long, contains path-traversal sequences, null bytes, an invalid
+/// first character, or characters outside `[a-zA-Z0-9_ .'-]`.
+fn sanitize_name(value: &str, field_name: &str) -> Result<String, Value> {
     let v = value.trim();
     if v.is_empty() {
-        return Some(
+        return Err(
             json!({"success": false, "error": format!("{field_name} must be a non-empty string"), "public": true}),
         );
     }
     if v.len() > 128 {
-        return Some(
+        return Err(
             json!({"success": false, "error": format!("{field_name} exceeds maximum length of 128 characters"), "public": true}),
         );
     }
     if v.contains("..") || v.contains('/') || v.contains('\\') || v.contains('\x00') {
-        return Some(
+        return Err(
             json!({"success": false, "error": format!("{field_name} contains invalid characters"), "public": true}),
         );
     }
     if !v.chars().next().is_some_and(|c| c.is_ascii_alphanumeric()) {
-        return Some(
+        return Err(
             json!({"success": false, "error": format!("{field_name} must start with an alphanumeric character"), "public": true}),
         );
     }
@@ -126,11 +128,11 @@ fn sanitize_name(value: &str, field_name: &str) -> Option<Value> {
         .chars()
         .all(|c| c.is_alphanumeric() || matches!(c, '_' | ' ' | '.' | '\'' | '-'))
     {
-        return Some(
+        return Err(
             json!({"success": false, "error": format!("{field_name} contains invalid characters"), "public": true}),
         );
     }
-    None
+    Ok(v.to_string())
 }
 
 /// Validate drawer/diary content.  Returns `Some(error_json)` if invalid.
@@ -408,12 +410,14 @@ async fn tool_add_drawer(conn: &Connection, args: &Value) -> Value {
         if a.is_empty() { "mcp" } else { a }
     };
 
-    if let Some(err) = sanitize_name(wing, "wing") {
-        return err;
-    }
-    if let Some(err) = sanitize_name(room, "room") {
-        return err;
-    }
+    let wing = match sanitize_name(wing, "wing") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let room = match sanitize_name(room, "room") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
     if let Some(err) = sanitize_content(content) {
         return err;
     }
@@ -444,8 +448,8 @@ async fn tool_add_drawer(conn: &Connection, args: &Value) -> Value {
 
     let params = drawer::DrawerParams {
         id: &id,
-        wing,
-        room,
+        wing: &wing,
+        room: &room,
         content,
         source_file: if source_file.is_empty() {
             ""
@@ -544,15 +548,18 @@ async fn tool_kg_add(conn: &Connection, args: &Value) -> Value {
         }
     };
 
-    if let Some(err) = sanitize_name(subject, "subject") {
-        return err;
-    }
-    if let Some(err) = sanitize_name(predicate, "predicate") {
-        return err;
-    }
-    if let Some(err) = sanitize_name(object, "object") {
-        return err;
-    }
+    let subject = match sanitize_name(subject, "subject") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let predicate = match sanitize_name(predicate, "predicate") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let object = match sanitize_name(object, "object") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
 
     wal_log(
         "kg_add",
@@ -568,9 +575,9 @@ async fn tool_kg_add(conn: &Connection, args: &Value) -> Value {
     match kg::add_triple(
         conn,
         &kg::TripleParams {
-            subject,
-            predicate,
-            object,
+            subject: &subject,
+            predicate: &predicate,
+            object: &object,
             valid_from: valid_from.as_deref(),
             valid_to: None,
             confidence: 1.0,
@@ -602,22 +609,25 @@ async fn tool_kg_invalidate(conn: &Connection, args: &Value) -> Value {
         }
     };
 
-    if let Some(err) = sanitize_name(subject, "subject") {
-        return err;
-    }
-    if let Some(err) = sanitize_name(predicate, "predicate") {
-        return err;
-    }
-    if let Some(err) = sanitize_name(object, "object") {
-        return err;
-    }
+    let subject = match sanitize_name(subject, "subject") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let predicate = match sanitize_name(predicate, "predicate") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let object = match sanitize_name(object, "object") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
 
     wal_log(
         "kg_invalidate",
         &json!({"subject": subject, "predicate": predicate, "object": object, "ended": ended}),
     );
 
-    match kg::invalidate(conn, subject, predicate, object, ended.as_deref()).await {
+    match kg::invalidate(conn, &subject, &predicate, &object, ended.as_deref()).await {
         Ok(()) => json!({
             "success": true,
             "fact": format!("{subject} → {predicate} → {object}"),
@@ -706,9 +716,10 @@ async fn tool_diary_write(conn: &Connection, args: &Value) -> Value {
         if t.is_empty() { "general" } else { t }
     };
 
-    if let Some(err) = sanitize_name(agent_name, "agent_name") {
-        return err;
-    }
+    let agent_name = match sanitize_name(agent_name, "agent_name") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
     if let Some(err) = sanitize_content(entry) {
         return err;
     }
@@ -732,7 +743,7 @@ async fn tool_diary_write(conn: &Connection, args: &Value) -> Value {
     match conn
         .execute(
             "INSERT OR IGNORE INTO drawers (id, wing, room, content, source_file, chunk_index, added_by, ingest_mode, extract_mode) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
-            turso::params![id.as_str(), wing.as_str(), "diary", entry, "", 0i32, agent_name, "diary", topic],
+            turso::params![id.as_str(), wing.as_str(), "diary", entry, "", 0i32, agent_name.as_str(), "diary", topic],
         )
         .await
     {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -159,15 +159,27 @@ fn sanitize_content(value: &str) -> Option<Value> {
 /// the WAL directory is unwritable.
 fn wal_log(operation: &str, params: &Value) {
     let wal_dir = crate::config::config_dir().join("wal");
+
+    // Create directory with restrictive permissions atomically on Unix.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt as _;
+        if std::fs::DirBuilder::new()
+            .recursive(true)
+            .mode(0o700)
+            .create(&wal_dir)
+            .is_err()
+        {
+            eprintln!("WAL: could not create {}", wal_dir.display());
+            return;
+        }
+    }
+    #[cfg(not(unix))]
     if std::fs::create_dir_all(&wal_dir).is_err() {
         eprintln!("WAL: could not create {}", wal_dir.display());
         return;
     }
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt as _;
-        let _ = std::fs::set_permissions(&wal_dir, std::fs::Permissions::from_mode(0o700));
-    }
+
     let wal_file = wal_dir.join("write_log.jsonl");
     let entry = json!({
         "timestamp": Utc::now().to_rfc3339(),
@@ -176,17 +188,27 @@ fn wal_log(operation: &str, params: &Value) {
     });
     let mut line = serde_json::to_string(&entry).unwrap_or_default();
     line.push('\n');
-    match std::fs::OpenOptions::new()
+
+    // Open with restrictive mode atomically on Unix.
+    #[cfg(unix)]
+    let open_result = {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .mode(0o600)
+            .open(&wal_file)
+    };
+    #[cfg(not(unix))]
+    let open_result = std::fs::OpenOptions::new()
         .create(true)
         .append(true)
-        .open(&wal_file)
-    {
+        .open(&wal_file);
+
+    match open_result {
         Ok(mut file) => {
-            let _ = file.write_all(line.as_bytes());
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::PermissionsExt as _;
-                let _ = std::fs::set_permissions(&wal_file, std::fs::Permissions::from_mode(0o600));
+            if let Err(e) = file.write_all(line.as_bytes()) {
+                eprintln!("WAL write failed: {e}");
             }
         }
         Err(e) => eprintln!("WAL write failed: {e}"),
@@ -407,6 +429,7 @@ async fn tool_add_drawer(conn: &Connection, args: &Value) -> Value {
     });
     let id = format!("drawer_{wing}_{room}_{}", &hex[..24]);
 
+    let content_preview: String = content.chars().take(200).collect();
     wal_log(
         "add_drawer",
         &json!({
@@ -415,7 +438,7 @@ async fn tool_add_drawer(conn: &Connection, args: &Value) -> Value {
             "room": room,
             "added_by": added_by,
             "content_length": content.len(),
-            "content_preview": &content[..content.len().min(200)],
+            "content_preview": content_preview,
         }),
     );
 
@@ -579,6 +602,16 @@ async fn tool_kg_invalidate(conn: &Connection, args: &Value) -> Value {
         }
     };
 
+    if let Some(err) = sanitize_name(subject, "subject") {
+        return err;
+    }
+    if let Some(err) = sanitize_name(predicate, "predicate") {
+        return err;
+    }
+    if let Some(err) = sanitize_name(object, "object") {
+        return err;
+    }
+
     wal_log(
         "kg_invalidate",
         &json!({"subject": subject, "predicate": predicate, "object": object, "ended": ended}),
@@ -684,13 +717,14 @@ async fn tool_diary_write(conn: &Connection, args: &Value) -> Value {
     let now = Utc::now();
     let id = Uuid::new_v4().to_string();
 
+    let entry_preview: String = entry.chars().take(200).collect();
     wal_log(
         "diary_write",
         &json!({
             "agent_name": agent_name,
             "topic": topic,
             "entry_id": id,
-            "entry_preview": &entry[..entry.len().min(200)],
+            "entry_preview": entry_preview,
         }),
     );
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
+use std::io::Write as _;
 
 use chrono::Utc;
 use serde_json::{Value, json};
+use sha2::Digest as _;
 use turso::Connection;
 
 use uuid::Uuid;
@@ -91,6 +93,104 @@ fn int_arg(args: &Value, key: &str, default: i64) -> i64 {
                 })
         })
         .unwrap_or(default)
+}
+
+/// Validate a wing/room/entity name.  Returns `Some(error_json)` if invalid.
+///
+/// Rejects: empty, >128 chars, path traversal (`..`, `/`, `\`), null bytes,
+/// and characters outside `[a-zA-Z0-9_ .'-]`.  First character must be ASCII
+/// alphanumeric.
+fn sanitize_name(value: &str, field_name: &str) -> Option<Value> {
+    let v = value.trim();
+    if v.is_empty() {
+        return Some(
+            json!({"success": false, "error": format!("{field_name} must be a non-empty string"), "public": true}),
+        );
+    }
+    if v.len() > 128 {
+        return Some(
+            json!({"success": false, "error": format!("{field_name} exceeds maximum length of 128 characters"), "public": true}),
+        );
+    }
+    if v.contains("..") || v.contains('/') || v.contains('\\') || v.contains('\x00') {
+        return Some(
+            json!({"success": false, "error": format!("{field_name} contains invalid characters"), "public": true}),
+        );
+    }
+    if !v.chars().next().is_some_and(|c| c.is_ascii_alphanumeric()) {
+        return Some(
+            json!({"success": false, "error": format!("{field_name} must start with an alphanumeric character"), "public": true}),
+        );
+    }
+    if !v
+        .chars()
+        .all(|c| c.is_alphanumeric() || matches!(c, '_' | ' ' | '.' | '\'' | '-'))
+    {
+        return Some(
+            json!({"success": false, "error": format!("{field_name} contains invalid characters"), "public": true}),
+        );
+    }
+    None
+}
+
+/// Validate drawer/diary content.  Returns `Some(error_json)` if invalid.
+fn sanitize_content(value: &str) -> Option<Value> {
+    if value.trim().is_empty() {
+        return Some(
+            json!({"success": false, "error": "content must be a non-empty string", "public": true}),
+        );
+    }
+    if value.len() > 100_000 {
+        return Some(
+            json!({"success": false, "error": "content exceeds maximum length of 100,000 characters", "public": true}),
+        );
+    }
+    if value.contains('\x00') {
+        return Some(
+            json!({"success": false, "error": "content contains null bytes", "public": true}),
+        );
+    }
+    None
+}
+
+/// Append a write-operation entry to `~/.mempalace/wal/write_log.jsonl`.
+///
+/// Failures are non-fatal: logged to stderr so the server stays alive even if
+/// the WAL directory is unwritable.
+fn wal_log(operation: &str, params: &Value) {
+    let wal_dir = crate::config::config_dir().join("wal");
+    if std::fs::create_dir_all(&wal_dir).is_err() {
+        eprintln!("WAL: could not create {}", wal_dir.display());
+        return;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        let _ = std::fs::set_permissions(&wal_dir, std::fs::Permissions::from_mode(0o700));
+    }
+    let wal_file = wal_dir.join("write_log.jsonl");
+    let entry = json!({
+        "timestamp": Utc::now().to_rfc3339(),
+        "operation": operation,
+        "params": params,
+    });
+    let mut line = serde_json::to_string(&entry).unwrap_or_default();
+    line.push('\n');
+    match std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&wal_file)
+    {
+        Ok(mut file) => {
+            let _ = file.write_all(line.as_bytes());
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt as _;
+                let _ = std::fs::set_permissions(&wal_file, std::fs::Permissions::from_mode(0o600));
+            }
+        }
+        Err(e) => eprintln!("WAL write failed: {e}"),
+    }
 }
 
 async fn tool_status(conn: &Connection) -> Value {
@@ -286,15 +386,38 @@ async fn tool_add_drawer(conn: &Connection, args: &Value) -> Value {
         if a.is_empty() { "mcp" } else { a }
     };
 
-    if wing.is_empty() || room.is_empty() || content.is_empty() {
-        return json!({"success": false, "error": "wing, room, and content are required", "public": true});
+    if let Some(err) = sanitize_name(wing, "wing") {
+        return err;
+    }
+    if let Some(err) = sanitize_name(room, "room") {
+        return err;
+    }
+    if let Some(err) = sanitize_content(content) {
+        return err;
     }
 
-    // Deterministic ID: same content in the same wing/room always produces the
-    // same ID, making the call idempotent (mirrors Python mcp_server behaviour).
-    let digest = md5::compute(content.as_bytes());
-    let hex = format!("{digest:x}");
-    let id = format!("drawer_{wing}_{room}_{}", &hex[..16]);
+    // Deterministic ID: sha256(wing+room+content[:100]) so the same content in
+    // the same wing/room always produces the same ID, making the call idempotent.
+    let content_prefix: String = content.chars().take(100).collect();
+    let hash = sha2::Sha256::digest(format!("{wing}{room}{content_prefix}").as_bytes());
+    let hex: String = hash.iter().fold(String::new(), |mut s, b| {
+        use std::fmt::Write as _;
+        let _ = write!(s, "{b:02x}");
+        s
+    });
+    let id = format!("drawer_{wing}_{room}_{}", &hex[..24]);
+
+    wal_log(
+        "add_drawer",
+        &json!({
+            "drawer_id": id,
+            "wing": wing,
+            "room": room,
+            "added_by": added_by,
+            "content_length": content.len(),
+            "content_preview": &content[..content.len().min(200)],
+        }),
+    );
 
     let params = drawer::DrawerParams {
         id: &id,
@@ -332,6 +455,8 @@ async fn tool_delete_drawer(conn: &Connection, args: &Value) -> Value {
     if drawer_id.is_empty() {
         return json!({"success": false, "error": "drawer_id is required", "public": true});
     }
+
+    wal_log("delete_drawer", &json!({"drawer_id": drawer_id}));
 
     match conn
         .execute("DELETE FROM drawers WHERE id = ?", [drawer_id.to_string()])
@@ -396,6 +521,27 @@ async fn tool_kg_add(conn: &Connection, args: &Value) -> Value {
         }
     };
 
+    if let Some(err) = sanitize_name(subject, "subject") {
+        return err;
+    }
+    if let Some(err) = sanitize_name(predicate, "predicate") {
+        return err;
+    }
+    if let Some(err) = sanitize_name(object, "object") {
+        return err;
+    }
+
+    wal_log(
+        "kg_add",
+        &json!({
+            "subject": subject,
+            "predicate": predicate,
+            "object": object,
+            "valid_from": valid_from,
+            "source_closet": source_closet,
+        }),
+    );
+
     match kg::add_triple(
         conn,
         &kg::TripleParams {
@@ -432,6 +578,11 @@ async fn tool_kg_invalidate(conn: &Connection, args: &Value) -> Value {
             Some(e.to_string())
         }
     };
+
+    wal_log(
+        "kg_invalidate",
+        &json!({"subject": subject, "predicate": predicate, "object": object, "ended": ended}),
+    );
 
     match kg::invalidate(conn, subject, predicate, object, ended.as_deref()).await {
         Ok(()) => json!({
@@ -522,13 +673,26 @@ async fn tool_diary_write(conn: &Connection, args: &Value) -> Value {
         if t.is_empty() { "general" } else { t }
     };
 
-    if agent_name.is_empty() || entry.is_empty() {
-        return json!({"success": false, "error": "agent_name and entry are required", "public": true});
+    if let Some(err) = sanitize_name(agent_name, "agent_name") {
+        return err;
+    }
+    if let Some(err) = sanitize_content(entry) {
+        return err;
     }
 
     let wing = format!("wing_{}", agent_name.to_lowercase().replace(' ', "_"));
     let now = Utc::now();
     let id = Uuid::new_v4().to_string();
+
+    wal_log(
+        "diary_write",
+        &json!({
+            "agent_name": agent_name,
+            "topic": topic,
+            "entry_id": id,
+            "entry_preview": &entry[..entry.len().min(200)],
+        }),
+    );
 
     // Use direct SQL to also set extract_mode (topic) which DrawerParams doesn't support
     match conn
@@ -651,7 +815,7 @@ mod tests {
     #[tokio::test]
     async fn add_drawer_deterministic_id_same_content() {
         let (_db, conn) = test_conn().await;
-        // Verify the ID is derived from md5(content) and matches our expectation.
+        // Verify the ID is derived from sha256(wing+room+content[:100])[:24].
         let content = "fn main() { println!(\"hello\"); }";
         let args = json!({
             "wing": "proj",
@@ -663,9 +827,14 @@ mod tests {
             .as_str()
             .expect("drawer_id must be a string");
 
-        let digest = md5::compute(content.as_bytes());
-        let hex = format!("{digest:x}");
-        let expected = format!("drawer_proj_code_{}", &hex[..16]);
+        let content_prefix: String = content.chars().take(100).collect();
+        let hash = sha2::Sha256::digest(format!("projcode{content_prefix}").as_bytes());
+        let hex: String = hash.iter().fold(String::new(), |mut s, b| {
+            use std::fmt::Write as _;
+            let _ = write!(s, "{b:02x}");
+            s
+        });
+        let expected = format!("drawer_proj_code_{}", &hex[..24]);
         assert_eq!(id, expected);
     }
 

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -13,6 +13,19 @@ use crate::error::Result;
 /// Normalize a file to transcript format.
 /// Detects format automatically and converts to `> user\nresponse\n\n` format.
 pub fn normalize(filepath: &Path) -> Result<String> {
+    const MAX_SIZE: u64 = 500 * 1024 * 1024; // 500 MB safety limit
+    let file_size = std::fs::metadata(filepath)
+        .map_err(|e| {
+            crate::error::Error::Other(format!("could not read {}: {e}", filepath.display()))
+        })?
+        .len();
+    if file_size > MAX_SIZE {
+        return Err(crate::error::Error::Other(format!(
+            "file too large ({} MB): {}",
+            file_size / (1024 * 1024),
+            filepath.display()
+        )));
+    }
     let content = std::fs::read_to_string(filepath).or_else(|_| {
         std::fs::read(filepath).map(|bytes| String::from_utf8_lossy(&bytes).to_string())
     })?;

--- a/src/palace/convo_miner.rs
+++ b/src/palace/convo_miner.rs
@@ -12,6 +12,8 @@ use crate::palace::room_detect::is_skip_dir;
 
 const CONVO_EXTENSIONS: &[&str] = &["txt", "md", "json", "jsonl"];
 const MIN_CHUNK_SIZE: usize = 30;
+/// Files larger than this are skipped — prevents OOM on huge files.
+const MAX_FILE_SIZE: u64 = 10 * 1024 * 1024; // 10 MB
 
 const TOPIC_KEYWORDS: &[(&str, &[&str])] = &[
     (
@@ -209,6 +211,11 @@ fn walk_convos(dir: &Path, files: &mut Vec<PathBuf>) {
     for entry in entries.flatten() {
         let path = entry.path();
         let name = entry.file_name().to_string_lossy().to_string();
+        // Skip symlinks — prevents following links to /dev/urandom etc.
+        if path.is_symlink() {
+            continue;
+        }
+
         if path.is_dir() {
             // Skip global cache dirs plus Claude Code-specific output dirs that
             // contain tool output and agent memory — not conversation transcripts.
@@ -220,6 +227,10 @@ fn walk_convos(dir: &Path, files: &mut Vec<PathBuf>) {
             // Skip .meta.json files — these are Claude Code session metadata,
             // not conversation content.
             if CONVO_EXTENSIONS.contains(&ext_lower.as_str()) && !name.ends_with(".meta.json") {
+                // Skip files exceeding size limit
+                if std::fs::metadata(&path).is_ok_and(|m| m.len() > MAX_FILE_SIZE) {
+                    continue;
+                }
                 files.push(path);
             }
         }

--- a/src/palace/miner.rs
+++ b/src/palace/miner.rs
@@ -23,6 +23,9 @@ pub struct MineParams {
     pub respect_gitignore: bool,
 }
 
+/// Files larger than this are skipped — prevents OOM on huge files.
+const MAX_FILE_SIZE: u64 = 10 * 1024 * 1024; // 10 MB
+
 const READABLE_EXTENSIONS: &[&str] = &[
     "txt", "md", "py", "js", "ts", "jsx", "tsx", "json", "yaml", "yml", "html", "css", "java",
     "go", "rs", "rb", "sh", "csv", "sql", "toml", "c", "cpp", "h", "hpp", "swift", "kt", "scala",
@@ -113,6 +116,11 @@ fn walk_dir(dir: &Path, files: &mut Vec<PathBuf>) {
         let path = entry.path();
         let name = entry.file_name().to_string_lossy().to_string();
 
+        // Skip symlinks — prevents following links to /dev/urandom etc.
+        if path.is_symlink() {
+            continue;
+        }
+
         if path.is_dir() {
             if !is_skip_dir(&name) {
                 walk_dir(&path, files);
@@ -122,6 +130,10 @@ fn walk_dir(dir: &Path, files: &mut Vec<PathBuf>) {
             if READABLE_EXTENSIONS.contains(&ext_lower.as_str())
                 && !SKIP_FILES.contains(&name.as_str())
             {
+                // Skip files exceeding size limit
+                if std::fs::metadata(&path).is_ok_and(|m| m.len() > MAX_FILE_SIZE) {
+                    continue;
+                }
                 files.push(path);
             }
         }

--- a/src/palace/miner.rs
+++ b/src/palace/miner.rs
@@ -101,6 +101,9 @@ fn walk_dir_gitignore(project_dir: &Path) -> Vec<PathBuf> {
             .unwrap_or("")
             .to_lowercase();
         if READABLE_EXTENSIONS.contains(&ext.as_str()) {
+            if entry.metadata().is_ok_and(|m| m.len() > MAX_FILE_SIZE) {
+                continue;
+            }
             files.push(path.to_path_buf());
         }
     }


### PR DESCRIPTION
## Summary

- MCP protocol version negotiation (2024-11-05 through 2025-11-25) instead of hardcoding
- Null `arguments` fix: treat explicit JSON `null` same as absent, preventing tool-call hang
- Input sanitisation on all 5 write tools (`sanitize_name` / `sanitize_content`): blocks path traversal, null bytes, oversized inputs
- WAL audit log at `~/.mempalace/wal/write_log.jsonl` for add_drawer, delete_drawer, kg_add, kg_invalidate, diary_write; dir/file permissions 0o700/0o600 on Unix
- `add_drawer` drawer_id: `md5(content)[:16]` → `sha256(wing+room+content[:100])[:24]`; removes `md5` crate, adds `sha2`
- Symlink skip in `walk_dir` and `walk_convos` (prevents following `/dev/urandom` etc.)
- 10 MB per-file guard in both miners (project and convo)
- 500 MB safety limit in `normalize` and `split` before reading into memory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - File-size guards: 500 MB for splitting/normalization; 10 MB for ingestion/mining.

* **Improvements**
  - Write-ahead logging for mutating operations; WAL failures are non-fatal and logged.
  - Stronger input sanitization with clearer validation errors.
  - Symlinks ignored during discovery.
  - Protocol negotiation now respects client-supported versions.
  - Deterministic IDs migrated to SHA‑256; MD5 removed.

* **Chores**
  - Rust toolchain minimum bumped to 1.88.
  - Python submodule added; docs and .gitignore updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->