### PR TITLE
Resync with mempalace-py @ f56e67b

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "mempalace-py"]
 	path = mempalace-py
-	url = https://github.com/milla-jovovich/mempalace.git
+	url = https://github.com/MemPalace/mempalace.git

--- a/README.md
+++ b/README.md
@@ -463,7 +463,7 @@ src/
 
 ```toml
 [lints.rust]
-unsafe_code = "forbid"
+unsafe_code = "deny"
 warnings = "deny"
 
 [lints.clippy]

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This reimplementation:
 - Ships as a single self-contained binary
 - Replaces ChromaDB semantic search with a keyword inverted index (BM25-style scoring via `drawer_words`)
 - Fixes the concurrency problem at the turso layer
-- Keeps all 19 MCP tools and all CLI commands fully compatible
+- Keeps all MCP tools and all CLI commands fully compatible
 
 **Trade-off:** Keyword search instead of embedding-based semantic search.
 Semantic search is deferred until an embedded model is available without network dependencies.
@@ -48,7 +48,7 @@ cp target/release/mempalace ~/.local/bin/mempalace
 claude mcp add mempalace -- /path/to/mempalace mcp
 ```
 
-The MCP server runs as a JSON-RPC 2.0 process over stdio. All 19 tools are available immediately
+The MCP server runs as a JSON-RPC 2.0 process over stdio. All 22 tools are available immediately
 after the server starts.
 
 On first use, call `mempalace_status` — it returns the full memory protocol and AAAK dialect spec
@@ -304,23 +304,26 @@ Traits: direct, memory-first, no summaries.
 
 ---
 
-## MCP Tools (19)
+## MCP Tools (22)
 
 All tools communicate over JSON-RPC 2.0. Invoke them from the AI side via the MCP protocol.
 
 ### Palace / Drawers
 
-| Tool                        | Parameters                                             | What it does                                                                |
-| --------------------------- | ------------------------------------------------------ | --------------------------------------------------------------------------- |
-| `mempalace_status`          | —                                                      | Overview + memory protocol + AAAK spec                                      |
-| `mempalace_list_wings`      | —                                                      | Wing names with drawer counts                                               |
-| `mempalace_list_rooms`      | `wing?`                                                | Room names with counts (all wings or one)                                   |
-| `mempalace_get_taxonomy`    | —                                                      | Full `wing → room → count` hierarchy                                        |
-| `mempalace_get_aaak_spec`   | —                                                      | AAAK dialect specification                                                  |
-| `mempalace_search`          | `query`, `limit?`, `wing?`, `room?`, `context?`        | Keyword search, returns `similarity` scores; sanitizes contaminated queries |
-| `mempalace_check_duplicate` | `content`                                              | True if highly similar content already exists                               |
-| `mempalace_add_drawer`      | `wing`, `room`, `content`, `source_file?`, `added_by?` | File a memory; blocks on duplicates                                         |
-| `mempalace_delete_drawer`   | `drawer_id`                                            | Permanently delete a drawer and its index entries                           |
+| Tool                        | Parameters                                                     | What it does                                                                |
+| --------------------------- | -------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `mempalace_status`          | —                                                              | Overview + memory protocol + AAAK spec                                      |
+| `mempalace_list_wings`      | —                                                              | Wing names with drawer counts                                               |
+| `mempalace_list_rooms`      | `wing?`                                                        | Room names with counts (all wings or one)                                   |
+| `mempalace_get_taxonomy`    | —                                                              | Full `wing → room → count` hierarchy                                        |
+| `mempalace_get_aaak_spec`   | —                                                              | AAAK dialect specification                                                  |
+| `mempalace_search`          | `query`, `limit?`, `wing?`, `room?`, `context?`                | Keyword search, returns `similarity` scores; sanitizes contaminated queries |
+| `mempalace_check_duplicate` | `content`                                                      | True if highly similar content already exists                               |
+| `mempalace_add_drawer`      | `wing`, `room`, `content`, `source_file?`, `added_by?`         | File a memory; blocks on duplicates                                         |
+| `mempalace_delete_drawer`   | `drawer_id`                                                    | Permanently delete a drawer and its index entries                           |
+| `mempalace_get_drawer`      | `drawer_id`                                                    | Fetch full content and metadata for a single drawer                         |
+| `mempalace_list_drawers`    | `wing?`, `room?`, `limit?` (max 100), `offset?`                | Paginated drawer listing with content previews                              |
+| `mempalace_update_drawer`   | `drawer_id`, `content?`, `wing?`, `room?`                      | Update an existing drawer's content and/or location                         |
 
 `mempalace_add_drawer` performs a duplicate check before inserting.
 If a highly similar drawer already exists it returns
@@ -429,8 +432,8 @@ src/
 
   mcp/
     mod.rs             Async stdio JSON-RPC 2.0 event loop
-    protocol.rs        PALACE_PROTOCOL, AAAK_SPEC, 19 tool schemas
-    tools.rs           Tool dispatch + all 19 handler implementations
+    protocol.rs        PALACE_PROTOCOL, AAAK_SPEC, 22 tool schemas
+    tools.rs           Tool dispatch + all 22 handler implementations
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A local-first memory palace for AI assistants. Single static binary backed by embedded SQLite (turso).
 No Python, no ChromaDB, no API keys.
 
-**Drop-in replacement for [milla-jovovich/mempalace](https://github.com/milla-jovovich/mempalace) with a ~13MB binary instead of a ~100MB Python environment.**
+**Drop-in replacement for [MemPalace/mempalace](https://github.com/MemPalace/mempalace) with a ~13MB binary instead of a ~100MB Python environment.**
 
 ---
 
@@ -310,20 +310,20 @@ All tools communicate over JSON-RPC 2.0. Invoke them from the AI side via the MC
 
 ### Palace / Drawers
 
-| Tool                        | Parameters                                                     | What it does                                                                |
-| --------------------------- | -------------------------------------------------------------- | --------------------------------------------------------------------------- |
-| `mempalace_status`          | —                                                              | Overview + memory protocol + AAAK spec                                      |
-| `mempalace_list_wings`      | —                                                              | Wing names with drawer counts                                               |
-| `mempalace_list_rooms`      | `wing?`                                                        | Room names with counts (all wings or one)                                   |
-| `mempalace_get_taxonomy`    | —                                                              | Full `wing → room → count` hierarchy                                        |
-| `mempalace_get_aaak_spec`   | —                                                              | AAAK dialect specification                                                  |
-| `mempalace_search`          | `query`, `limit?`, `wing?`, `room?`, `context?`                | Keyword search, returns `similarity` scores; sanitizes contaminated queries |
-| `mempalace_check_duplicate` | `content`                                                      | True if highly similar content already exists                               |
-| `mempalace_add_drawer`      | `wing`, `room`, `content`, `source_file?`, `added_by?`         | File a memory; blocks on duplicates                                         |
-| `mempalace_delete_drawer`   | `drawer_id`                                                    | Permanently delete a drawer and its index entries                           |
-| `mempalace_get_drawer`      | `drawer_id`                                                    | Fetch full content and metadata for a single drawer                         |
-| `mempalace_list_drawers`    | `wing?`, `room?`, `limit?` (max 100), `offset?`                | Paginated drawer listing with content previews                              |
-| `mempalace_update_drawer`   | `drawer_id`, `content?`, `wing?`, `room?`                      | Update an existing drawer's content and/or location                         |
+| Tool                        | Parameters                                             | What it does                                                                |
+| --------------------------- | ------------------------------------------------------ | --------------------------------------------------------------------------- |
+| `mempalace_status`          | —                                                      | Overview + memory protocol + AAAK spec                                      |
+| `mempalace_list_wings`      | —                                                      | Wing names with drawer counts                                               |
+| `mempalace_list_rooms`      | `wing?`                                                | Room names with counts (all wings or one)                                   |
+| `mempalace_get_taxonomy`    | —                                                      | Full `wing → room → count` hierarchy                                        |
+| `mempalace_get_aaak_spec`   | —                                                      | AAAK dialect specification                                                  |
+| `mempalace_search`          | `query`, `limit?`, `wing?`, `room?`, `context?`        | Keyword search, returns `similarity` scores; sanitizes contaminated queries |
+| `mempalace_check_duplicate` | `content`                                              | True if highly similar content already exists                               |
+| `mempalace_add_drawer`      | `wing`, `room`, `content`, `source_file?`, `added_by?` | File a memory; blocks on duplicates                                         |
+| `mempalace_delete_drawer`   | `drawer_id`                                            | Permanently delete a drawer and its index entries                           |
+| `mempalace_get_drawer`      | `drawer_id`                                            | Fetch full content and metadata for a single drawer                         |
+| `mempalace_list_drawers`    | `wing?`, `room?`, `limit?` (max 100), `offset?`        | Paginated drawer listing with content previews                              |
+| `mempalace_update_drawer`   | `drawer_id`, `content?`, `wing?`, `room?`              | Update an existing drawer's content and/or location                         |
 
 `mempalace_add_drawer` performs a duplicate check before inserting.
 If a highly similar drawer already exists it returns

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,8 @@ async fn open_palace() -> error::Result<(turso::Database, turso::Connection, std
     Ok((db, conn, db_path))
 }
 
+// Each match arm is a single CLI subcommand — splitting this into separate
+// functions would not reduce complexity, only scatter the dispatch logic.
 #[allow(clippy::too_many_lines)]
 async fn run(cli: Cli) -> error::Result<()> {
     match cli.command {

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,18 +46,40 @@ fn main() {
 }
 
 /// Expand a leading `~` to the user's home directory.
+///
+/// Resolves the home directory by trying `HOME`, then `USERPROFILE`, then
+/// `HOMEDRIVE` + `HOMEPATH` (Windows fallback). Uses `OsStr`-based path
+/// component inspection to avoid lossy UTF-8 conversion.
 fn expand_tilde(path: &std::path::Path) -> std::path::PathBuf {
-    let s = path.to_string_lossy();
-    if let Some(rest) = s.strip_prefix("~/") {
-        if let Some(home) = std::env::var_os("HOME") {
-            return std::path::PathBuf::from(home).join(rest);
-        }
-    } else if s == "~"
-        && let Some(home) = std::env::var_os("HOME")
-    {
-        return std::path::PathBuf::from(home);
+    use std::ffi::OsStr;
+    use std::path::Component;
+
+    let mut components = path.components();
+    let first = components.next();
+
+    if first != Some(Component::Normal(OsStr::new("~"))) {
+        return path.to_path_buf();
     }
-    path.to_path_buf()
+
+    let home = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .or_else(|| {
+            let drive = std::env::var_os("HOMEDRIVE")?;
+            let home_path = std::env::var_os("HOMEPATH")?;
+            Some(
+                std::path::PathBuf::from(drive)
+                    .join(home_path)
+                    .into_os_string(),
+            )
+        });
+
+    match home {
+        Some(h) => {
+            let rest: std::path::PathBuf = components.collect();
+            std::path::PathBuf::from(h).join(rest)
+        }
+        None => path.to_path_buf(),
+    }
 }
 
 /// Open the palace DB, ensuring schema exists. Returns `(db, conn, path)`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,21 @@ fn main() {
         });
 }
 
+/// Expand a leading `~` to the user's home directory.
+fn expand_tilde(path: &std::path::Path) -> std::path::PathBuf {
+    let s = path.to_string_lossy();
+    if let Some(rest) = s.strip_prefix("~/") {
+        if let Some(home) = std::env::var_os("HOME") {
+            return std::path::PathBuf::from(home).join(rest);
+        }
+    } else if s == "~"
+        && let Some(home) = std::env::var_os("HOME")
+    {
+        return std::path::PathBuf::from(home);
+    }
+    path.to_path_buf()
+}
+
 /// Open the palace DB, ensuring schema exists. Returns `(db, conn, path)`.
 async fn open_palace() -> error::Result<(turso::Database, turso::Connection, std::path::PathBuf)> {
     let cfg = MempalaceConfig::init()?;
@@ -54,6 +69,7 @@ async fn open_palace() -> error::Result<(turso::Database, turso::Connection, std
     Ok((db, conn, db_path))
 }
 
+#[allow(clippy::too_many_lines)]
 async fn run(cli: Cli) -> error::Result<()> {
     match cli.command {
         Command::Status => {
@@ -143,6 +159,9 @@ async fn run(cli: Cli) -> error::Result<()> {
             dry_run,
             min_sessions,
         } => {
+            // Expand ~ so that `mempalace split ~/convos` works as expected.
+            let dir = expand_tilde(&dir);
+            let output_dir = output_dir.as_deref().map(expand_tilde);
             cli::split::run(&dir, output_dir.as_deref(), dry_run, min_sessions)?;
         }
 

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -93,7 +93,13 @@ async fn handle_request(conn: &Connection, request: &Value) -> Option<Value> {
             }))
         }
 
-        "notifications/initialized" => None,
+        "ping" => Some(json!({
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": {}
+        })),
+
+        m if m.starts_with("notifications/") => None,
 
         "tools/list" => {
             let tools = protocol::tool_definitions();

--- a/src/mcp/protocol.rs
+++ b/src/mcp/protocol.rs
@@ -27,7 +27,7 @@ Read AAAK naturally — expand codes mentally, treat *markers* as emotional cont
 When WRITING AAAK: use entity codes, mark emotions, keep structure tight.";
 
 /// Generate the tools/list response payload.
-// 19 tool schemas in a single JSON literal — splitting would hurt readability
+// 22 tool schemas in a single JSON literal — splitting would hurt readability
 // with no structural benefit since each tool is a self-contained object.
 #[allow(clippy::too_many_lines)]
 pub fn tool_definitions() -> Vec<serde_json::Value> {
@@ -117,6 +117,53 @@ pub fn tool_definitions() -> Vec<serde_json::Value> {
                 "type": "object",
                 "properties": {
                     "drawer_id": {"type": "string", "description": "ID of the drawer to delete"}
+                },
+                "required": ["drawer_id"]
+            }
+        },
+        {
+            "name": "mempalace_get_drawer",
+            "description": "Fetch a single drawer by ID — returns full content and metadata.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "drawer_id": {"type": "string", "description": "ID of the drawer to fetch"}
+                },
+                "required": ["drawer_id"]
+            }
+        },
+        {
+            "name": "mempalace_list_drawers",
+            "description": "List drawers with pagination. Optional wing/room filter. Returns IDs, wings, rooms, and content previews.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "wing": {"type": "string", "description": "Filter by wing (optional)"},
+                    "room": {"type": "string", "description": "Filter by room (optional)"},
+                    "limit": {
+                        "type": "integer",
+                        "description": "Max results per page (default 20, max 100)",
+                        "minimum": 1,
+                        "maximum": 100
+                    },
+                    "offset": {
+                        "type": "integer",
+                        "description": "Offset for pagination (default 0)",
+                        "minimum": 0
+                    }
+                }
+            }
+        },
+        {
+            "name": "mempalace_update_drawer",
+            "description": "Update an existing drawer's content and/or metadata (wing, room). Returns error if drawer not found.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "drawer_id": {"type": "string", "description": "ID of the drawer to update"},
+                    "content": {"type": "string", "description": "New content (optional — omit to keep existing)"},
+                    "wing": {"type": "string", "description": "New wing (optional — omit to keep existing)"},
+                    "room": {"type": "string", "description": "New room (optional — omit to keep existing)"}
                 },
                 "required": ["drawer_id"]
             }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -30,6 +30,9 @@ pub async fn dispatch(conn: &Connection, name: &str, args: &Value) -> Value {
         "mempalace_check_duplicate" => tool_check_duplicate(conn, args).await,
         "mempalace_add_drawer" => tool_add_drawer(conn, args).await,
         "mempalace_delete_drawer" => tool_delete_drawer(conn, args).await,
+        "mempalace_get_drawer" => tool_get_drawer(conn, args).await,
+        "mempalace_list_drawers" => tool_list_drawers(conn, args).await,
+        "mempalace_update_drawer" => tool_update_drawer(conn, args).await,
         "mempalace_kg_query" => tool_kg_query(conn, args).await,
         "mempalace_kg_add" => tool_kg_add(conn, args).await,
         "mempalace_kg_invalidate" => tool_kg_invalidate(conn, args).await,
@@ -355,7 +358,7 @@ async fn tool_search(conn: &Connection, args: &Value) -> Value {
     if raw_query.is_empty() {
         return json!({"error": "query must be a non-empty string", "public": true});
     }
-    let limit = usize::try_from(int_arg(args, "limit", 5)).unwrap_or(5);
+    let limit = usize::try_from(int_arg(args, "limit", 5).clamp(1, 100)).unwrap_or(5);
     let context_received = !str_arg(args, "context").trim().is_empty();
     let wing = match sanitize_opt_name(str_arg(args, "wing"), "wing") {
         Ok(v) => v,
@@ -473,7 +476,6 @@ async fn tool_add_drawer(conn: &Connection, args: &Value) -> Value {
         s
     });
     let id = format!("drawer_{wing}_{room}_{}", &hex[..24]);
-    let content_preview: String = content.chars().take(200).collect();
     wal_log(
         "add_drawer",
         json!({
@@ -482,7 +484,7 @@ async fn tool_add_drawer(conn: &Connection, args: &Value) -> Value {
             "room": room,
             "added_by": added_by,
             "content_length": content.len(),
-            "content_preview": content_preview,
+            "content_preview": format!("[REDACTED {} chars]", content.chars().count()),
         }),
     )
     .await;
@@ -547,6 +549,228 @@ async fn tool_delete_drawer(conn: &Connection, args: &Value) -> Value {
     }
 }
 
+async fn tool_get_drawer(conn: &Connection, args: &Value) -> Value {
+    let drawer_id = match sanitize_name(str_arg(args, "drawer_id"), "drawer_id") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+
+    let rows = query_all(
+        conn,
+        "SELECT id, content, wing, room, source_file, filed_at FROM drawers WHERE id = ?",
+        [drawer_id.as_str()],
+    )
+    .await;
+
+    match rows {
+        Ok(rows) if rows.is_empty() => {
+            json!({"error": format!("Drawer not found: {drawer_id}"), "public": true})
+        }
+        Ok(rows) => {
+            let row = &rows[0];
+            let content: String = row.get(1).unwrap_or_default();
+            let wing: String = row.get(2).unwrap_or_default();
+            let room: String = row.get(3).unwrap_or_default();
+            let source_file: String = row.get(4).unwrap_or_default();
+            let filed_at: String = row.get(5).unwrap_or_default();
+            json!({
+                "drawer_id": drawer_id,
+                "content": content,
+                "wing": wing,
+                "room": room,
+                "source_file": source_file,
+                "filed_at": filed_at,
+            })
+        }
+        Err(e) => json!({"error": e.to_string()}),
+    }
+}
+
+async fn tool_list_drawers(conn: &Connection, args: &Value) -> Value {
+    const MAX_LIMIT: i64 = 100;
+    let limit = int_arg(args, "limit", 20).clamp(1, MAX_LIMIT);
+    let offset = args
+        .get("offset")
+        .and_then(serde_json::Value::as_i64)
+        .unwrap_or(0)
+        .max(0);
+    let wing = match sanitize_opt_name(str_arg(args, "wing"), "wing") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let room = match sanitize_opt_name(str_arg(args, "room"), "room") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+
+    // Build WHERE clause based on filters
+    let rows = match (&wing, &room) {
+        (Some(w), Some(r)) => {
+            query_all(
+                conn,
+                "SELECT id, content, wing, room FROM drawers WHERE wing = ?1 AND room = ?2 ORDER BY filed_at DESC LIMIT ?3 OFFSET ?4",
+                (w.as_str(), r.as_str(), limit, offset),
+            )
+            .await
+        }
+        (Some(w), None) => {
+            query_all(
+                conn,
+                "SELECT id, content, wing, room FROM drawers WHERE wing = ?1 ORDER BY filed_at DESC LIMIT ?2 OFFSET ?3",
+                (w.as_str(), limit, offset),
+            )
+            .await
+        }
+        (None, Some(r)) => {
+            query_all(
+                conn,
+                "SELECT id, content, wing, room FROM drawers WHERE room = ?1 ORDER BY filed_at DESC LIMIT ?2 OFFSET ?3",
+                (r.as_str(), limit, offset),
+            )
+            .await
+        }
+        (None, None) => {
+            query_all(
+                conn,
+                "SELECT id, content, wing, room FROM drawers ORDER BY filed_at DESC LIMIT ?1 OFFSET ?2",
+                (limit, offset),
+            )
+            .await
+        }
+    };
+
+    match rows {
+        Ok(rows) => {
+            let drawers: Vec<Value> = rows
+                .iter()
+                .map(|row| {
+                    let id: String = row.get(0).unwrap_or_default();
+                    let content: String = row.get(1).unwrap_or_default();
+                    let wing_val: String = row.get(2).unwrap_or_default();
+                    let room_val: String = row.get(3).unwrap_or_default();
+                    let preview = if content.chars().count() > 200 {
+                        format!("{}...", content.chars().take(200).collect::<String>())
+                    } else {
+                        content.clone()
+                    };
+                    json!({
+                        "drawer_id": id,
+                        "wing": wing_val,
+                        "room": room_val,
+                        "content_preview": preview,
+                    })
+                })
+                .collect();
+            let count = drawers.len();
+            json!({
+                "drawers": drawers,
+                "count": count,
+                "offset": offset,
+                "limit": limit,
+            })
+        }
+        Err(e) => json!({"error": e.to_string()}),
+    }
+}
+
+async fn tool_update_drawer(conn: &Connection, args: &Value) -> Value {
+    let drawer_id = match sanitize_name(str_arg(args, "drawer_id"), "drawer_id") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+
+    let new_content = {
+        let s = str_arg(args, "content");
+        if s.is_empty() {
+            None
+        } else {
+            match sanitize_content(s) {
+                Ok(v) => Some(v),
+                Err(e) => return e,
+            }
+        }
+    };
+    let new_wing = match sanitize_opt_name(str_arg(args, "wing"), "wing") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let new_room = match sanitize_opt_name(str_arg(args, "room"), "room") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+
+    // No-op: nothing to change
+    if new_content.is_none() && new_wing.is_none() && new_room.is_none() {
+        return json!({"success": true, "drawer_id": drawer_id, "noop": true});
+    }
+
+    // Fetch existing drawer
+    let rows = query_all(
+        conn,
+        "SELECT wing, room, content FROM drawers WHERE id = ?",
+        [drawer_id.as_str()],
+    )
+    .await;
+
+    let rows = match rows {
+        Ok(r) => r,
+        Err(e) => return json!({"success": false, "error": e.to_string()}),
+    };
+
+    if rows.is_empty() {
+        return json!({"success": false, "error": format!("Drawer not found: {drawer_id}"), "public": true});
+    }
+
+    let old_wing: String = rows[0].get(0).unwrap_or_default();
+    let old_room: String = rows[0].get(1).unwrap_or_default();
+    let old_content: String = rows[0].get(2).unwrap_or_default();
+
+    let final_wing = new_wing.as_deref().unwrap_or(&old_wing);
+    let final_room = new_room.as_deref().unwrap_or(&old_room);
+    let final_content = new_content.as_deref().unwrap_or(&old_content);
+
+    wal_log(
+        "update_drawer",
+        json!({
+            "drawer_id": drawer_id,
+            "old_wing": old_wing,
+            "old_room": old_room,
+            "new_wing": final_wing,
+            "new_room": final_room,
+            "content_changed": new_content.is_some(),
+        }),
+    )
+    .await;
+
+    match conn
+        .execute(
+            "UPDATE drawers SET wing = ?1, room = ?2, content = ?3 WHERE id = ?4",
+            turso::params![final_wing, final_room, final_content, drawer_id.as_str()],
+        )
+        .await
+    {
+        Ok(_) => {
+            // Re-index words if content changed
+            if new_content.is_some() {
+                let _ = conn
+                    .execute(
+                        "DELETE FROM drawer_words WHERE drawer_id = ?",
+                        [drawer_id.as_str()],
+                    )
+                    .await;
+                let _ = drawer::index_words(conn, &drawer_id, final_content).await;
+            }
+            json!({
+                "success": true,
+                "drawer_id": drawer_id,
+                "wing": final_wing,
+                "room": final_room,
+            })
+        }
+        Err(e) => json!({"success": false, "error": e.to_string()}),
+    }
+}
+
 async fn tool_kg_query(conn: &Connection, args: &Value) -> Value {
     let entity = match sanitize_name(str_arg(args, "entity"), "entity") {
         Ok(v) => v,
@@ -564,6 +788,9 @@ async fn tool_kg_query(conn: &Connection, args: &Value) -> Value {
         let d = str_arg(args, "direction");
         if d.is_empty() { "both" } else { d }
     };
+    if !matches!(direction, "outgoing" | "incoming" | "both") {
+        return json!({"error": "direction must be 'outgoing', 'incoming', or 'both'", "public": true});
+    }
 
     match kg::query::query_entity(conn, &entity, as_of.as_deref(), direction).await {
         Ok(facts) => {
@@ -720,7 +947,7 @@ async fn tool_traverse(conn: &Connection, args: &Value) -> Value {
         Ok(v) => v,
         Err(e) => return e,
     };
-    let max_hops = usize::try_from(int_arg(args, "max_hops", 2)).unwrap_or(2);
+    let max_hops = usize::try_from(int_arg(args, "max_hops", 2).clamp(1, 10)).unwrap_or(2);
 
     match graph::traverse(conn, &start_room, max_hops).await {
         Ok(results) => json!(results),
@@ -779,14 +1006,13 @@ async fn tool_diary_write(conn: &Connection, args: &Value) -> Value {
     let now = Utc::now();
     let id = Uuid::new_v4().to_string();
 
-    let entry_preview: String = entry.chars().take(200).collect();
     wal_log(
         "diary_write",
         json!({
             "agent_name": agent_name,
             "topic": topic,
             "entry_id": id,
-            "entry_preview": entry_preview,
+            "entry_preview": format!("[REDACTED {} chars]", entry.chars().count()),
         }),
     )
     .await;
@@ -815,7 +1041,7 @@ async fn tool_diary_write(conn: &Connection, args: &Value) -> Value {
 
 async fn tool_diary_read(conn: &Connection, args: &Value) -> Value {
     let agent_name = str_arg(args, "agent_name");
-    let last_n = int_arg(args, "last_n", 10);
+    let last_n = int_arg(args, "last_n", 10).clamp(1, 100);
 
     let agent_name = match sanitize_name(agent_name, "agent_name") {
         Ok(v) => v,

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -611,7 +611,7 @@ async fn tool_list_drawers(conn: &Connection, args: &Value) -> Value {
         (Some(w), Some(r)) => {
             query_all(
                 conn,
-                "SELECT id, content, wing, room FROM drawers WHERE wing = ?1 AND room = ?2 AND ingest_mode != 'diary' ORDER BY filed_at DESC, id DESC LIMIT ?3 OFFSET ?4",
+                "SELECT id, content, wing, room FROM drawers WHERE wing = ?1 AND room = ?2 AND (ingest_mode IS NULL OR ingest_mode != 'diary') ORDER BY filed_at DESC, id DESC LIMIT ?3 OFFSET ?4",
                 (w.as_str(), r.as_str(), limit, offset),
             )
             .await
@@ -619,7 +619,7 @@ async fn tool_list_drawers(conn: &Connection, args: &Value) -> Value {
         (Some(w), None) => {
             query_all(
                 conn,
-                "SELECT id, content, wing, room FROM drawers WHERE wing = ?1 AND ingest_mode != 'diary' ORDER BY filed_at DESC, id DESC LIMIT ?2 OFFSET ?3",
+                "SELECT id, content, wing, room FROM drawers WHERE wing = ?1 AND (ingest_mode IS NULL OR ingest_mode != 'diary') ORDER BY filed_at DESC, id DESC LIMIT ?2 OFFSET ?3",
                 (w.as_str(), limit, offset),
             )
             .await
@@ -627,7 +627,7 @@ async fn tool_list_drawers(conn: &Connection, args: &Value) -> Value {
         (None, Some(r)) => {
             query_all(
                 conn,
-                "SELECT id, content, wing, room FROM drawers WHERE room = ?1 AND ingest_mode != 'diary' ORDER BY filed_at DESC, id DESC LIMIT ?2 OFFSET ?3",
+                "SELECT id, content, wing, room FROM drawers WHERE room = ?1 AND (ingest_mode IS NULL OR ingest_mode != 'diary') ORDER BY filed_at DESC, id DESC LIMIT ?2 OFFSET ?3",
                 (r.as_str(), limit, offset),
             )
             .await
@@ -635,7 +635,7 @@ async fn tool_list_drawers(conn: &Connection, args: &Value) -> Value {
         (None, None) => {
             query_all(
                 conn,
-                "SELECT id, content, wing, room FROM drawers WHERE ingest_mode != 'diary' ORDER BY filed_at DESC, id DESC LIMIT ?1 OFFSET ?2",
+                "SELECT id, content, wing, room FROM drawers WHERE (ingest_mode IS NULL OR ingest_mode != 'diary') ORDER BY filed_at DESC, id DESC LIMIT ?1 OFFSET ?2",
                 (limit, offset),
             )
             .await

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -549,6 +549,7 @@ async fn tool_delete_drawer(conn: &Connection, args: &Value) -> Value {
     }
 }
 
+/// Fetch a single drawer by ID, returning its full content and metadata.
 async fn tool_get_drawer(conn: &Connection, args: &Value) -> Value {
     let drawer_id = match sanitize_name(str_arg(args, "drawer_id"), "drawer_id") {
         Ok(v) => v,
@@ -589,6 +590,7 @@ async fn tool_get_drawer(conn: &Connection, args: &Value) -> Value {
     }
 }
 
+/// List drawers with optional wing/room filtering and cursor-style pagination.
 async fn tool_list_drawers(conn: &Connection, args: &Value) -> Value {
     const MAX_LIMIT: i64 = 100;
     let limit = int_arg(args, "limit", 20).clamp(1, MAX_LIMIT);
@@ -674,6 +676,11 @@ async fn tool_list_drawers(conn: &Connection, args: &Value) -> Value {
     }
 }
 
+/// Update an existing drawer's content and/or location (wing/room).
+///
+/// Recomputes the deterministic SHA256 ID after any change to keep it
+/// consistent with `tool_add_drawer`.  Rejects updates that would collide
+/// with an existing drawer.
 // The complexity comes from: ID recomputation, duplicate detection, conditional
 // reindex, and error propagation — each a distinct correctness concern that
 // cannot be collapsed without obscuring the logic.

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -554,6 +554,9 @@ async fn tool_get_drawer(conn: &Connection, args: &Value) -> Value {
         Ok(v) => v,
         Err(e) => return e,
     };
+    if !drawer_id.starts_with("drawer_") {
+        return json!({"error": "drawer_id has invalid format", "public": true});
+    }
 
     let rows = query_all(
         conn,
@@ -589,11 +592,7 @@ async fn tool_get_drawer(conn: &Connection, args: &Value) -> Value {
 async fn tool_list_drawers(conn: &Connection, args: &Value) -> Value {
     const MAX_LIMIT: i64 = 100;
     let limit = int_arg(args, "limit", 20).clamp(1, MAX_LIMIT);
-    let offset = args
-        .get("offset")
-        .and_then(serde_json::Value::as_i64)
-        .unwrap_or(0)
-        .max(0);
+    let offset = int_arg(args, "offset", 0).max(0);
     let wing = match sanitize_opt_name(str_arg(args, "wing"), "wing") {
         Ok(v) => v,
         Err(e) => return e,
@@ -603,12 +602,14 @@ async fn tool_list_drawers(conn: &Connection, args: &Value) -> Value {
         Err(e) => return e,
     };
 
-    // Build WHERE clause based on filters
+    // Exclude diary entries (ingest_mode = 'diary') — they use UUID IDs, not
+    // the drawer_ prefix scheme, and have their own mempalace_diary_read tool.
+    // Use id DESC as a tiebreaker so pages are stable when filed_at values collide.
     let rows = match (&wing, &room) {
         (Some(w), Some(r)) => {
             query_all(
                 conn,
-                "SELECT id, content, wing, room FROM drawers WHERE wing = ?1 AND room = ?2 ORDER BY filed_at DESC LIMIT ?3 OFFSET ?4",
+                "SELECT id, content, wing, room FROM drawers WHERE wing = ?1 AND room = ?2 AND ingest_mode != 'diary' ORDER BY filed_at DESC, id DESC LIMIT ?3 OFFSET ?4",
                 (w.as_str(), r.as_str(), limit, offset),
             )
             .await
@@ -616,7 +617,7 @@ async fn tool_list_drawers(conn: &Connection, args: &Value) -> Value {
         (Some(w), None) => {
             query_all(
                 conn,
-                "SELECT id, content, wing, room FROM drawers WHERE wing = ?1 ORDER BY filed_at DESC LIMIT ?2 OFFSET ?3",
+                "SELECT id, content, wing, room FROM drawers WHERE wing = ?1 AND ingest_mode != 'diary' ORDER BY filed_at DESC, id DESC LIMIT ?2 OFFSET ?3",
                 (w.as_str(), limit, offset),
             )
             .await
@@ -624,7 +625,7 @@ async fn tool_list_drawers(conn: &Connection, args: &Value) -> Value {
         (None, Some(r)) => {
             query_all(
                 conn,
-                "SELECT id, content, wing, room FROM drawers WHERE room = ?1 ORDER BY filed_at DESC LIMIT ?2 OFFSET ?3",
+                "SELECT id, content, wing, room FROM drawers WHERE room = ?1 AND ingest_mode != 'diary' ORDER BY filed_at DESC, id DESC LIMIT ?2 OFFSET ?3",
                 (r.as_str(), limit, offset),
             )
             .await
@@ -632,7 +633,7 @@ async fn tool_list_drawers(conn: &Connection, args: &Value) -> Value {
         (None, None) => {
             query_all(
                 conn,
-                "SELECT id, content, wing, room FROM drawers ORDER BY filed_at DESC LIMIT ?1 OFFSET ?2",
+                "SELECT id, content, wing, room FROM drawers WHERE ingest_mode != 'diary' ORDER BY filed_at DESC, id DESC LIMIT ?1 OFFSET ?2",
                 (limit, offset),
             )
             .await
@@ -673,11 +674,19 @@ async fn tool_list_drawers(conn: &Connection, args: &Value) -> Value {
     }
 }
 
+// The complexity comes from: ID recomputation, duplicate detection, conditional
+// reindex, and error propagation — each a distinct correctness concern that
+// cannot be collapsed without obscuring the logic.
+#[allow(clippy::too_many_lines)]
 async fn tool_update_drawer(conn: &Connection, args: &Value) -> Value {
     let drawer_id = match sanitize_name(str_arg(args, "drawer_id"), "drawer_id") {
         Ok(v) => v,
         Err(e) => return e,
     };
+    // Diary entries use UUID IDs; they must not be mutated via this handler.
+    if !drawer_id.starts_with("drawer_") {
+        return json!({"success": false, "error": "drawer_id has invalid format", "public": true});
+    }
 
     let new_content = {
         let s = str_arg(args, "content");
@@ -729,10 +738,23 @@ async fn tool_update_drawer(conn: &Connection, args: &Value) -> Value {
     let final_room = new_room.as_deref().unwrap_or(&old_room);
     let final_content = new_content.as_deref().unwrap_or(&old_content);
 
+    // Recompute the deterministic ID to keep it consistent with tool_add_drawer.
+    // wing/room/content are all baked into the ID, so any change means a new ID.
+    let hash = sha2::Sha256::digest(
+        format!("{final_wing}\u{1f}{final_room}\u{1f}{final_content}").as_bytes(),
+    );
+    let hex: String = hash.iter().fold(String::new(), |mut s, b| {
+        use std::fmt::Write as _;
+        let _ = write!(s, "{b:02x}");
+        s
+    });
+    let new_id = format!("drawer_{final_wing}_{final_room}_{}", &hex[..24]);
+
     wal_log(
         "update_drawer",
         json!({
             "drawer_id": drawer_id,
+            "new_drawer_id": new_id,
             "old_wing": old_wing,
             "old_room": old_room,
             "new_wing": final_wing,
@@ -742,27 +764,70 @@ async fn tool_update_drawer(conn: &Connection, args: &Value) -> Value {
     )
     .await;
 
+    // If the recomputed ID already exists (and differs), the new wing+room+content
+    // is a duplicate of another drawer — reject to prevent silent duplication.
+    if new_id != drawer_id {
+        let existing = query_all(
+            conn,
+            "SELECT id FROM drawers WHERE id = ?",
+            [new_id.as_str()],
+        )
+        .await;
+        match existing {
+            Ok(rows) if !rows.is_empty() => {
+                return json!({
+                    "success": false,
+                    "error": "A drawer with this wing/room/content already exists",
+                    "existing_drawer_id": new_id,
+                    "public": true,
+                });
+            }
+            Err(e) => return json!({"success": false, "error": e.to_string()}),
+            Ok(_) => {}
+        }
+    }
+
     match conn
         .execute(
-            "UPDATE drawers SET wing = ?1, room = ?2, content = ?3 WHERE id = ?4",
-            turso::params![final_wing, final_room, final_content, drawer_id.as_str()],
+            "UPDATE drawers SET id = ?1, wing = ?2, room = ?3, content = ?4 WHERE id = ?5",
+            turso::params![
+                new_id.as_str(),
+                final_wing,
+                final_room,
+                final_content,
+                drawer_id.as_str()
+            ],
         )
         .await
     {
         Ok(_) => {
-            // Re-index words if content changed
-            if new_content.is_some() {
+            // Re-index words: always needed when the ID changes or content changes.
+            if let Err(e) = conn
+                .execute(
+                    "DELETE FROM drawer_words WHERE drawer_id = ?",
+                    [drawer_id.as_str()],
+                )
+                .await
+            {
+                return json!({"success": false, "error": e.to_string()});
+            }
+            if new_id != drawer_id {
+                // drawer_words rows for the old ID were deleted above; if the new
+                // ID already had entries (shouldn't happen — we checked above),
+                // clean those too.
                 let _ = conn
                     .execute(
                         "DELETE FROM drawer_words WHERE drawer_id = ?",
-                        [drawer_id.as_str()],
+                        [new_id.as_str()],
                     )
                     .await;
-                let _ = drawer::index_words(conn, &drawer_id, final_content).await;
+            }
+            if let Err(e) = drawer::index_words(conn, &new_id, final_content).await {
+                return json!({"success": false, "error": e.to_string()});
             }
             json!({
                 "success": true,
-                "drawer_id": drawer_id,
+                "drawer_id": new_id,
                 "wing": final_wing,
                 "room": final_room,
             })


### PR DESCRIPTION
## Summary

- New MCP tools: `mempalace_get_drawer`, `mempalace_list_drawers`, `mempalace_update_drawer` — full read/list/update CRUD on individual drawers
- Security: clamp `limit` [1,100], `max_hops` [1,10], `last_n` [1,100] to bound unbounded queries
- Security: validate `direction` in `mempalace_kg_query`; redact `content_preview`/`entry_preview` in WAL log entries
- Protocol: handle `ping` method correctly; treat all `notifications/*` methods as no-ops
- CLI: expand `~` in `split` directory argument

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three drawer-management tools: fetch drawer, list drawers with filters/pagination, and update drawer details.
  * CLI now expands tilde (~) in path arguments.

* **Improvements**
  * Notification handling: explicit ping and prefix-based no-response notifications.
  * Stricter input bounds and validation for various operations.
  * WAL logging now redacts content by character count.

* **Documentation**
  * Updated docs and branding to show 22 available tools and repository rename.

* **Chores**
  * Updated tracked subproject reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->