### PR TITLE
Resync with mempalace-py @ 1056018

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,17 +310,17 @@ All tools communicate over JSON-RPC 2.0. Invoke them from the AI side via the MC
 
 ### Palace / Drawers
 
-| Tool                        | Parameters                                             | What it does                                      |
-| --------------------------- | ------------------------------------------------------ | ------------------------------------------------- |
-| `mempalace_status`          | —                                                      | Overview + memory protocol + AAAK spec            |
-| `mempalace_list_wings`      | —                                                      | Wing names with drawer counts                     |
-| `mempalace_list_rooms`      | `wing?`                                                | Room names with counts (all wings or one)         |
-| `mempalace_get_taxonomy`    | —                                                      | Full `wing → room → count` hierarchy              |
-| `mempalace_get_aaak_spec`   | —                                                      | AAAK dialect specification                        |
-| `mempalace_search`          | `query`, `limit?`, `wing?`, `room?`                    | Keyword search, returns `similarity` scores       |
-| `mempalace_check_duplicate` | `content`                                              | True if highly similar content already exists     |
-| `mempalace_add_drawer`      | `wing`, `room`, `content`, `source_file?`, `added_by?` | File a memory; blocks on duplicates               |
-| `mempalace_delete_drawer`   | `drawer_id`                                            | Permanently delete a drawer and its index entries |
+| Tool                        | Parameters                                             | What it does                                                                |
+| --------------------------- | ------------------------------------------------------ | --------------------------------------------------------------------------- |
+| `mempalace_status`          | —                                                      | Overview + memory protocol + AAAK spec                                      |
+| `mempalace_list_wings`      | —                                                      | Wing names with drawer counts                                               |
+| `mempalace_list_rooms`      | `wing?`                                                | Room names with counts (all wings or one)                                   |
+| `mempalace_get_taxonomy`    | —                                                      | Full `wing → room → count` hierarchy                                        |
+| `mempalace_get_aaak_spec`   | —                                                      | AAAK dialect specification                                                  |
+| `mempalace_search`          | `query`, `limit?`, `wing?`, `room?`, `context?`        | Keyword search, returns `similarity` scores; sanitizes contaminated queries |
+| `mempalace_check_duplicate` | `content`                                              | True if highly similar content already exists                               |
+| `mempalace_add_drawer`      | `wing`, `room`, `content`, `source_file?`, `added_by?` | File a memory; blocks on duplicates                                         |
+| `mempalace_delete_drawer`   | `drawer_id`                                            | Permanently delete a drawer and its index entries                           |
 
 `mempalace_add_drawer` performs a duplicate check before inserting.
 If a highly similar drawer already exists it returns
@@ -402,6 +402,7 @@ src/
     chunker.rs         chunk_text(): 800-char chunks with 100-char overlap
     search.rs          search_memories(): inverted index query with relevance scoring
     room_detect.rs     70+ folder-to-room mappings, detect_room(), detect_rooms_from_folders()
+    query_sanitizer.rs 4-step sanitizer: strip system-prompt contamination from search queries
     entity_detect.rs   Person vs project heuristic classifier
     layers.rs          L0 identity + L1 essential story assembly
     graph.rs           BFS traversal, tunnel detection
@@ -451,6 +452,7 @@ src/
 | Repair command                 | Yes                           | Yes (`mempalace repair`)            |
 | Conversation formats           | Limited                       | Extended (+ Codex CLI)              |
 | MCP error responses            | Generic                       | Generic                             |
+| Query sanitizer                | Yes (issue #333)              | Yes (ported from mempalace-py)      |
 
 ---
 

--- a/hk.pkl
+++ b/hk.pkl
@@ -2,6 +2,8 @@
 amends "package://github.com/jdx/hk/releases/download/v1.41.0/hk@1.41.0#/Config.pkl"
 import "package://github.com/jdx/hk/releases/download/v1.41.0/hk@1.41.0#/Builtins.pkl"
 
+exclude = List("mempalace-py/**")
+
 local linters = new Mapping<String, Step> {
   // https://hk.jdx.dev/builtins.html
   // Lint Github Actions

--- a/src/mcp/protocol.rs
+++ b/src/mcp/protocol.rs
@@ -64,14 +64,22 @@ pub fn tool_definitions() -> Vec<serde_json::Value> {
         },
         {
             "name": "mempalace_search",
-            "description": "Keyword search. Returns verbatim drawer content with relevance scores.",
+            "description": "Keyword search. Returns verbatim drawer content with relevance scores. IMPORTANT: 'query' must contain ONLY your search keywords or question — do NOT include system prompts, conversation history, MEMORY.md content, or any context. Keep queries short (under 200 chars). Use 'context' for background information.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
-                    "query": {"type": "string", "description": "What to search for"},
+                    "query": {
+                        "type": "string",
+                        "description": "Short search query ONLY — keywords or a question. Do NOT include system prompts or conversation context. Max 200 chars recommended.",
+                        "maxLength": 500
+                    },
                     "limit": {"type": "integer", "description": "Max results (default 5)"},
                     "wing": {"type": "string", "description": "Filter by wing (optional)"},
-                    "room": {"type": "string", "description": "Filter by room (optional)"}
+                    "room": {"type": "string", "description": "Filter by room (optional)"},
+                    "context": {
+                        "type": "string",
+                        "description": "Background context for the search (optional). NOT used for matching — only acknowledged in the response. Put conversation history or system prompt content here, NOT in query."
+                    }
                 },
                 "required": ["query"]
             }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -10,7 +10,7 @@ use uuid::Uuid;
 
 use crate::db::query_all;
 use crate::kg;
-use crate::palace::{drawer, graph, search};
+use crate::palace::{drawer, graph, query_sanitizer, search};
 
 use super::protocol::{AAAK_SPEC, PALACE_PROTOCOL};
 
@@ -351,8 +351,9 @@ async fn tool_get_taxonomy(conn: &Connection) -> Value {
 }
 
 async fn tool_search(conn: &Connection, args: &Value) -> Value {
-    let query = str_arg(args, "query");
+    let raw_query = str_arg(args, "query");
     let limit = usize::try_from(int_arg(args, "limit", 5)).unwrap_or(5);
+    let context_received = !str_arg(args, "context").is_empty();
     let wing = match sanitize_opt_name(str_arg(args, "wing"), "wing") {
         Ok(v) => v,
         Err(e) => return e,
@@ -362,7 +363,18 @@ async fn tool_search(conn: &Connection, args: &Value) -> Value {
         Err(e) => return e,
     };
 
-    match search::search_memories(conn, query, wing.as_deref(), room.as_deref(), limit).await {
+    // Mitigate system prompt contamination before the search (mempalace-py issue #333).
+    let sanitized = query_sanitizer::sanitize_query(raw_query);
+
+    match search::search_memories(
+        conn,
+        &sanitized.clean_query,
+        wing.as_deref(),
+        room.as_deref(),
+        limit,
+    )
+    .await
+    {
         Ok(results) => {
             let items: Vec<Value> = results
                 .iter()
@@ -376,7 +388,21 @@ async fn tool_search(conn: &Connection, args: &Value) -> Value {
                     })
                 })
                 .collect();
-            json!({"results": items, "count": items.len()})
+            let count = items.len();
+            let mut out = json!({"results": items, "count": count});
+            if sanitized.was_sanitized {
+                out["query_sanitized"] = json!(true);
+                out["sanitizer"] = json!({
+                    "method": sanitized.method,
+                    "original_length": sanitized.original_length,
+                    "clean_length": sanitized.clean_length,
+                    "clean_query": sanitized.clean_query,
+                });
+            }
+            if context_received {
+                out["context_received"] = json!(true);
+            }
+            out
         }
         Err(e) => json!({"error": e.to_string()}),
     }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -351,9 +351,12 @@ async fn tool_get_taxonomy(conn: &Connection) -> Value {
 }
 
 async fn tool_search(conn: &Connection, args: &Value) -> Value {
-    let raw_query = str_arg(args, "query");
+    let raw_query = str_arg(args, "query").trim();
+    if raw_query.is_empty() {
+        return json!({"error": "query must be a non-empty string", "public": true});
+    }
     let limit = usize::try_from(int_arg(args, "limit", 5)).unwrap_or(5);
-    let context_received = !str_arg(args, "context").is_empty();
+    let context_received = !str_arg(args, "context").trim().is_empty();
     let wing = match sanitize_opt_name(str_arg(args, "wing"), "wing") {
         Ok(v) => v,
         Err(e) => return e,

--- a/src/palace/mod.rs
+++ b/src/palace/mod.rs
@@ -8,5 +8,6 @@ pub mod entity_detect;
 pub mod graph;
 pub mod layers;
 pub mod miner;
+pub mod query_sanitizer;
 pub mod room_detect;
 pub mod search;

--- a/src/palace/query_sanitizer.rs
+++ b/src/palace/query_sanitizer.rs
@@ -18,6 +18,7 @@ use regex::Regex;
 const MAX_QUERY_LEN: usize = 500;
 const SAFE_QUERY_LEN: usize = 200;
 const MIN_SEGMENT_LEN: usize = 10;
+const MIN_QUESTION_SEGMENT_LEN: usize = 3;
 
 static QUESTION_RE: OnceLock<Regex> = OnceLock::new();
 
@@ -68,7 +69,7 @@ pub fn sanitize_query(raw: &str) -> SanitizedQuery {
 
     // Step 2: find the last newline-segment that ends with `?` or `？`.
     for seg in segments.iter().rev() {
-        if question_re().is_match(seg) && seg.chars().count() >= MIN_SEGMENT_LEN {
+        if question_re().is_match(seg) && seg.chars().count() >= MIN_QUESTION_SEGMENT_LEN {
             let candidate = tail_guard(seg);
             eprintln!(
                 "mempalace: query sanitized {original_length} → {} chars (method=question_extraction)",

--- a/src/palace/query_sanitizer.rs
+++ b/src/palace/query_sanitizer.rs
@@ -1,0 +1,199 @@
+//! Query sanitizer — mitigate system prompt contamination in search queries.
+//!
+//! Problem: AI agents sometimes prepend system prompts (2000+ chars) to search
+//! queries. Embedding models represent the full string as a single vector where
+//! the system prompt overwhelms the actual question (typically 10–50 chars),
+//! causing near-total retrieval failure. See mempalace-py issue #333.
+//!
+//! Approach: four-step extraction, in order of precision:
+//!   1. Short-query passthrough (≤ 200 chars) — no action needed.
+//!   2. Question extraction — find a sentence ending with `?`.
+//!   3. Tail sentence — take the last meaningful newline-delimited segment.
+//!   4. Tail truncation — fallback, take the last 500 chars.
+
+use regex::Regex;
+
+const MAX_QUERY_LEN: usize = 500;
+const SAFE_QUERY_LEN: usize = 200;
+const MIN_SEGMENT_LEN: usize = 10;
+
+/// Result of [`sanitize_query`].
+pub struct SanitizedQuery {
+    /// The cleaned query to use for search.
+    pub clean_query: String,
+    /// Whether any sanitization was applied.
+    pub was_sanitized: bool,
+    /// Byte length of the original input.
+    pub original_length: usize,
+    /// Byte length of the cleaned output.
+    pub clean_length: usize,
+    /// Name of the method used.
+    pub method: &'static str,
+}
+
+/// Extract the actual search intent from a potentially contaminated query.
+///
+/// Logs a warning to stderr (not stdout — MCP servers must not pollute stdout)
+/// when sanitization is applied.
+#[must_use]
+pub fn sanitize_query(raw: &str) -> SanitizedQuery {
+    let raw = raw.trim();
+    let original_length = raw.len();
+
+    if raw.is_empty() {
+        return passthrough(String::new(), 0);
+    }
+
+    // Step 1: short query — almost certainly not contaminated.
+    if original_length <= SAFE_QUERY_LEN {
+        return passthrough(raw.to_owned(), original_length);
+    }
+
+    let segments: Vec<&str> = raw
+        .lines()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    // Step 2: find the last newline-segment that ends with `?` or `？`.
+    let question_re = Regex::new(r#"[?？]\s*["']?\s*$"#)
+        .expect("valid regex: question_re pattern is a compile-time constant");
+
+    for seg in segments.iter().rev() {
+        if question_re.is_match(seg) && seg.len() >= MIN_SEGMENT_LEN {
+            let candidate = tail_guard(seg);
+            eprintln!(
+                "mempalace: query sanitized {original_length} → {} chars (method=question_extraction)",
+                candidate.len()
+            );
+            return sanitized(candidate, original_length, "question_extraction");
+        }
+    }
+
+    // Step 3: take the last meaningful segment (system prompts are prepended,
+    // so the actual query is at the end of the string).
+    for seg in segments.iter().rev() {
+        if seg.len() >= MIN_SEGMENT_LEN {
+            let candidate = tail_guard(seg);
+            eprintln!(
+                "mempalace: query sanitized {original_length} → {} chars (method=tail_sentence)",
+                candidate.len()
+            );
+            return sanitized(candidate, original_length, "tail_sentence");
+        }
+    }
+
+    // Step 4: nothing usable found — truncate to the tail.
+    let candidate = tail_guard(raw);
+    eprintln!(
+        "mempalace: query sanitized {original_length} → {} chars (method=tail_truncation)",
+        candidate.len()
+    );
+    sanitized(candidate, original_length, "tail_truncation")
+}
+
+fn passthrough(s: String, len: usize) -> SanitizedQuery {
+    SanitizedQuery {
+        clean_length: len,
+        clean_query: s,
+        was_sanitized: false,
+        original_length: len,
+        method: "passthrough",
+    }
+}
+
+fn sanitized(clean_query: String, original_length: usize, method: &'static str) -> SanitizedQuery {
+    let clean_length = clean_query.len();
+    SanitizedQuery {
+        clean_query,
+        was_sanitized: true,
+        original_length,
+        clean_length,
+        method,
+    }
+}
+
+/// Return the last [`MAX_QUERY_LEN`] bytes of `s`, adjusted to a valid UTF-8
+/// char boundary so slicing never panics.
+fn tail_guard(s: &str) -> String {
+    if s.len() <= MAX_QUERY_LEN {
+        return s.to_owned();
+    }
+    let byte_start = s.len() - MAX_QUERY_LEN;
+    // Advance to the next valid char boundary at or after `byte_start`.
+    let boundary = (byte_start..=s.len())
+        .find(|&i| s.is_char_boundary(i))
+        .unwrap_or(s.len());
+    s[boundary..].to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn passthrough_short() {
+        let r = sanitize_query("what is the capital of France?");
+        assert!(!r.was_sanitized);
+        assert_eq!(r.method, "passthrough");
+        assert_eq!(r.clean_query, "what is the capital of France?");
+    }
+
+    #[test]
+    fn passthrough_empty() {
+        let r = sanitize_query("   ");
+        assert!(!r.was_sanitized);
+        assert_eq!(r.clean_query, "");
+    }
+
+    #[test]
+    fn question_extraction() {
+        let prompt = format!(
+            "{}\nwhat did we decide about the database schema?",
+            "x".repeat(300)
+        );
+        let r = sanitize_query(&prompt);
+        assert!(r.was_sanitized);
+        assert_eq!(r.method, "question_extraction");
+        assert_eq!(
+            r.clean_query,
+            "what did we decide about the database schema?"
+        );
+    }
+
+    #[test]
+    fn tail_sentence() {
+        let prompt = format!("{}\nchromadb locking bug", "x".repeat(300));
+        let r = sanitize_query(&prompt);
+        assert!(r.was_sanitized);
+        assert_eq!(r.method, "tail_sentence");
+        assert_eq!(r.clean_query, "chromadb locking bug");
+    }
+
+    #[test]
+    fn tail_truncation() {
+        // All newline-segments are tiny (< MIN_SEGMENT_LEN), forcing fallback.
+        let prompt = "ab\n".repeat(100); // 300 chars; each segment "ab" is only 2 chars
+        let r = sanitize_query(&prompt);
+        assert!(r.was_sanitized);
+        assert_eq!(r.method, "tail_truncation");
+    }
+
+    #[test]
+    fn tail_sentence_long_line() {
+        // Single long line with no newlines → tail_sentence via the last (only) segment.
+        let prompt = "a".repeat(600);
+        let r = sanitize_query(&prompt);
+        assert!(r.was_sanitized);
+        assert_eq!(r.method, "tail_sentence");
+        assert_eq!(r.clean_length, MAX_QUERY_LEN);
+    }
+
+    #[test]
+    fn utf8_boundary_safe() {
+        // 300 bytes of ASCII + a 3-byte UTF-8 char pushes total over SAFE_QUERY_LEN
+        let prompt = format!("{}{}", "a".repeat(300), "é".repeat(50));
+        let r = sanitize_query(&prompt);
+        assert!(std::str::from_utf8(r.clean_query.as_bytes()).is_ok());
+    }
+}

--- a/src/palace/query_sanitizer.rs
+++ b/src/palace/query_sanitizer.rs
@@ -17,7 +17,6 @@ use regex::Regex;
 
 const MAX_QUERY_LEN: usize = 500;
 const SAFE_QUERY_LEN: usize = 200;
-const MIN_SEGMENT_LEN: usize = 10;
 const MIN_QUESTION_SEGMENT_LEN: usize = 3;
 
 static QUESTION_RE: OnceLock<Regex> = OnceLock::new();
@@ -67,23 +66,19 @@ pub fn sanitize_query(raw: &str) -> SanitizedQuery {
         .filter(|s| !s.is_empty())
         .collect();
 
-    // Step 2: find the last newline-segment that ends with `?` or `？`.
-    for seg in segments.iter().rev() {
-        if question_re().is_match(seg) && seg.chars().count() >= MIN_QUESTION_SEGMENT_LEN {
-            let candidate = tail_guard(seg);
+    // Step 2/3: treat the trailing segment as the primary intent carrier.
+    if let Some(last_seg) = segments.last().copied() {
+        let last_len = last_seg.chars().count();
+        if question_re().is_match(last_seg) && last_len >= MIN_QUESTION_SEGMENT_LEN {
+            let candidate = tail_guard(last_seg);
             eprintln!(
                 "mempalace: query sanitized {original_length} → {} chars (method=question_extraction)",
                 candidate.chars().count()
             );
             return sanitized(candidate, original_length, "question_extraction");
         }
-    }
-
-    // Step 3: take the last meaningful segment (system prompts are prepended,
-    // so the actual query is at the end of the string).
-    for seg in segments.iter().rev() {
-        if seg.chars().count() >= MIN_SEGMENT_LEN {
-            let candidate = tail_guard(seg);
+        if last_len >= MIN_QUESTION_SEGMENT_LEN {
+            let candidate = tail_guard(last_seg);
             eprintln!(
                 "mempalace: query sanitized {original_length} → {} chars (method=tail_sentence)",
                 candidate.chars().count()
@@ -206,9 +201,10 @@ mod tests {
 
     #[test]
     fn utf8_boundary_safe() {
-        // 300 bytes of ASCII + a 3-byte UTF-8 char pushes total over SAFE_QUERY_LEN
-        let prompt = format!("{}{}", "a".repeat(300), "é".repeat(50));
+        // Force truncation with multi-byte chars to validate UTF-8-safe slicing.
+        let prompt = "é".repeat(550);
         let r = sanitize_query(&prompt);
+        assert_eq!(r.clean_length, MAX_QUERY_LEN);
         assert!(std::str::from_utf8(r.clean_query.as_bytes()).is_ok());
     }
 }

--- a/src/palace/query_sanitizer.rs
+++ b/src/palace/query_sanitizer.rs
@@ -168,6 +168,15 @@ mod tests {
     }
 
     #[test]
+    fn question_extraction_short_question_segment() {
+        let prompt = format!("{}\nETA?", "x".repeat(300));
+        let r = sanitize_query(&prompt);
+        assert!(r.was_sanitized);
+        assert_eq!(r.method, "question_extraction");
+        assert_eq!(r.clean_query, "ETA?");
+    }
+
+    #[test]
     fn tail_sentence() {
         let prompt = format!("{}\nchromadb locking bug", "x".repeat(300));
         let r = sanitize_query(&prompt);

--- a/src/palace/query_sanitizer.rs
+++ b/src/palace/query_sanitizer.rs
@@ -34,7 +34,8 @@ pub struct SanitizedQuery {
     pub clean_query: String,
     /// Whether any sanitization was applied.
     pub was_sanitized: bool,
-    /// Char count of the original input.
+    /// Char count of the trimmed input (see the `trim()` call at the top of
+    /// [`sanitize_query`] — the raw string is trimmed before this is measured).
     pub original_length: usize,
     /// Char count of the cleaned output.
     pub clean_length: usize,
@@ -182,7 +183,7 @@ mod tests {
 
     #[test]
     fn tail_truncation() {
-        // All newline-segments are tiny (< MIN_SEGMENT_LEN), forcing fallback.
+        // All newline-segments are tiny (only 2 chars each), forcing fallback to tail_truncation.
         let prompt = "ab\n".repeat(100); // 300 chars; each segment "ab" is only 2 chars
         let r = sanitize_query(&prompt);
         assert!(r.was_sanitized);

--- a/src/palace/query_sanitizer.rs
+++ b/src/palace/query_sanitizer.rs
@@ -11,11 +11,22 @@
 //!   3. Tail sentence — take the last meaningful newline-delimited segment.
 //!   4. Tail truncation — fallback, take the last 500 chars.
 
+use std::sync::OnceLock;
+
 use regex::Regex;
 
 const MAX_QUERY_LEN: usize = 500;
 const SAFE_QUERY_LEN: usize = 200;
 const MIN_SEGMENT_LEN: usize = 10;
+
+static QUESTION_RE: OnceLock<Regex> = OnceLock::new();
+
+fn question_re() -> &'static Regex {
+    QUESTION_RE.get_or_init(|| {
+        Regex::new(r#"[?？]\s*["']?\s*$"#)
+            .expect("valid regex: question_re pattern is a compile-time constant")
+    })
+}
 
 /// Result of [`sanitize_query`].
 pub struct SanitizedQuery {
@@ -23,9 +34,9 @@ pub struct SanitizedQuery {
     pub clean_query: String,
     /// Whether any sanitization was applied.
     pub was_sanitized: bool,
-    /// Byte length of the original input.
+    /// Char count of the original input.
     pub original_length: usize,
-    /// Byte length of the cleaned output.
+    /// Char count of the cleaned output.
     pub clean_length: usize,
     /// Name of the method used.
     pub method: &'static str,
@@ -38,7 +49,7 @@ pub struct SanitizedQuery {
 #[must_use]
 pub fn sanitize_query(raw: &str) -> SanitizedQuery {
     let raw = raw.trim();
-    let original_length = raw.len();
+    let original_length = raw.chars().count();
 
     if raw.is_empty() {
         return passthrough(String::new(), 0);
@@ -56,15 +67,12 @@ pub fn sanitize_query(raw: &str) -> SanitizedQuery {
         .collect();
 
     // Step 2: find the last newline-segment that ends with `?` or `？`.
-    let question_re = Regex::new(r#"[?？]\s*["']?\s*$"#)
-        .expect("valid regex: question_re pattern is a compile-time constant");
-
     for seg in segments.iter().rev() {
-        if question_re.is_match(seg) && seg.len() >= MIN_SEGMENT_LEN {
+        if question_re().is_match(seg) && seg.chars().count() >= MIN_SEGMENT_LEN {
             let candidate = tail_guard(seg);
             eprintln!(
                 "mempalace: query sanitized {original_length} → {} chars (method=question_extraction)",
-                candidate.len()
+                candidate.chars().count()
             );
             return sanitized(candidate, original_length, "question_extraction");
         }
@@ -73,11 +81,11 @@ pub fn sanitize_query(raw: &str) -> SanitizedQuery {
     // Step 3: take the last meaningful segment (system prompts are prepended,
     // so the actual query is at the end of the string).
     for seg in segments.iter().rev() {
-        if seg.len() >= MIN_SEGMENT_LEN {
+        if seg.chars().count() >= MIN_SEGMENT_LEN {
             let candidate = tail_guard(seg);
             eprintln!(
                 "mempalace: query sanitized {original_length} → {} chars (method=tail_sentence)",
-                candidate.len()
+                candidate.chars().count()
             );
             return sanitized(candidate, original_length, "tail_sentence");
         }
@@ -87,7 +95,7 @@ pub fn sanitize_query(raw: &str) -> SanitizedQuery {
     let candidate = tail_guard(raw);
     eprintln!(
         "mempalace: query sanitized {original_length} → {} chars (method=tail_truncation)",
-        candidate.len()
+        candidate.chars().count()
     );
     sanitized(candidate, original_length, "tail_truncation")
 }
@@ -103,7 +111,7 @@ fn passthrough(s: String, len: usize) -> SanitizedQuery {
 }
 
 fn sanitized(clean_query: String, original_length: usize, method: &'static str) -> SanitizedQuery {
-    let clean_length = clean_query.len();
+    let clean_length = clean_query.chars().count();
     SanitizedQuery {
         clean_query,
         was_sanitized: true,
@@ -113,18 +121,15 @@ fn sanitized(clean_query: String, original_length: usize, method: &'static str) 
     }
 }
 
-/// Return the last [`MAX_QUERY_LEN`] bytes of `s`, adjusted to a valid UTF-8
-/// char boundary so slicing never panics.
+/// Return the last [`MAX_QUERY_LEN`] chars of `s`.
 fn tail_guard(s: &str) -> String {
-    if s.len() <= MAX_QUERY_LEN {
+    let total = s.chars().count();
+    if total <= MAX_QUERY_LEN {
         return s.to_owned();
     }
-    let byte_start = s.len() - MAX_QUERY_LEN;
-    // Advance to the next valid char boundary at or after `byte_start`.
-    let boundary = (byte_start..=s.len())
-        .find(|&i| s.is_char_boundary(i))
-        .unwrap_or(s.len());
-    s[boundary..].to_owned()
+    let skip = total - MAX_QUERY_LEN;
+    let byte_start = s.char_indices().nth(skip).map_or(0, |(i, _)| i);
+    s[byte_start..].to_owned()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Ports the query sanitizer from mempalace-py, mitigating system prompt contamination in `mempalace_search` queries. Queries over 200 chars are cleaned via 4-step extraction (question → tail sentence → tail truncation) before hitting the index.
- `mempalace_search` tool now calls the sanitizer, attaches `sanitizer` metadata to the response when a query is cleaned, and accepts a `context` parameter for background information (acknowledged but not used for matching).
- Updated `mempalace_search` schema: stronger description warning agents not to stuff system prompts into `query`, `maxLength: 500` on the query field, new optional `context` field.
- 6 new tests covering all sanitizer paths including UTF-8 boundary safety.

Not ported (ChromaDB/Python-specific): pagination fixes in status/list tools, `convo_miner` upsert, `miner` delete-before-insert, and the `migrate`/`dedup`/`repair` CLI commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional context parameter added; responses indicate when context is received
  * Automatic query sanitization; responses include sanitized flag and sanitizer metadata (method, original/clean lengths)
  * Successful search responses always include results and a count

* **Validation**
  * Queries trimmed; empty/whitespace queries are rejected with a clear error
  * Max-length guidance added for queries

* **Documentation**
  * README and tool docs updated to describe the new parameter and sanitization behavior

* **Tests**
  * Unit tests added covering sanitization behaviors and UTF-8 safety
<!-- end of auto-generated comment: release notes by coderabbit.ai -->