### PR TITLE
Resync with mempalace-py @ 4aa7e1e

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "mempalace-py"]
 	path = mempalace-py
 	url = https://github.com/MemPalace/mempalace.git
+	branch = main

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ cp target/release/mempalace ~/.local/bin/mempalace
 claude mcp add mempalace -- /path/to/mempalace mcp
 ```
 
-The MCP server runs as a JSON-RPC 2.0 process over stdio. All 22 tools are available immediately
+The MCP server runs as a JSON-RPC 2.0 process over stdio. All 26 tools are available immediately
 after the server starts.
 
 On first use, call `mempalace_status` — it returns the full memory protocol and AAAK dialect spec
@@ -304,7 +304,7 @@ Traits: direct, memory-first, no summaries.
 
 ---
 
-## MCP Tools (22)
+## MCP Tools (26)
 
 All tools communicate over JSON-RPC 2.0. Invoke them from the AI side via the MCP protocol.
 
@@ -351,8 +351,20 @@ Invalidation preserves the old fact with a `valid_to` date rather than deleting 
 | `mempalace_find_tunnels` | `wing_a?`, `wing_b?`      | Rooms that bridge two wings                  |
 | `mempalace_graph_stats`  | —                         | Total rooms, tunnel count, edges             |
 
-Tunnels are rooms that appear in more than one wing — they are automatic cross-wing connections,
-no configuration needed.
+Auto-tunnels are rooms that appear in more than one wing — discovered automatically, no configuration needed.
+
+### Explicit Tunnels
+
+| Tool                       | Parameters                                                                                                     | What it does                                           |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| `mempalace_create_tunnel`  | `source_wing`, `source_room`, `target_wing`, `target_room`, `label?`, `source_drawer_id?`, `target_drawer_id?` | Create a named cross-wing link between two rooms       |
+| `mempalace_list_tunnels`   | `wing?`                                                                                                        | List all explicit tunnels, optionally filtered by wing |
+| `mempalace_delete_tunnel`  | `tunnel_id`                                                                                                    | Delete an explicit tunnel by its ID                    |
+| `mempalace_follow_tunnels` | `wing`, `room`                                                                                                 | See what a room connects to via explicit tunnels       |
+
+Explicit tunnels are agent-created cross-wing links stored in the database. Use them when content in
+one project relates to another (e.g. an API design in `project_api` connects to a schema in
+`project_database`). Tunnels are symmetric — A→B and B→A share the same ID.
 
 ### Agent Diary
 
@@ -369,13 +381,14 @@ Diary entries live in `wing_{agent_name}/diary`. Use AAAK format for compact ent
 
 Single SQLite file at `~/.mempalace/palace.db`:
 
-| Table          | Purpose                                                                                        |
-| -------------- | ---------------------------------------------------------------------------------------------- |
-| `drawers`      | Content chunks: wing, room, content, source_file, chunk_index, added_by, ingest_mode, filed_at |
-| `drawer_words` | Inverted index: word → drawer_id → count                                                       |
-| `entities`     | Knowledge graph nodes: name, type, properties (JSON)                                           |
-| `triples`      | Knowledge graph edges: subject, predicate, object, valid_from, valid_to, confidence            |
-| `compressed`   | AAAK-compressed drawer versions                                                                |
+| Table              | Purpose                                                                                        |
+| ------------------ | ---------------------------------------------------------------------------------------------- |
+| `drawers`          | Content chunks: wing, room, content, source_file, chunk_index, added_by, ingest_mode, filed_at |
+| `drawer_words`     | Inverted index: word → drawer_id → count                                                       |
+| `entities`         | Knowledge graph nodes: name, type, properties (JSON)                                           |
+| `triples`          | Knowledge graph edges: subject, predicate, object, valid_from, valid_to, confidence            |
+| `compressed`       | AAAK-compressed drawer versions                                                                |
+| `explicit_tunnels` | Agent-created cross-wing links: source/target wing+room, label, canonical SHA256 tunnel_id     |
 
 ---
 
@@ -385,7 +398,7 @@ Single SQLite file at `~/.mempalace/palace.db`:
 src/
   main.rs              Entry point: clap dispatch → open_palace() → handler
   db.rs                open_db(), query_all() helpers over turso::Connection
-  schema.rs            DDL: 5 tables + indexes, ensure_schema()
+  schema.rs            DDL: 6 tables + indexes, ensure_schema()
   config.rs            MempalaceConfig (~/.mempalace/config.json) + ProjectConfig (mempalace.yaml)
   error.rs             thiserror Error enum
 
@@ -408,14 +421,14 @@ src/
     query_sanitizer.rs 4-step sanitizer: strip system-prompt contamination from search queries
     entity_detect.rs   Person vs project heuristic classifier
     layers.rs          L0 identity + L1 essential story assembly
-    graph.rs           BFS traversal, tunnel detection
+    graph.rs           BFS traversal, auto-tunnel detection, explicit tunnel CRUD
 
   kg/
     mod.rs             Entity + triple CRUD
     query.rs           query_entity(), kg_timeline()
 
   normalize/           Chat export parsers → canonical transcript text
-    claude_code.rs     JSONL (Claude Code); accepts both "human" and "user" types
+    claude_code.rs     JSONL (Claude Code); strip_noise() removes UI chrome / system-reminder tags
     claude_ai.rs       JSON array (Claude.ai) + privacy export format
     codex.rs           JSONL (OpenAI Codex CLI)
     chatgpt.rs         ChatGPT export JSON
@@ -432,8 +445,8 @@ src/
 
   mcp/
     mod.rs             Async stdio JSON-RPC 2.0 event loop
-    protocol.rs        PALACE_PROTOCOL, AAAK_SPEC, 22 tool schemas
-    tools.rs           Tool dispatch + all 22 handler implementations
+    protocol.rs        PALACE_PROTOCOL, AAAK_SPEC, 26 tool schemas
+    tools.rs           Tool dispatch + all 26 handler implementations
 ```
 
 ---

--- a/src/mcp/protocol.rs
+++ b/src/mcp/protocol.rs
@@ -72,8 +72,8 @@ pub fn tool_definitions() -> Vec<serde_json::Value> {
                 "properties": {
                     "query": {
                         "type": "string",
-                        "description": "Short search query ONLY — keywords or a question. Do NOT include system prompts or conversation context. Max 200 chars recommended.",
-                        "maxLength": 500
+                        "description": "Short search query ONLY — keywords or a question. Max 250 chars.",
+                        "maxLength": 250
                     },
                     "limit": {"type": "integer", "description": "Max results (default 5)"},
                     "wing": {"type": "string", "description": "Filter by wing (optional)"},
@@ -278,6 +278,56 @@ pub fn tool_definitions() -> Vec<serde_json::Value> {
                     "last_n": {"type": "integer", "description": "Number of recent entries to read (default: 10)"}
                 },
                 "required": ["agent_name"]
+            }
+        },
+        {
+            "name": "mempalace_create_tunnel",
+            "description": "Create an explicit cross-wing tunnel between two palace locations. Use when content in one project relates to another — e.g., an API design in project_api connects to a database schema in project_database.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "source_wing": {"type": "string", "description": "Wing of the source location"},
+                    "source_room": {"type": "string", "description": "Room in the source wing"},
+                    "target_wing": {"type": "string", "description": "Wing of the target location"},
+                    "target_room": {"type": "string", "description": "Room in the target wing"},
+                    "label": {"type": "string", "description": "Description of the connection (optional)"},
+                    "source_drawer_id": {"type": "string", "description": "Optional specific source drawer ID"},
+                    "target_drawer_id": {"type": "string", "description": "Optional specific target drawer ID"}
+                },
+                "required": ["source_wing", "source_room", "target_wing", "target_room"]
+            }
+        },
+        {
+            "name": "mempalace_list_tunnels",
+            "description": "List all explicit cross-wing tunnels. Optionally filter by wing.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "wing": {"type": "string", "description": "Filter to tunnels involving this wing (optional)"}
+                }
+            }
+        },
+        {
+            "name": "mempalace_delete_tunnel",
+            "description": "Delete an explicit tunnel by its ID.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "tunnel_id": {"type": "string", "description": "Tunnel ID to delete"}
+                },
+                "required": ["tunnel_id"]
+            }
+        },
+        {
+            "name": "mempalace_follow_tunnels",
+            "description": "Follow explicit tunnels from a room to see what it connects to in other wings.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "wing": {"type": "string", "description": "Wing to start from"},
+                    "room": {"type": "string", "description": "Room to follow tunnels from"}
+                },
+                "required": ["wing", "room"]
             }
         }
     ]).as_array()

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1202,7 +1202,23 @@ async fn tool_create_tunnel(connection: &Connection, args: &Value) -> Value {
     )
     .await
     {
-        Ok(tunnel) => json!(tunnel),
+        Ok(tunnel) => {
+            wal_log(
+                "create_tunnel",
+                json!({
+                    "tunnel_id": tunnel.id,
+                    "source_wing": tunnel.source_wing,
+                    "source_room": tunnel.source_room,
+                    "target_wing": tunnel.target_wing,
+                    "target_room": tunnel.target_room,
+                    "label": tunnel.label,
+                    "source_drawer_id": tunnel.source_drawer_id,
+                    "target_drawer_id": tunnel.target_drawer_id,
+                }),
+            )
+            .await;
+            json!(tunnel)
+        }
         Err(e) => json!({"error": e.to_string()}),
     }
 }
@@ -1230,6 +1246,8 @@ async fn tool_delete_tunnel(connection: &Connection, args: &Value) -> Value {
     if tunnel_id.len() != TUNNEL_ID_LEN || !tunnel_id.chars().all(|c| c.is_ascii_hexdigit()) {
         return json!({"error": "tunnel_id must be a 16-character hex string", "public": true});
     }
+
+    wal_log("delete_tunnel", json!({"tunnel_id": tunnel_id})).await;
 
     match graph::delete_tunnel(connection, tunnel_id).await {
         Ok(deleted) => json!({"deleted": deleted, "tunnel_id": tunnel_id}),

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -23,6 +23,10 @@ const MAX_EXACT_INT_F64: f64 = 9_007_199_254_740_991.0;
 /// index rows.  255 characters is generous for a short descriptive label.
 const MAX_LABEL_LEN: usize = 255;
 
+/// Exact character length of a tunnel ID.  Tunnel IDs are the first 16 hex
+/// characters of a SHA256 digest (see `canonical_tunnel_id` in graph.rs).
+const TUNNEL_ID_LEN: usize = 16;
+
 /// Dispatch a tool call by name and return the JSON result.
 pub async fn dispatch(connection: &Connection, name: &str, args: &Value) -> Value {
     // Empty name and non-object args can arrive from untrusted MCP clients;
@@ -1147,14 +1151,16 @@ async fn tool_create_tunnel(connection: &Connection, args: &Value) -> Value {
         }
         v
     };
-    let source_drawer_id = {
-        let v = str_arg(args, "source_drawer_id");
-        if v.is_empty() { None } else { Some(v) }
-    };
-    let target_drawer_id = {
-        let v = str_arg(args, "target_drawer_id");
-        if v.is_empty() { None } else { Some(v) }
-    };
+    let source_drawer_id =
+        match sanitize_opt_name(str_arg(args, "source_drawer_id"), "source_drawer_id") {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+    let target_drawer_id =
+        match sanitize_opt_name(str_arg(args, "target_drawer_id"), "target_drawer_id") {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
 
     match graph::create_tunnel(
         connection,
@@ -1164,8 +1170,8 @@ async fn tool_create_tunnel(connection: &Connection, args: &Value) -> Value {
             target_wing: &target_wing,
             target_room: &target_room,
             label,
-            source_drawer_id,
-            target_drawer_id,
+            source_drawer_id: source_drawer_id.as_deref(),
+            target_drawer_id: target_drawer_id.as_deref(),
         },
     )
     .await
@@ -1188,9 +1194,15 @@ async fn tool_list_tunnels(connection: &Connection, args: &Value) -> Value {
 }
 
 async fn tool_delete_tunnel(connection: &Connection, args: &Value) -> Value {
-    let tunnel_id = str_arg(args, "tunnel_id");
+    // Trim before validation to avoid spurious failures from surrounding whitespace.
+    let tunnel_id = str_arg(args, "tunnel_id").trim();
     if tunnel_id.is_empty() {
         return json!({"error": "tunnel_id is required", "public": true});
+    }
+    // Tunnel IDs are the first 16 hex characters of a SHA256 digest — validate
+    // the exact format so arbitrary strings are never passed to the database.
+    if tunnel_id.len() != TUNNEL_ID_LEN || !tunnel_id.chars().all(|c| c.is_ascii_hexdigit()) {
+        return json!({"error": "tunnel_id must be a 16-character hex string", "public": true});
     }
 
     match graph::delete_tunnel(connection, tunnel_id).await {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -18,6 +18,11 @@ use super::protocol::{AAAK_SPEC, PALACE_PROTOCOL};
 /// Values above this lose precision when stored in f64, so we reject them.
 const MAX_EXACT_INT_F64: f64 = 9_007_199_254_740_991.0;
 
+/// Maximum byte length for a tunnel label.  Labels are free-form strings stored
+/// in `SQLite`; without a cap an unbounded value could waste DB space or overflow
+/// index rows.  255 characters is generous for a short descriptive label.
+const MAX_LABEL_LEN: usize = 255;
+
 /// Dispatch a tool call by name and return the JSON result.
 pub async fn dispatch(connection: &Connection, name: &str, args: &Value) -> Value {
     // Empty name and non-object args can arrive from untrusted MCP clients;
@@ -1135,7 +1140,13 @@ async fn tool_create_tunnel(connection: &Connection, args: &Value) -> Value {
         Ok(v) => v,
         Err(e) => return e,
     };
-    let label = str_arg(args, "label");
+    let label = {
+        let v = str_arg(args, "label");
+        if v.len() > MAX_LABEL_LEN {
+            return json!({"success": false, "error": format!("label exceeds maximum length of {MAX_LABEL_LEN} characters"), "public": true});
+        }
+        v
+    };
     let source_drawer_id = {
         let v = str_arg(args, "source_drawer_id");
         if v.is_empty() { None } else { Some(v) }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -181,6 +181,35 @@ fn sanitize_opt_name(value: &str, field_name: &str) -> Result<Option<String>, Va
     sanitize_name(value, field_name).map(Some)
 }
 
+/// Validate tunnel label: trim, non-empty, reject null bytes and length violations.
+fn sanitize_label(value: &str) -> Result<String, Value> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(
+            json!({"success": false, "error": "label must be a non-empty string", "public": true}),
+        );
+    }
+    if trimmed.len() > MAX_LABEL_LEN {
+        return Err(
+            json!({"success": false, "error": format!("label exceeds maximum length of {MAX_LABEL_LEN} characters"), "public": true}),
+        );
+    }
+    if trimmed.contains('\0') {
+        return Err(
+            json!({"success": false, "error": "label contains null bytes", "public": true}),
+        );
+    }
+    let result = trimmed.to_string();
+
+    // Postconditions: result is non-empty, trimmed, and safe.
+    debug_assert!(!result.is_empty());
+    debug_assert!(result == result.trim());
+    debug_assert!(!result.contains('\0'));
+    debug_assert!(result.len() <= MAX_LABEL_LEN);
+
+    Ok(result)
+}
+
 /// Validate drawer/diary content.  Returns `Ok(trimmed)` if valid, or `Err(error_json)` if not.
 fn sanitize_content(value: &str) -> Result<String, Value> {
     let trimmed = value.trim();
@@ -1144,12 +1173,9 @@ async fn tool_create_tunnel(connection: &Connection, args: &Value) -> Value {
         Ok(v) => v,
         Err(e) => return e,
     };
-    let label = {
-        let v = str_arg(args, "label");
-        if v.len() > MAX_LABEL_LEN {
-            return json!({"success": false, "error": format!("label exceeds maximum length of {MAX_LABEL_LEN} characters"), "public": true});
-        }
-        v
+    let label = match sanitize_label(str_arg(args, "label")) {
+        Ok(v) => v,
+        Err(e) => return e,
     };
     let source_drawer_id =
         match sanitize_opt_name(str_arg(args, "source_drawer_id"), "source_drawer_id") {
@@ -1169,7 +1195,7 @@ async fn tool_create_tunnel(connection: &Connection, args: &Value) -> Value {
             source_room: &source_room,
             target_wing: &target_wing,
             target_room: &target_room,
-            label,
+            label: &label,
             source_drawer_id: source_drawer_id.as_deref(),
             target_drawer_id: target_drawer_id.as_deref(),
         },

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -50,6 +50,10 @@ pub async fn dispatch(connection: &Connection, name: &str, args: &Value) -> Valu
         "mempalace_traverse" => tool_traverse(connection, args).await,
         "mempalace_find_tunnels" => tool_find_tunnels(connection, args).await,
         "mempalace_graph_stats" => tool_graph_stats(connection).await,
+        "mempalace_create_tunnel" => tool_create_tunnel(connection, args).await,
+        "mempalace_list_tunnels" => tool_list_tunnels(connection, args).await,
+        "mempalace_delete_tunnel" => tool_delete_tunnel(connection, args).await,
+        "mempalace_follow_tunnels" => tool_follow_tunnels(connection, args).await,
         "mempalace_diary_write" => tool_diary_write(connection, args).await,
         "mempalace_diary_read" => tool_diary_read(connection, args).await,
         _ => json!({"error": format!("Unknown tool: {name}"), "public": true}),
@@ -1110,6 +1114,92 @@ async fn tool_find_tunnels(connection: &Connection, args: &Value) -> Value {
 async fn tool_graph_stats(connection: &Connection) -> Value {
     match graph::graph_stats(connection).await {
         Ok(stats) => json!(stats),
+        Err(e) => json!({"error": e.to_string()}),
+    }
+}
+
+async fn tool_create_tunnel(connection: &Connection, args: &Value) -> Value {
+    let source_wing = match sanitize_name(str_arg(args, "source_wing"), "source_wing") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let source_room = match sanitize_name(str_arg(args, "source_room"), "source_room") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let target_wing = match sanitize_name(str_arg(args, "target_wing"), "target_wing") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let target_room = match sanitize_name(str_arg(args, "target_room"), "target_room") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let label = str_arg(args, "label");
+    let source_drawer_id = {
+        let v = str_arg(args, "source_drawer_id");
+        if v.is_empty() { None } else { Some(v) }
+    };
+    let target_drawer_id = {
+        let v = str_arg(args, "target_drawer_id");
+        if v.is_empty() { None } else { Some(v) }
+    };
+
+    match graph::create_tunnel(
+        connection,
+        &graph::CreateTunnelParams {
+            source_wing: &source_wing,
+            source_room: &source_room,
+            target_wing: &target_wing,
+            target_room: &target_room,
+            label,
+            source_drawer_id,
+            target_drawer_id,
+        },
+    )
+    .await
+    {
+        Ok(tunnel) => json!(tunnel),
+        Err(e) => json!({"error": e.to_string()}),
+    }
+}
+
+async fn tool_list_tunnels(connection: &Connection, args: &Value) -> Value {
+    let wing = match sanitize_opt_name(str_arg(args, "wing"), "wing") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+
+    match graph::list_tunnels(connection, wing.as_deref()).await {
+        Ok(tunnels) => json!({"tunnels": tunnels, "count": tunnels.len()}),
+        Err(e) => json!({"error": e.to_string()}),
+    }
+}
+
+async fn tool_delete_tunnel(connection: &Connection, args: &Value) -> Value {
+    let tunnel_id = str_arg(args, "tunnel_id");
+    if tunnel_id.is_empty() {
+        return json!({"error": "tunnel_id is required", "public": true});
+    }
+
+    match graph::delete_tunnel(connection, tunnel_id).await {
+        Ok(deleted) => json!({"deleted": deleted, "tunnel_id": tunnel_id}),
+        Err(e) => json!({"error": e.to_string()}),
+    }
+}
+
+async fn tool_follow_tunnels(connection: &Connection, args: &Value) -> Value {
+    let wing = match sanitize_name(str_arg(args, "wing"), "wing") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let room = match sanitize_name(str_arg(args, "room"), "room") {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+
+    match graph::follow_tunnels(connection, &wing, &room).await {
+        Ok(connections) => json!({"wing": wing, "room": room, "connections": connections}),
         Err(e) => json!({"error": e.to_string()}),
     }
 }

--- a/src/normalize/claude_ai.rs
+++ b/src/normalize/claude_ai.rs
@@ -15,7 +15,9 @@ use super::messages_to_transcript;
 /// export uses `"sender"` while the API format uses `"role"`).  A top-level
 /// `"text"` key is used as fallback when `"content"` is absent or empty.
 ///
-/// Returns `None` if fewer than 2 messages are found across all conversations.
+/// Returns `None` if no conversation yields at least 2 messages (the threshold
+/// is per conversation — a conversation with fewer than 2 messages is silently
+/// dropped; if all conversations are dropped the result is `None`).
 pub fn try_parse(data: &serde_json::Value) -> Option<String> {
     if let Some(arr) = data.as_array() {
         // Privacy export: array of conversation objects, each with a chat_messages

--- a/src/normalize/claude_ai.rs
+++ b/src/normalize/claude_ai.rs
@@ -8,42 +8,94 @@ use super::messages_to_transcript;
 /// - JSON array of message objects (`[{"role":…,"content":…}]`)
 /// - Object with a `"messages"` or `"chat_messages"` key
 /// - Privacy export: top-level array of conversation objects where each object
-///   has a `"chat_messages"` key — all conversations are flattened into one transcript
+///   has a `"chat_messages"` or `"messages"` key — each conversation becomes
+///   its own transcript, joined by blank lines (preserves conversation boundaries)
 ///
-/// Returns `None` if fewer than 2 messages are found.
+/// Both `"role"` and `"sender"` are accepted as the author field (the privacy
+/// export uses `"sender"` while the API format uses `"role"`).  A top-level
+/// `"text"` key is used as fallback when `"content"` is absent or empty.
+///
+/// Returns `None` if fewer than 2 messages are found across all conversations.
 pub fn try_parse(data: &serde_json::Value) -> Option<String> {
-    let items = if let Some(arr) = data.as_array() {
-        // Privacy export: array of conversation objects, each with a chat_messages key.
-        // Only treat as privacy export if ALL elements contain "chat_messages" to avoid
-        // misclassifying mixed arrays with some having chat_messages and others not.
-        if arr
-            .iter()
-            .all(|v| v.get("chat_messages").and_then(|m| m.as_array()).is_some())
-        {
-            arr.iter()
-                .filter_map(|conv| conv.get("chat_messages").and_then(|v| v.as_array()))
-                .flatten()
-                .cloned()
-                .collect()
-        } else {
-            arr.clone()
-        }
-    } else if let Some(obj) = data.as_object() {
-        obj.get("messages")
-            .or_else(|| obj.get("chat_messages"))
-            .and_then(|v| v.as_array())
-            .cloned()?
-    } else {
-        return None;
-    };
+    if let Some(arr) = data.as_array() {
+        // Privacy export: array of conversation objects, each with a chat_messages
+        // or messages key.  Only treat as privacy export if the first element looks
+        // like a conversation object (has chat_messages or messages) to avoid
+        // misclassifying a plain flat message array.
+        let first_is_convo = arr.first().is_some_and(|v| {
+            v.get("chat_messages")
+                .or_else(|| v.get("messages"))
+                .and_then(|m| m.as_array())
+                .is_some()
+        });
 
+        if first_is_convo {
+            // Process each conversation separately; join transcripts with blank lines.
+            let transcripts: Vec<String> = arr
+                .iter()
+                .filter_map(|conv| {
+                    let msgs = conv
+                        .get("chat_messages")
+                        .or_else(|| conv.get("messages"))
+                        .and_then(|v| v.as_array())?;
+                    collect_messages(msgs)
+                })
+                .collect();
+
+            return if transcripts.is_empty() {
+                None
+            } else {
+                Some(transcripts.join("\n\n"))
+            };
+        }
+
+        // Flat array of message objects.
+        collect_messages(arr)
+    } else if let Some(obj) = data.as_object() {
+        let items = obj
+            .get("messages")
+            .or_else(|| obj.get("chat_messages"))
+            .and_then(|v| v.as_array())?;
+        collect_messages(items)
+    } else {
+        None
+    }
+}
+
+/// Extract (role, text) pairs from a message list and return a transcript.
+///
+/// Accepts both `"role"` (API format) and `"sender"` (privacy export) as the
+/// author field, and falls back to a top-level `"text"` key when `"content"`
+/// blocks are absent or empty.  Returns `None` if fewer than 2 messages found.
+fn collect_messages(items: &[serde_json::Value]) -> Option<String> {
     let mut messages: Vec<(String, String)> = Vec::new();
 
-    for item in &items {
-        let obj = item.as_object()?;
-        let role = obj.get("role")?.as_str()?;
-        let content = obj.get("content")?;
-        let text = extract_content(content);
+    for item in items {
+        let Some(obj) = item.as_object() else {
+            continue;
+        };
+
+        // Accept "role" (API) or "sender" (privacy export).
+        let role = obj
+            .get("role")
+            .or_else(|| obj.get("sender"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+
+        // Primary: content blocks. Fallback: top-level "text" key.
+        let text = {
+            let from_content = obj.get("content").map(extract_content).unwrap_or_default();
+            if from_content.is_empty() {
+                obj.get("text")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .trim()
+                    .to_string()
+            } else {
+                from_content
+            }
+        };
+
         if text.is_empty() {
             continue;
         }
@@ -151,5 +203,65 @@ mod tests {
         let data: serde_json::Value =
             serde_json::from_str(r#"{"something":"else"}"#).expect("valid json");
         assert!(try_parse(&data).is_none());
+    }
+
+    #[test]
+    fn parse_privacy_export_with_sender_field() {
+        // Privacy exports use "sender" instead of "role".
+        let data: serde_json::Value = serde_json::from_str(
+            r#"[{"chat_messages":[{"sender":"human","content":"question"},{"sender":"assistant","content":"answer_42"}]}]"#,
+        )
+        .expect("valid json");
+        let result = try_parse(&data).expect("should parse");
+        assert!(result.contains("> question"), "user turn preserved");
+        assert!(result.contains("answer_42"), "assistant turn preserved");
+    }
+
+    #[test]
+    fn parse_with_top_level_text_fallback() {
+        // Some export variants have a top-level "text" key instead of "content".
+        let data: serde_json::Value = serde_json::from_str(
+            r#"[{"role":"user","text":"fallback question"},{"role":"assistant","text":"fallback_answer"}]"#,
+        )
+        .expect("valid json");
+        let result = try_parse(&data).expect("should parse with text fallback");
+        assert!(
+            result.contains("> fallback question"),
+            "user turn from text key"
+        );
+        assert!(
+            result.contains("fallback_answer"),
+            "assistant turn from text key"
+        );
+    }
+
+    #[test]
+    fn parse_privacy_export_each_convo_separate() {
+        // Each conversation must produce a separate transcript block joined by \n\n.
+        let data: serde_json::Value = serde_json::from_str(
+            r#"[
+                {"chat_messages":[{"role":"user","content":"convo1_q"},{"role":"assistant","content":"convo1_a"}]},
+                {"chat_messages":[{"role":"user","content":"convo2_q"},{"role":"assistant","content":"convo2_a"}]}
+            ]"#,
+        )
+        .expect("valid json");
+        let result = try_parse(&data).expect("should parse");
+        // Both conversations present.
+        assert!(result.contains("convo1_q"), "first convo user turn");
+        assert!(result.contains("convo1_a"), "first convo assistant turn");
+        assert!(result.contains("convo2_q"), "second convo user turn");
+        assert!(result.contains("convo2_a"), "second convo assistant turn");
+    }
+
+    #[test]
+    fn parse_privacy_export_messages_key_variant() {
+        // Some privacy exports use "messages" instead of "chat_messages".
+        let data: serde_json::Value = serde_json::from_str(
+            r#"[{"messages":[{"role":"user","content":"hi"},{"role":"assistant","content":"hello"}]}]"#,
+        )
+        .expect("valid json");
+        let result = try_parse(&data).expect("should parse messages key variant");
+        assert!(result.contains("> hi"), "user turn");
+        assert!(result.contains("hello"), "assistant turn");
     }
 }

--- a/src/normalize/claude_code.rs
+++ b/src/normalize/claude_code.rs
@@ -1,5 +1,6 @@
 //! Parser for Claude Code JSONL conversation exports.
 
+use std::borrow::Cow;
 use std::sync::LazyLock;
 
 use regex::Regex;
@@ -103,20 +104,43 @@ static EXCESS_BLANK_RE: LazyLock<Regex> = LazyLock::new(|| {
 /// Applied per message (never across boundaries) so a dangling open tag
 /// in one message cannot consume text from the next.
 pub fn strip_noise(text: &str) -> String {
-    assert!(!text.is_empty(), "strip_noise: text must not be empty");
+    // Early return: empty input needs no processing.
+    if text.is_empty() {
+        return String::new();
+    }
 
-    let mut result = text.to_owned();
+    // Use Cow to avoid allocating a new String per regex when nothing matches.
+    // replace_all returns Cow::Borrowed (no copy) when the pattern is absent.
+    let mut result: Cow<str> = Cow::Borrowed(text);
     for re in NOISE_TAG_RES.iter() {
-        result = re.replace_all(&result, "").into_owned();
+        let replaced = re.replace_all(result.as_ref(), "");
+        if let Cow::Owned(s) = replaced {
+            result = Cow::Owned(s);
+        }
     }
     for re in NOISE_LINE_RES.iter() {
-        result = re.replace_all(&result, "").into_owned();
+        let replaced = re.replace_all(result.as_ref(), "");
+        if let Cow::Owned(s) = replaced {
+            result = Cow::Owned(s);
+        }
     }
-    result = HOOK_LINE_RE.replace_all(&result, "").into_owned();
-    result = COLLAPSED_LINES_RE.replace_all(&result, "").into_owned();
-    result = TOKEN_MARKER_RE.replace_all(&result, "").into_owned();
+    let replaced = HOOK_LINE_RE.replace_all(result.as_ref(), "");
+    if let Cow::Owned(s) = replaced {
+        result = Cow::Owned(s);
+    }
+    let replaced = COLLAPSED_LINES_RE.replace_all(result.as_ref(), "");
+    if let Cow::Owned(s) = replaced {
+        result = Cow::Owned(s);
+    }
+    let replaced = TOKEN_MARKER_RE.replace_all(result.as_ref(), "");
+    if let Cow::Owned(s) = replaced {
+        result = Cow::Owned(s);
+    }
     // Collapse runs of 4+ blank lines down to 3 (a visual paragraph break).
-    result = EXCESS_BLANK_RE.replace_all(&result, "\n\n\n").into_owned();
+    let replaced = EXCESS_BLANK_RE.replace_all(result.as_ref(), "\n\n\n");
+    if let Cow::Owned(s) = replaced {
+        result = Cow::Owned(s);
+    }
 
     // Postcondition: result is trimmed (no leading/trailing whitespace).
     result.trim().to_string()

--- a/src/normalize/claude_code.rs
+++ b/src/normalize/claude_code.rs
@@ -1,6 +1,126 @@
 //! Parser for Claude Code JSONL conversation exports.
 
+use std::sync::LazyLock;
+
+use regex::Regex;
+
 use super::messages_to_transcript;
+
+// ── Noise stripping ──────────────────────────────────────────────────────────
+// Claude Code and other tools inject system tags, hook output, and UI chrome
+// into transcripts. These waste drawer space and pollute search results.
+//
+// strip_noise is applied per message, never across message boundaries, so a
+// stray unclosed tag in one message cannot eat content from adjacent messages.
+// All patterns are line-anchored; user prose mentioning these strings inline
+// is preserved verbatim.
+
+const NOISE_TAG_NAMES: &[&str] = &[
+    "system-reminder",
+    "command-message",
+    "command-name",
+    "task-notification",
+    "user-prompt-submit-hook",
+    "hook_output",
+];
+
+const NOISE_LINE_PREFIXES: &[&str] = &[
+    "CURRENT TIME:",
+    "VERIFIED FACTS (do not contradict)",
+    "AGENT SPECIALIZATION:",
+    "Checking verified facts...",
+    "Injecting timestamp...",
+    "Starting background pipeline...",
+    "Checking emotional weights...",
+    "Auto-save reminder...",
+    "Checking pipeline...",
+    "MemPalace auto-save checkpoint.",
+];
+
+// Compiled once at startup. Panics are unreachable — patterns are compile-time
+// literals. #[allow] covers the .expect() calls inside the LazyLock closures.
+#[allow(clippy::expect_used)]
+static NOISE_TAG_RES: LazyLock<Vec<Regex>> = LazyLock::new(|| {
+    NOISE_TAG_NAMES
+        .iter()
+        .map(|name| {
+            // (?sm): s = dot matches newline (spans tag body), m = ^ anchors to line start.
+            // Lazy .*? stops at the first closing tag. The blockquote prefix (?:> )?
+            // handles transcripts where lines are already prefixed with "> ".
+            Regex::new(&format!(
+                r"(?sm)^(?:> )?<{name}(?:\s[^>]*)?>.*?</{name}>[ \t]*\n?"
+            ))
+            .expect("noise tag regex is a compile-time literal and cannot fail")
+        })
+        .collect()
+});
+
+#[allow(clippy::expect_used)]
+static NOISE_LINE_RES: LazyLock<Vec<Regex>> = LazyLock::new(|| {
+    NOISE_LINE_PREFIXES
+        .iter()
+        .map(|prefix| {
+            // Line-anchored, case-sensitive. regex::escape handles dots and parens.
+            Regex::new(&format!(r"(?m)^(?:> )?{}.*\n?", regex::escape(prefix)))
+                .expect("noise line regex is a compile-time literal and cannot fail")
+        })
+        .collect()
+});
+
+// "Ran 2 Stop hook", "Ran 1 PreCompact hook", etc. — Claude Code TUI chrome.
+// Explicit hook names; prose like "our CI has a stop hook" stays intact.
+#[allow(clippy::expect_used)]
+static HOOK_LINE_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?m)^(?:> )?Ran \d+ (?:Stop|PreCompact|PreToolUse|PostToolUse|UserPromptSubmit|Notification|SessionStart|SessionEnd) hooks?.*\n?",
+    )
+    .expect("hook line regex is a compile-time literal and cannot fail")
+});
+
+// "… +N lines" collapsed-output marker.
+#[allow(clippy::expect_used)]
+static COLLAPSED_LINES_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?m)^(?:> )?…\s*\+\d+ lines.*\n?")
+        .expect("collapsed lines regex is a compile-time literal and cannot fail")
+});
+
+// "[N tokens] (ctrl+o to expand)" inline chrome.
+// Narrow pattern — a bare "(ctrl+o to expand)" in user prose stays intact.
+#[allow(clippy::expect_used)]
+static TOKEN_MARKER_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\s*\[\d+\s+tokens?\]\s*\(ctrl\+o to expand\)")
+        .expect("token marker regex is a compile-time literal and cannot fail")
+});
+
+// Collapse runs of blank lines created by the removals.
+#[allow(clippy::expect_used)]
+static EXCESS_BLANK_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\n{4,}").expect("excess blank regex is a compile-time literal and cannot fail")
+});
+
+/// Remove system tags, hook output, and Claude Code UI chrome from a message.
+///
+/// Applied per message (never across boundaries) so a dangling open tag
+/// in one message cannot consume text from the next.
+pub fn strip_noise(text: &str) -> String {
+    assert!(!text.is_empty(), "strip_noise: text must not be empty");
+
+    let mut result = text.to_owned();
+    for re in NOISE_TAG_RES.iter() {
+        result = re.replace_all(&result, "").into_owned();
+    }
+    for re in NOISE_LINE_RES.iter() {
+        result = re.replace_all(&result, "").into_owned();
+    }
+    result = HOOK_LINE_RE.replace_all(&result, "").into_owned();
+    result = COLLAPSED_LINES_RE.replace_all(&result, "").into_owned();
+    result = TOKEN_MARKER_RE.replace_all(&result, "").into_owned();
+    // Collapse runs of 4+ blank lines down to 3 (a visual paragraph break).
+    result = EXCESS_BLANK_RE.replace_all(&result, "\n\n\n").into_owned();
+
+    // Postcondition: result is trimmed (no leading/trailing whitespace).
+    result.trim().to_string()
+}
 
 /// Try to parse Claude Code JSONL format into transcript text.
 ///
@@ -21,8 +141,12 @@ pub fn try_parse(content: &str) -> Option<String> {
 
         let msg_type = obj.get("type")?.as_str()?;
         let message = obj.get("message")?.as_object()?;
-        let text = extract_content(message.get("content")?);
-
+        let raw = extract_content(message.get("content")?);
+        if raw.is_empty() {
+            continue;
+        }
+        // Strip system-injected noise per message, never across boundaries.
+        let text = strip_noise(&raw);
         if text.is_empty() {
             continue;
         }
@@ -124,5 +248,109 @@ mod tests {
 {"type":"assistant","message":{"content":"reply"}}"#;
         let result = try_parse(jsonl).expect("should parse");
         assert!(result.contains("> array msg"));
+    }
+
+    // ── strip_noise tests ────────────────────────────────────────────────────
+
+    #[test]
+    fn strip_noise_removes_system_reminder_tag() {
+        let text = "hello\n<system-reminder>do not share</system-reminder>\nworld";
+        let result = strip_noise(text);
+        assert!(!result.contains("system-reminder"), "tag should be removed");
+        assert!(
+            !result.contains("do not share"),
+            "tag body should be removed"
+        );
+        assert!(result.contains("hello"), "surrounding text preserved");
+        assert!(result.contains("world"), "surrounding text preserved");
+    }
+
+    #[test]
+    fn strip_noise_removes_hook_line() {
+        let text = "some content\nRan 2 Stop hooks\nmore content";
+        let result = strip_noise(text);
+        assert!(!result.contains("Ran 2 Stop hooks"), "hook line removed");
+        assert!(
+            result.contains("some content"),
+            "surrounding text preserved"
+        );
+        assert!(
+            result.contains("more content"),
+            "surrounding text preserved"
+        );
+    }
+
+    #[test]
+    fn strip_noise_removes_token_marker() {
+        let text = "big response [512 tokens] (ctrl+o to expand) end";
+        let result = strip_noise(text);
+        assert!(!result.contains("ctrl+o to expand"), "token marker removed");
+        assert!(
+            result.contains("big response"),
+            "surrounding text preserved"
+        );
+    }
+
+    #[test]
+    fn strip_noise_removes_noise_line_prefix() {
+        let text = "useful text\nCURRENT TIME: 2026-04-14T12:00:00Z\nmore text";
+        let result = strip_noise(text);
+        assert!(!result.contains("CURRENT TIME:"), "noise prefix removed");
+        assert!(result.contains("useful text"), "surrounding text preserved");
+    }
+
+    #[test]
+    fn strip_noise_preserves_inline_mentions() {
+        // "current time:" lowercase and mid-sentence should not be stripped.
+        let text = "The current time: field is important in our API.";
+        let result = strip_noise(text);
+        assert_eq!(result, text.trim(), "inline lowercase mention preserved");
+    }
+
+    #[test]
+    fn strip_noise_multiline_tag() {
+        let text = "before\n<system-reminder>\nline one\nline two\n</system-reminder>\nafter";
+        let result = strip_noise(text);
+        assert!(!result.contains("line one"), "multiline tag body removed");
+        assert!(!result.contains("line two"), "multiline tag body removed");
+        assert!(result.contains("before"), "surrounding text preserved");
+        assert!(result.contains("after"), "surrounding text preserved");
+    }
+
+    #[test]
+    fn strip_noise_empty_after_stripping_returns_empty() {
+        // A message that is purely a system-reminder should survive as empty.
+        let text = "<system-reminder>noise only</system-reminder>";
+        let result = strip_noise(text);
+        assert!(result.is_empty(), "pure noise becomes empty");
+    }
+
+    #[test]
+    fn strip_noise_removes_collapsed_lines_marker() {
+        let text = "output\n… +42 lines\nmore";
+        let result = strip_noise(text);
+        assert!(
+            !result.contains("42 lines"),
+            "collapsed lines marker removed"
+        );
+    }
+
+    #[test]
+    fn jsonl_messages_with_noise_are_stripped() {
+        // Verify strip_noise is called during try_parse — noise in a JSONL message
+        // should not appear in the parsed transcript.
+        let jsonl = "{\"type\":\"human\",\"message\":{\"content\":\"hello world\"}}\n\
+            {\"type\":\"assistant\",\"message\":{\"content\":\"reply\\n<system-reminder>internal</system-reminder>\"}}";
+        let result = try_parse(jsonl).expect("should parse");
+        assert!(result.contains("> hello world"), "user turn preserved");
+        assert!(result.contains("reply"), "assistant content preserved");
+        assert!(
+            !result.contains("system-reminder"),
+            "noise tag stripped from assistant turn"
+        );
+        assert!(
+            !result.contains("internal"),
+            "noise tag body stripped from assistant turn"
+        );
     }
 }

--- a/src/palace/convo_miner.rs
+++ b/src/palace/convo_miner.rs
@@ -130,13 +130,18 @@ fn chunk_exchanges(content: &str) -> Vec<Chunk> {
         .filter(|l| l.trim_start().starts_with('>'))
         .count();
 
-    // Route to chunk_by_exchange whenever at least one user turn (>) is present,
-    // including single-exchange transcripts.  The previous threshold of 3 caused
-    // single-exchange blocks to fall through to chunk_by_paragraph, which never
-    // splits on CHUNK_SIZE, silently discarding content beyond the first paragraph.
-    // chunk_by_exchange handles sparse-quote input gracefully: lines without a
-    // leading '>' are skipped by the inner else branch, so no data is lost.
-    if quote_count >= 1 {
+    // Route to chunk_by_exchange only when the first non-empty line is a user
+    // turn marker ('>').  A previous version routed whenever quote_count >= 1,
+    // but chunk_by_exchange silently drops every non-'>' line via its else-skip
+    // branch.  Content that starts with unquoted preamble (leading text before
+    // the first '>') would therefore be discarded; chunk_by_paragraph preserves
+    // it instead.  The quote_count >= 1 guard still rejects fully unquoted files.
+    let first_nonempty_is_quote = lines
+        .iter()
+        .find(|l| !l.trim().is_empty())
+        .is_some_and(|l| l.trim_start().starts_with('>'));
+
+    if quote_count >= 1 && first_nonempty_is_quote {
         chunk_by_exchange(&lines)
     } else {
         chunk_by_paragraph(content)
@@ -749,5 +754,38 @@ mod tests {
             input.as_bytes(),
             "reconstructed content must match original bytes exactly"
         );
+    }
+
+    #[test]
+    fn chunk_exchanges_single_exchange_regression() {
+        // Regression: chunk_exchanges must route single-exchange transcripts
+        // through chunk_by_exchange, preserving all AI lines.  An earlier
+        // threshold of quote_count >= 3 caused single-exchange blocks to fall
+        // through to chunk_by_paragraph, silently dropping lines beyond the
+        // first paragraph boundary.  This test calls the public dispatcher
+        // (chunk_exchanges) rather than chunk_by_exchange directly so any future
+        // regression in the routing logic is caught here.
+        let lines: Vec<String> = std::iter::once("> user question".to_string())
+            .chain((1..=9).map(|n| format!("ai line {n}")))
+            .collect();
+        let input = lines.join("\n");
+        let chunks = chunk_exchanges(&input);
+        assert!(!chunks.is_empty(), "must produce at least one chunk");
+        let all_text = chunks
+            .iter()
+            .map(|c| c.content.as_str())
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert!(
+            all_text.contains("ai line 9"),
+            "all AI lines must be preserved via chunk_exchanges dispatcher"
+        );
+        // Chunk indices must be contiguous and 0-based.
+        for (expected, chunk) in chunks.iter().enumerate() {
+            assert_eq!(
+                chunk.chunk_index, expected,
+                "chunk indices must be 0-based and contiguous"
+            );
+        }
     }
 }

--- a/src/palace/convo_miner.rs
+++ b/src/palace/convo_miner.rs
@@ -213,9 +213,16 @@ fn chunk_by_exchange(lines: &[&str]) -> Vec<Chunk> {
                 let mut remainder = &content[first_end..];
                 while !remainder.is_empty() {
                     let end = chunk_by_exchange_floor_char_boundary(remainder, CHUNK_SIZE);
-                    // floor_char_boundary returns at least 1 for non-empty input
-                    // when CHUNK_SIZE > 0, preventing an infinite loop.
-                    let end = end.max(1);
+                    // If floor_char_boundary returned 0 (edge case for corrupted input),
+                    // advance by the first character's UTF-8 byte length to maintain
+                    // boundary safety and prevent infinite loops.
+                    let end = if end == 0 {
+                        // Invariant: remainder is non-empty (guarded by while condition),
+                        // so chars().next() always returns Some.
+                        remainder.chars().next().map_or(1, char::len_utf8)
+                    } else {
+                        end
+                    };
                     let part = &remainder[..end];
                     remainder = &remainder[end..];
                     chunks.push(Chunk {
@@ -698,5 +705,39 @@ mod tests {
         let s = "aé"; // bytes: [0x61, 0xC3, 0xA9]
         assert_eq!(chunk_by_exchange_floor_char_boundary(s, 2), 1); // step back to 'a' boundary
         assert_eq!(chunk_by_exchange_floor_char_boundary(s, 3), 3); // end of 'é' is fine
+    }
+
+    #[test]
+    fn chunk_by_exchange_small_tail_regression() {
+        // Regression test: when content is CHUNK_SIZE + (MIN_CHUNK_SIZE - 1) bytes,
+        // the split produces a full first chunk and a small tail; verify both are
+        // preserved and chunk indices are contiguous.
+        let ai_body = "x".repeat(CHUNK_SIZE + (MIN_CHUNK_SIZE - 1)); // 829 bytes
+        let input = format!("> user\n{ai_body}");
+        let lines: Vec<&str> = input.lines().collect();
+
+        let chunks = chunk_by_exchange(&lines);
+
+        // Must produce exactly two chunks: one full (800) and one small (29+).
+        assert_eq!(chunks.len(), 2, "must produce exactly two chunks");
+
+        // Chunk indices must be contiguous and 0-based.
+        for (expected, chunk) in chunks.iter().enumerate() {
+            assert_eq!(
+                chunk.chunk_index, expected,
+                "chunk indices must be 0-based and contiguous"
+            );
+        }
+
+        // Full byte reconstruction: concatenate all chunk bodies.
+        let reconstructed = chunks
+            .iter()
+            .map(|c| c.content.as_str())
+            .collect::<String>();
+        assert_eq!(
+            reconstructed.as_bytes(),
+            input.as_bytes(),
+            "reconstructed content must match original bytes exactly"
+        );
     }
 }

--- a/src/palace/convo_miner.rs
+++ b/src/palace/convo_miner.rs
@@ -200,6 +200,7 @@ fn chunk_by_exchange(lines: &[&str]) -> Vec<Chunk> {
                 // mid-codepoint for multi-byte chars (emoji, CJK, accents).
                 let first_end = chunk_by_exchange_floor_char_boundary(&content, CHUNK_SIZE);
                 let first = &content[..first_end];
+                // Guard first chunk to avoid nearly-empty starts.
                 if first.trim().len() > MIN_CHUNK_SIZE {
                     chunks.push(Chunk {
                         content: first.to_string(),
@@ -207,6 +208,8 @@ fn chunk_by_exchange(lines: &[&str]) -> Vec<Chunk> {
                     });
                 }
                 // Remaining response in CHUNK_SIZE continuation drawers.
+                // Continuation fragments are always pushed (no MIN_CHUNK_SIZE filter)
+                // to prevent silent data loss once we've committed to multi-chunk output.
                 let mut remainder = &content[first_end..];
                 while !remainder.is_empty() {
                     let end = chunk_by_exchange_floor_char_boundary(remainder, CHUNK_SIZE);
@@ -215,12 +218,10 @@ fn chunk_by_exchange(lines: &[&str]) -> Vec<Chunk> {
                     let end = end.max(1);
                     let part = &remainder[..end];
                     remainder = &remainder[end..];
-                    if part.trim().len() > MIN_CHUNK_SIZE {
-                        chunks.push(Chunk {
-                            content: part.to_string(),
-                            chunk_index: chunks.len(),
-                        });
-                    }
+                    chunks.push(Chunk {
+                        content: part.to_string(),
+                        chunk_index: chunks.len(),
+                    });
                 }
             } else if content.trim().len() > MIN_CHUNK_SIZE {
                 chunks.push(Chunk {
@@ -672,6 +673,16 @@ mod tests {
                 "every chunk must be valid UTF-8"
             );
         }
+        // Round-trip validation: reconstruct original from chunks and verify bytes match.
+        let reconstructed = chunks
+            .iter()
+            .map(|c| c.content.as_str())
+            .collect::<String>();
+        assert_eq!(
+            reconstructed.as_bytes(),
+            input.as_bytes(),
+            "reconstructed content must match original bytes exactly"
+        );
     }
 
     #[test]

--- a/src/palace/convo_miner.rs
+++ b/src/palace/convo_miner.rs
@@ -131,6 +131,26 @@ fn chunk_exchanges(content: &str) -> Vec<Chunk> {
     }
 }
 
+/// Return the largest byte index ≤ `index` that is a UTF‑8 char boundary in `s`.
+///
+/// Slicing `s` by a raw byte offset is unsafe when the string contains multi‑byte
+/// characters (emoji, accented letters, CJK) because the offset may land mid‑
+/// codepoint, causing a panic.  This function walks backwards from `index` until
+/// it finds a valid boundary, guaranteeing `&s[..result]` never panics.
+fn chunk_by_exchange_floor_char_boundary(s: &str, index: usize) -> usize {
+    if index >= s.len() {
+        return s.len();
+    }
+    let mut i = index;
+    while !s.is_char_boundary(i) {
+        i -= 1;
+    }
+    // Postcondition: i is a valid char boundary within s.
+    debug_assert!(s.is_char_boundary(i));
+    debug_assert!(i <= index);
+    i
+}
+
 /// One user turn (>) + the full AI response that follows = one or more chunks.
 ///
 /// The full AI response is preserved verbatim. When the combined user-turn +
@@ -172,7 +192,10 @@ fn chunk_by_exchange(lines: &[&str]) -> Vec<Chunk> {
 
             if content.len() > CHUNK_SIZE {
                 // First chunk: user turn + as much response as fits.
-                let first = &content[..CHUNK_SIZE];
+                // Use char-boundary-safe slicing: a raw byte offset can land
+                // mid-codepoint for multi-byte chars (emoji, CJK, accents).
+                let first_end = chunk_by_exchange_floor_char_boundary(&content, CHUNK_SIZE);
+                let first = &content[..first_end];
                 if first.trim().len() > MIN_CHUNK_SIZE {
                     chunks.push(Chunk {
                         content: first.to_string(),
@@ -180,9 +203,12 @@ fn chunk_by_exchange(lines: &[&str]) -> Vec<Chunk> {
                     });
                 }
                 // Remaining response in CHUNK_SIZE continuation drawers.
-                let mut remainder = &content[CHUNK_SIZE..];
+                let mut remainder = &content[first_end..];
                 while !remainder.is_empty() {
-                    let end = CHUNK_SIZE.min(remainder.len());
+                    let end = chunk_by_exchange_floor_char_boundary(remainder, CHUNK_SIZE);
+                    // floor_char_boundary returns at least 1 for non-empty input
+                    // when CHUNK_SIZE > 0, preventing an infinite loop.
+                    let end = end.max(1);
                     let part = &remainder[..end];
                     remainder = &remainder[end..];
                     if part.trim().len() > MIN_CHUNK_SIZE {
@@ -623,5 +649,39 @@ mod tests {
             chunks[0].content.contains("assistant replies"),
             "answer preserved"
         );
+    }
+
+    #[test]
+    fn chunk_by_exchange_multibyte_chars_no_panic() {
+        // Emoji and accented chars are multi-byte; a raw byte slice at CHUNK_SIZE
+        // could land mid-codepoint and panic.  This test verifies the split is
+        // UTF-8-boundary-safe and all content is preserved across chunks.
+        let emoji_line = "🚀".repeat(300); // 300 × 4 bytes = 1200 bytes, well above CHUNK_SIZE
+        let input = format!("> question\n{emoji_line}");
+        let lines: Vec<&str> = input.lines().collect();
+        // Must not panic and must produce valid UTF-8 in every chunk.
+        let chunks = chunk_by_exchange(&lines);
+        assert!(!chunks.is_empty(), "must produce at least one chunk");
+        for chunk in &chunks {
+            assert!(
+                std::str::from_utf8(chunk.content.as_bytes()).is_ok(),
+                "every chunk must be valid UTF-8"
+            );
+        }
+    }
+
+    #[test]
+    fn chunk_by_exchange_floor_char_boundary_ascii() {
+        // ASCII strings: every byte is a char boundary, so result == index.
+        assert_eq!(chunk_by_exchange_floor_char_boundary("hello", 3), 3);
+        assert_eq!(chunk_by_exchange_floor_char_boundary("hello", 10), 5); // clamped to len
+    }
+
+    #[test]
+    fn chunk_by_exchange_floor_char_boundary_multibyte() {
+        // "é" is 2 bytes (0xC3 0xA9); byte 1 is mid-codepoint.
+        let s = "aé"; // bytes: [0x61, 0xC3, 0xA9]
+        assert_eq!(chunk_by_exchange_floor_char_boundary(s, 2), 1); // step back to 'a' boundary
+        assert_eq!(chunk_by_exchange_floor_char_boundary(s, 3), 3); // end of 'é' is fine
     }
 }

--- a/src/palace/convo_miner.rs
+++ b/src/palace/convo_miner.rs
@@ -12,8 +12,11 @@ use crate::palace::room_detect::is_skip_dir;
 
 const CONVO_EXTENSIONS: &[&str] = &["txt", "md", "json", "jsonl"];
 const MIN_CHUNK_SIZE: usize = 30;
-/// Chars per drawer — large exchanges are split at this boundary so the full
-/// AI response is stored without truncation.  Mirrors miner.py's `CHUNK_SIZE`.
+/// Bytes per drawer — large exchanges are split at this boundary (rounded down
+/// to a UTF-8 char boundary) so the full AI response is stored without
+/// truncation.  Mirrors miner.py's `CHUNK_SIZE`.  Uses `content.len()` (bytes),
+/// not `content.chars().count()`, so chunks may be slightly shorter for
+/// multi-byte characters.
 const CHUNK_SIZE: usize = 800;
 /// Files larger than this are skipped — prevents OOM on huge files.
 const MAX_FILE_SIZE: u64 = 10 * 1024 * 1024; // 10 MB
@@ -153,9 +156,10 @@ fn chunk_by_exchange_floor_char_boundary(s: &str, index: usize) -> usize {
 
 /// One user turn (>) + the full AI response that follows = one or more chunks.
 ///
-/// The full AI response is preserved verbatim. When the combined user-turn +
-/// response exceeds `CHUNK_SIZE`, the response is split across consecutive
-/// drawers so nothing is silently discarded (fixes the prior 8-line cap).
+/// Each line is whitespace-trimmed and empty lines are dropped; the remaining
+/// lines are joined with a single space.  When the combined content exceeds
+/// `CHUNK_SIZE` bytes, it is split across consecutive drawers so nothing is
+/// silently discarded (fixes the prior 8-line cap).
 fn chunk_by_exchange(lines: &[&str]) -> Vec<Chunk> {
     let mut chunks = Vec::new();
     let mut i = 0;

--- a/src/palace/convo_miner.rs
+++ b/src/palace/convo_miner.rs
@@ -21,6 +21,9 @@ const CHUNK_SIZE: usize = 800;
 /// Files larger than this are skipped — prevents OOM on huge files.
 const MAX_FILE_SIZE: u64 = 10 * 1024 * 1024; // 10 MB
 
+// Compile-time invariant: chunk size must be greater than min chunk size.
+const _: () = assert!(CHUNK_SIZE > MIN_CHUNK_SIZE);
+
 use super::WALK_DEPTH_LIMIT;
 
 const TOPIC_KEYWORDS: &[(&str, &[&str])] = &[

--- a/src/palace/convo_miner.rs
+++ b/src/palace/convo_miner.rs
@@ -709,16 +709,17 @@ mod tests {
 
     #[test]
     fn chunk_by_exchange_small_tail_regression() {
-        // Regression test: when content is CHUNK_SIZE + (MIN_CHUNK_SIZE - 1) bytes,
-        // the split produces a full first chunk and a small tail; verify both are
-        // preserved and chunk indices are contiguous.
-        let ai_body = "x".repeat(CHUNK_SIZE + (MIN_CHUNK_SIZE - 1)); // 829 bytes
+        // Regression test: tail chunk smaller than MIN_CHUNK_SIZE is preserved.
+        // Total size = CHUNK_SIZE + (MIN_CHUNK_SIZE - 1) - prefix_len so remainder
+        // after first CHUNK_SIZE bytes is strictly < MIN_CHUNK_SIZE.
+        let prefix_len = "> user\n".len(); // 7 bytes
+        let ai_body = "x".repeat(CHUNK_SIZE + (MIN_CHUNK_SIZE - 1) - prefix_len); // 822 bytes
         let input = format!("> user\n{ai_body}");
         let lines: Vec<&str> = input.lines().collect();
 
         let chunks = chunk_by_exchange(&lines);
 
-        // Must produce exactly two chunks: one full (800) and one small (29+).
+        // Must produce exactly two chunks: one full (800) and one tail (< 30).
         assert_eq!(chunks.len(), 2, "must produce exactly two chunks");
 
         // Chunk indices must be contiguous and 0-based.

--- a/src/palace/convo_miner.rs
+++ b/src/palace/convo_miner.rs
@@ -130,7 +130,13 @@ fn chunk_exchanges(content: &str) -> Vec<Chunk> {
         .filter(|l| l.trim_start().starts_with('>'))
         .count();
 
-    if quote_count >= 3 {
+    // Route to chunk_by_exchange whenever at least one user turn (>) is present,
+    // including single-exchange transcripts.  The previous threshold of 3 caused
+    // single-exchange blocks to fall through to chunk_by_paragraph, which never
+    // splits on CHUNK_SIZE, silently discarding content beyond the first paragraph.
+    // chunk_by_exchange handles sparse-quote input gracefully: lines without a
+    // leading '>' are skipped by the inner else branch, so no data is lost.
+    if quote_count >= 1 {
         chunk_by_exchange(&lines)
     } else {
         chunk_by_paragraph(content)

--- a/src/palace/convo_miner.rs
+++ b/src/palace/convo_miner.rs
@@ -12,6 +12,9 @@ use crate::palace::room_detect::is_skip_dir;
 
 const CONVO_EXTENSIONS: &[&str] = &["txt", "md", "json", "jsonl"];
 const MIN_CHUNK_SIZE: usize = 30;
+/// Chars per drawer — large exchanges are split at this boundary so the full
+/// AI response is stored without truncation.  Mirrors miner.py's `CHUNK_SIZE`.
+const CHUNK_SIZE: usize = 800;
 /// Files larger than this are skipped — prevents OOM on huge files.
 const MAX_FILE_SIZE: u64 = 10 * 1024 * 1024; // 10 MB
 
@@ -128,6 +131,11 @@ fn chunk_exchanges(content: &str) -> Vec<Chunk> {
     }
 }
 
+/// One user turn (>) + the full AI response that follows = one or more chunks.
+///
+/// The full AI response is preserved verbatim. When the combined user-turn +
+/// response exceeds `CHUNK_SIZE`, the response is split across consecutive
+/// drawers so nothing is silently discarded (fixes the prior 8-line cap).
 fn chunk_by_exchange(lines: &[&str]) -> Vec<Chunk> {
     let mut chunks = Vec::new();
     let mut i = 0;
@@ -154,14 +162,37 @@ fn chunk_by_exchange(lines: &[&str]) -> Vec<Chunk> {
                 i += 1;
             }
 
-            let ai_response = ai_lines[..ai_lines.len().min(8)].join(" ");
+            // Full response — no truncation.
+            let ai_response = ai_lines.join(" ");
             let content = if ai_response.is_empty() {
                 user_turn.to_string()
             } else {
                 format!("{user_turn}\n{ai_response}")
             };
 
-            if content.trim().len() > MIN_CHUNK_SIZE {
+            if content.len() > CHUNK_SIZE {
+                // First chunk: user turn + as much response as fits.
+                let first = &content[..CHUNK_SIZE];
+                if first.trim().len() > MIN_CHUNK_SIZE {
+                    chunks.push(Chunk {
+                        content: first.to_string(),
+                        chunk_index: chunks.len(),
+                    });
+                }
+                // Remaining response in CHUNK_SIZE continuation drawers.
+                let mut remainder = &content[CHUNK_SIZE..];
+                while !remainder.is_empty() {
+                    let end = CHUNK_SIZE.min(remainder.len());
+                    let part = &remainder[..end];
+                    remainder = &remainder[end..];
+                    if part.trim().len() > MIN_CHUNK_SIZE {
+                        chunks.push(Chunk {
+                            content: part.to_string(),
+                            chunk_index: chunks.len(),
+                        });
+                    }
+                }
+            } else if content.trim().len() > MIN_CHUNK_SIZE {
                 chunks.push(Chunk {
                     content,
                     chunk_index: chunks.len(),
@@ -544,5 +575,53 @@ mod tests {
     fn detect_convo_room_handles_utf8_without_panicking() {
         let content = "🚀 Planejamento técnico com decisão sobre API e arquitetura. ".repeat(200);
         assert_eq!(detect_convo_room(&content), "technical");
+    }
+
+    #[test]
+    fn chunk_by_exchange_stores_full_ai_response() {
+        // Before the fix the AI response was truncated to 8 lines; this test
+        // verifies the 9th line is now preserved.
+        let lines: Vec<String> = std::iter::once("> user question".to_string())
+            .chain((1..=9).map(|n| format!("ai line {n}")))
+            .collect();
+        let refs: Vec<&str> = lines.iter().map(String::as_str).collect();
+        let chunks = chunk_by_exchange(&refs);
+        assert!(!chunks.is_empty(), "must produce at least one chunk");
+        let all_text = chunks
+            .iter()
+            .map(|c| c.content.as_str())
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert!(
+            all_text.contains("ai line 9"),
+            "9th AI line must be preserved"
+        );
+    }
+
+    #[test]
+    fn chunk_by_exchange_splits_large_exchange() {
+        // A long AI response (> CHUNK_SIZE) must be split into multiple drawers.
+        let ai_body = "x ".repeat(500); // ~1000 chars > CHUNK_SIZE=800
+        let input = format!("> user turn\n{ai_body}");
+        let lines: Vec<&str> = input.lines().collect();
+        let chunks = chunk_by_exchange(&lines);
+        assert!(chunks.len() >= 2, "large exchange must produce 2+ chunks");
+        // Chunk indices must be contiguous and 0-based.
+        for (expected, chunk) in chunks.iter().enumerate() {
+            assert_eq!(chunk.chunk_index, expected, "chunk indices must be 0-based");
+        }
+    }
+
+    #[test]
+    fn chunk_by_exchange_small_exchange_single_chunk() {
+        // Content is > MIN_CHUNK_SIZE (30) so it must produce exactly one chunk.
+        let input = "> user asks a question here\nthe assistant replies with an answer";
+        let lines: Vec<&str> = input.lines().collect();
+        let chunks = chunk_by_exchange(&lines);
+        assert_eq!(chunks.len(), 1, "small exchange fits in one chunk");
+        assert!(
+            chunks[0].content.contains("assistant replies"),
+            "answer preserved"
+        );
     }
 }

--- a/src/palace/graph.rs
+++ b/src/palace/graph.rs
@@ -1,6 +1,8 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
+use chrono::Utc;
 use serde::Serialize;
+use sha2::Digest as _;
 use turso::Connection;
 
 use crate::db::query_all;
@@ -285,6 +287,376 @@ pub async fn graph_stats(connection: &Connection) -> Result<GraphStats> {
     })
 }
 
+// =============================================================================
+// EXPLICIT TUNNELS — agent-created cross-wing links
+// =============================================================================
+// Passive tunnels are discovered from shared room names across wings.
+// Explicit tunnels are created by agents when they notice a connection
+// between two specific rooms in different wings/projects.
+//
+// Tunnels are symmetric (undirected): create_tunnel(A, B) and
+// create_tunnel(B, A) produce the same canonical ID via a sorted hash,
+// so a second call with flipped endpoints updates rather than duplicates.
+
+/// An explicit tunnel linking two palace locations.
+#[derive(Debug, Clone, Serialize)]
+pub struct ExplicitTunnel {
+    /// Canonical tunnel ID — SHA256 of sorted endpoints.
+    pub id: String,
+    /// Source wing.
+    pub source_wing: String,
+    /// Source room.
+    pub source_room: String,
+    /// Target wing.
+    pub target_wing: String,
+    /// Target room.
+    pub target_room: String,
+    /// Optional specific source drawer ID.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_drawer_id: Option<String>,
+    /// Optional specific target drawer ID.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_drawer_id: Option<String>,
+    /// Human-readable description of the connection.
+    pub label: String,
+    /// ISO timestamp when the tunnel was created.
+    pub created_at: String,
+    /// ISO timestamp when the tunnel was last updated (if it has been).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
+}
+
+/// A connection returned by `follow_tunnels`, relative to the queried location.
+#[derive(Debug, Clone, Serialize)]
+pub struct TunnelConnection {
+    /// `"outgoing"` if the queried location is the source, `"incoming"` if target.
+    pub direction: String,
+    /// Wing of the connected room.
+    pub connected_wing: String,
+    /// Room of the connected room.
+    pub connected_room: String,
+    /// Human-readable description.
+    pub label: String,
+    /// Tunnel ID.
+    pub tunnel_id: String,
+    /// Optional drawer ID at the connected end.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub drawer_id: Option<String>,
+    /// Short preview of the connected drawer content (if collection supplied).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub drawer_preview: Option<String>,
+}
+
+/// Compute the canonical tunnel ID from two endpoints.
+///
+/// Tunnels are undirected — sort the two endpoint strings before hashing so
+/// `canonical_tunnel_id(A, B) == canonical_tunnel_id(B, A)`.
+fn canonical_tunnel_id(
+    source_wing: &str,
+    source_room: &str,
+    target_wing: &str,
+    target_room: &str,
+) -> String {
+    assert!(!source_wing.is_empty(), "source_wing must not be empty");
+    assert!(!source_room.is_empty(), "source_room must not be empty");
+    assert!(!target_wing.is_empty(), "target_wing must not be empty");
+    assert!(!target_room.is_empty(), "target_room must not be empty");
+
+    let src = format!("{source_wing}/{source_room}");
+    let tgt = format!("{target_wing}/{target_room}");
+    let (a, b) = if src <= tgt {
+        (src.as_str(), tgt.as_str())
+    } else {
+        (tgt.as_str(), src.as_str())
+    };
+    // ↔ (U+2194) separates the two endpoints. A bare `/` would be ambiguous
+    // because wing and room strings can themselves contain slashes in principle;
+    // a non-ASCII multi-byte separator makes accidental collisions impossible.
+    let input = format!("{a}\u{2194}{b}");
+    let hash = sha2::Sha256::digest(input.as_bytes());
+    let hex: String = hash.iter().fold(String::new(), |mut s, byte| {
+        use std::fmt::Write as _;
+        let _ = write!(s, "{byte:02x}");
+        s
+    });
+    // Postcondition: SHA256 hex is always 64 chars; we take the first 16.
+    assert_eq!(hex.len(), 64, "SHA256 hex output must be 64 characters");
+    hex[..16].to_string()
+}
+
+/// Parameters for creating or updating an explicit tunnel.
+pub struct CreateTunnelParams<'a> {
+    /// Wing of the source location.
+    pub source_wing: &'a str,
+    /// Room in the source wing.
+    pub source_room: &'a str,
+    /// Wing of the target location.
+    pub target_wing: &'a str,
+    /// Room in the target wing.
+    pub target_room: &'a str,
+    /// Human-readable description of the connection.
+    pub label: &'a str,
+    /// Optional specific source drawer ID.
+    pub source_drawer_id: Option<&'a str>,
+    /// Optional specific target drawer ID.
+    pub target_drawer_id: Option<&'a str>,
+}
+
+/// Create (or update) an explicit tunnel between two palace locations.
+///
+/// Tunnels are symmetric: calling with (A, B) and (B, A) both resolve to the
+/// same canonical ID.  A second call with the same endpoints updates the label
+/// and optional drawer IDs rather than creating a duplicate.
+pub async fn create_tunnel(
+    connection: &Connection,
+    params: &CreateTunnelParams<'_>,
+) -> Result<ExplicitTunnel> {
+    assert!(
+        !params.source_wing.is_empty(),
+        "source_wing must not be empty"
+    );
+    assert!(
+        !params.source_room.is_empty(),
+        "source_room must not be empty"
+    );
+    assert!(
+        !params.target_wing.is_empty(),
+        "target_wing must not be empty"
+    );
+    assert!(
+        !params.target_room.is_empty(),
+        "target_room must not be empty"
+    );
+
+    let tunnel_id = canonical_tunnel_id(
+        params.source_wing,
+        params.source_room,
+        params.target_wing,
+        params.target_room,
+    );
+    let now = Utc::now().to_rfc3339();
+
+    create_tunnel_upsert(connection, &tunnel_id, params, &now).await?;
+    create_tunnel_read_back(connection, &tunnel_id).await
+}
+
+/// UPDATE the tunnel if it exists, INSERT if it does not.
+///
+/// The UPDATE-then-INSERT pattern (rather than INSERT OR REPLACE) preserves
+/// `created_at` on repeated calls — REPLACE would delete and re-insert the row,
+/// resetting the creation timestamp.
+async fn create_tunnel_upsert(
+    connection: &Connection,
+    tunnel_id: &str,
+    params: &CreateTunnelParams<'_>,
+    now: &str,
+) -> Result<()> {
+    assert!(!tunnel_id.is_empty(), "tunnel_id must not be empty");
+    assert!(!now.is_empty(), "now must not be empty");
+
+    let rows_updated = connection
+        .execute(
+            "UPDATE explicit_tunnels SET label = ?1, source_drawer_id = ?2, target_drawer_id = ?3, updated_at = ?4 WHERE id = ?5",
+            turso::params![params.label, params.source_drawer_id, params.target_drawer_id, now, tunnel_id],
+        )
+        .await?;
+
+    // Postcondition: at most one row updated (tunnel_id is the primary key).
+    assert!(
+        rows_updated <= 1,
+        "tunnel ID is a primary key — at most one row updated"
+    );
+
+    if rows_updated == 0 {
+        // No existing row — insert the new tunnel.
+        connection
+            .execute(
+                "INSERT INTO explicit_tunnels (id, source_wing, source_room, target_wing, target_room, source_drawer_id, target_drawer_id, label, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                turso::params![
+                    tunnel_id,
+                    params.source_wing,
+                    params.source_room,
+                    params.target_wing,
+                    params.target_room,
+                    params.source_drawer_id,
+                    params.target_drawer_id,
+                    params.label,
+                    now
+                ],
+            )
+            .await?;
+    }
+
+    Ok(())
+}
+
+/// Read the tunnel row back after upsert — the pair assertion half of the write.
+async fn create_tunnel_read_back(
+    connection: &Connection,
+    tunnel_id: &str,
+) -> Result<ExplicitTunnel> {
+    assert!(!tunnel_id.is_empty(), "tunnel_id must not be empty");
+
+    let rows = query_all(
+        connection,
+        "SELECT id, source_wing, source_room, target_wing, target_room, source_drawer_id, target_drawer_id, label, created_at, updated_at FROM explicit_tunnels WHERE id = ?1",
+        [tunnel_id],
+    )
+    .await?;
+
+    // Pair assertion: the row must exist immediately after create_tunnel_upsert.
+    assert!(
+        !rows.is_empty(),
+        "pair assertion: tunnel must exist after upsert"
+    );
+
+    let row = &rows[0];
+    Ok(ExplicitTunnel {
+        id: row.get(0).unwrap_or_default(),
+        source_wing: row.get(1).unwrap_or_default(),
+        source_room: row.get(2).unwrap_or_default(),
+        target_wing: row.get(3).unwrap_or_default(),
+        target_room: row.get(4).unwrap_or_default(),
+        source_drawer_id: row.get(5).ok(),
+        target_drawer_id: row.get(6).ok(),
+        label: row.get(7).unwrap_or_default(),
+        created_at: row.get(8).unwrap_or_default(),
+        updated_at: row.get(9).ok(),
+    })
+}
+
+/// List explicit tunnels, optionally filtered to those involving a given wing.
+pub async fn list_tunnels(
+    connection: &Connection,
+    wing: Option<&str>,
+) -> Result<Vec<ExplicitTunnel>> {
+    if let Some(w) = wing {
+        assert!(!w.is_empty(), "wing filter must not be an empty string");
+    }
+
+    // Two separate queries rather than one with a `?1 IS NULL OR ...` guard,
+    // so SQLite can use the wing column index when a filter is present instead
+    // of falling back to a full table scan.
+    let rows = if let Some(w) = wing {
+        query_all(
+            connection,
+            "SELECT id, source_wing, source_room, target_wing, target_room, source_drawer_id, target_drawer_id, label, created_at, updated_at FROM explicit_tunnels WHERE source_wing = ?1 OR target_wing = ?1 ORDER BY created_at DESC",
+            [w],
+        )
+        .await?
+    } else {
+        query_all(
+            connection,
+            "SELECT id, source_wing, source_room, target_wing, target_room, source_drawer_id, target_drawer_id, label, created_at, updated_at FROM explicit_tunnels ORDER BY created_at DESC",
+            (),
+        )
+        .await?
+    };
+
+    let tunnels: Vec<ExplicitTunnel> = rows
+        .iter()
+        .map(|row| ExplicitTunnel {
+            id: row.get(0).unwrap_or_default(),
+            source_wing: row.get(1).unwrap_or_default(),
+            source_room: row.get(2).unwrap_or_default(),
+            target_wing: row.get(3).unwrap_or_default(),
+            target_room: row.get(4).unwrap_or_default(),
+            source_drawer_id: row.get(5).ok(),
+            target_drawer_id: row.get(6).ok(),
+            label: row.get(7).unwrap_or_default(),
+            created_at: row.get(8).unwrap_or_default(),
+            updated_at: row.get(9).ok(),
+        })
+        .collect();
+
+    // Postcondition: every returned tunnel was assigned an ID at insert time.
+    debug_assert!(tunnels.iter().all(|t| !t.id.is_empty()));
+
+    Ok(tunnels)
+}
+
+/// Delete an explicit tunnel by ID.  Returns `true` if a row was deleted.
+pub async fn delete_tunnel(connection: &Connection, tunnel_id: &str) -> Result<bool> {
+    assert!(!tunnel_id.is_empty(), "tunnel_id must not be empty");
+    let rows_affected = connection
+        .execute("DELETE FROM explicit_tunnels WHERE id = ?1", [tunnel_id])
+        .await?;
+
+    // Postcondition: at most one row deleted (ID is the primary key).
+    assert!(
+        rows_affected <= 1,
+        "tunnel ID is a primary key — at most one row deleted"
+    );
+
+    Ok(rows_affected == 1)
+}
+
+/// Follow explicit tunnels from a room — returns connections to linked rooms.
+///
+/// Optionally fetches a short preview of the drawer at the connected end
+/// when `drawer_ids` happen to be stored on the tunnel.
+pub async fn follow_tunnels(
+    connection: &Connection,
+    wing: &str,
+    room: &str,
+) -> Result<Vec<TunnelConnection>> {
+    assert!(!wing.is_empty(), "wing must not be empty");
+    assert!(!room.is_empty(), "room must not be empty");
+
+    let rows = query_all(
+        connection,
+        "SELECT id, source_wing, source_room, target_wing, target_room, source_drawer_id, target_drawer_id, label FROM explicit_tunnels WHERE (source_wing = ?1 AND source_room = ?2) OR (target_wing = ?1 AND target_room = ?2)",
+        [wing, room],
+    )
+    .await?;
+
+    let mut connections = Vec::new();
+    for row in &rows {
+        let tunnel_id: String = row.get(0).unwrap_or_default();
+        let source_wing: String = row.get(1).unwrap_or_default();
+        let source_room: String = row.get(2).unwrap_or_default();
+        let target_wing: String = row.get(3).unwrap_or_default();
+        let target_room: String = row.get(4).unwrap_or_default();
+        let source_drawer_id: Option<String> = row.get(5).ok();
+        let target_drawer_id: Option<String> = row.get(6).ok();
+        let label: String = row.get(7).unwrap_or_default();
+
+        // Direction is relative to the queried location: if we ARE the source
+        // the link points away from us (outgoing); if we are the target, it
+        // points at us (incoming).
+        if source_wing == wing && source_room == room {
+            connections.push(TunnelConnection {
+                direction: "outgoing".to_string(),
+                connected_wing: target_wing,
+                connected_room: target_room,
+                label,
+                tunnel_id,
+                drawer_id: target_drawer_id,
+                drawer_preview: None,
+            });
+        } else {
+            connections.push(TunnelConnection {
+                direction: "incoming".to_string(),
+                connected_wing: source_wing,
+                connected_room: source_room,
+                label,
+                tunnel_id,
+                drawer_id: source_drawer_id,
+                drawer_preview: None,
+            });
+        }
+    }
+
+    // Postcondition: every connection has a recognised direction value.
+    debug_assert!(
+        connections
+            .iter()
+            .all(|c| c.direction == "outgoing" || c.direction == "incoming")
+    );
+
+    Ok(connections)
+}
+
 #[cfg(test)]
 // Test code — .expect() is acceptable with a descriptive message.
 #[allow(clippy::expect_used)]
@@ -365,5 +737,199 @@ mod tests {
         assert_eq!(tunnels.len(), 1);
         assert_eq!(tunnels[0].room, "backend");
         assert_eq!(tunnels[0].wings.len(), 2);
+    }
+
+    // ── explicit tunnel tests ─────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn create_tunnel_round_trip() {
+        let (_db, connection) = crate::test_helpers::test_db().await;
+        let tunnel = create_tunnel(
+            &connection,
+            &CreateTunnelParams {
+                source_wing: "wing_api",
+                source_room: "schemas",
+                target_wing: "wing_db",
+                target_room: "migrations",
+                label: "API schema drives DB migration",
+                source_drawer_id: None,
+                target_drawer_id: None,
+            },
+        )
+        .await
+        .expect("create_tunnel should succeed");
+
+        assert!(!tunnel.id.is_empty(), "tunnel ID must be assigned");
+        assert_eq!(tunnel.source_wing, "wing_api");
+        assert_eq!(tunnel.source_room, "schemas");
+        assert_eq!(tunnel.target_wing, "wing_db");
+        assert_eq!(tunnel.target_room, "migrations");
+        assert_eq!(tunnel.label, "API schema drives DB migration");
+        assert!(tunnel.updated_at.is_none(), "new tunnel has no updated_at");
+    }
+
+    #[tokio::test]
+    async fn create_tunnel_idempotent_update() {
+        // A second call with the same endpoints must update, not duplicate.
+        let (_db, connection) = crate::test_helpers::test_db().await;
+        let first = create_tunnel(
+            &connection,
+            &CreateTunnelParams {
+                source_wing: "wA",
+                source_room: "rA",
+                target_wing: "wB",
+                target_room: "rB",
+                label: "first label",
+                source_drawer_id: None,
+                target_drawer_id: None,
+            },
+        )
+        .await
+        .expect("first create_tunnel");
+
+        let second = create_tunnel(
+            &connection,
+            &CreateTunnelParams {
+                source_wing: "wA",
+                source_room: "rA",
+                target_wing: "wB",
+                target_room: "rB",
+                label: "updated label",
+                source_drawer_id: None,
+                target_drawer_id: None,
+            },
+        )
+        .await
+        .expect("second create_tunnel");
+
+        assert_eq!(first.id, second.id, "same endpoints → same canonical ID");
+        assert_eq!(second.label, "updated label", "label must be updated");
+        assert!(second.updated_at.is_some(), "repeated call sets updated_at");
+
+        let tunnels = list_tunnels(&connection, None).await.expect("list_tunnels");
+        assert_eq!(tunnels.len(), 1, "must remain exactly one tunnel");
+    }
+
+    #[tokio::test]
+    async fn create_tunnel_symmetric_id() {
+        // (A→B) and (B→A) must produce the same canonical ID.
+        let id_ab = canonical_tunnel_id("wing_a", "room_a", "wing_b", "room_b");
+        let id_ba = canonical_tunnel_id("wing_b", "room_b", "wing_a", "room_a");
+        assert_eq!(id_ab, id_ba, "tunnel ID must be symmetric");
+    }
+
+    #[tokio::test]
+    async fn list_tunnels_wing_filter() {
+        let (_db, connection) = crate::test_helpers::test_db().await;
+        create_tunnel(
+            &connection,
+            &CreateTunnelParams {
+                source_wing: "wA",
+                source_room: "rA",
+                target_wing: "wB",
+                target_room: "rB",
+                label: "",
+                source_drawer_id: None,
+                target_drawer_id: None,
+            },
+        )
+        .await
+        .expect("create AB");
+        create_tunnel(
+            &connection,
+            &CreateTunnelParams {
+                source_wing: "wC",
+                source_room: "rC",
+                target_wing: "wD",
+                target_room: "rD",
+                label: "",
+                source_drawer_id: None,
+                target_drawer_id: None,
+            },
+        )
+        .await
+        .expect("create CD");
+
+        let tunnels = list_tunnels(&connection, Some("wA"))
+            .await
+            .expect("list by wA");
+        assert_eq!(tunnels.len(), 1, "filter by wA should return 1 tunnel");
+        assert!(
+            tunnels[0].source_wing == "wA" || tunnels[0].target_wing == "wA",
+            "returned tunnel must involve wA"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_tunnel_removes_row() {
+        let (_db, connection) = crate::test_helpers::test_db().await;
+        let tunnel = create_tunnel(
+            &connection,
+            &CreateTunnelParams {
+                source_wing: "wx",
+                source_room: "rx",
+                target_wing: "wy",
+                target_room: "ry",
+                label: "",
+                source_drawer_id: None,
+                target_drawer_id: None,
+            },
+        )
+        .await
+        .expect("create tunnel");
+
+        let deleted = delete_tunnel(&connection, &tunnel.id)
+            .await
+            .expect("delete_tunnel");
+        assert!(deleted, "delete must return true for existing tunnel");
+
+        let tunnels = list_tunnels(&connection, None)
+            .await
+            .expect("list after delete");
+        assert!(tunnels.is_empty(), "tunnel list must be empty after delete");
+    }
+
+    #[tokio::test]
+    async fn delete_tunnel_nonexistent_returns_false() {
+        let (_db, connection) = crate::test_helpers::test_db().await;
+        let deleted = delete_tunnel(&connection, "nonexistent_id_000000")
+            .await
+            .expect("delete_tunnel on missing ID should not error");
+        assert!(!deleted, "delete of nonexistent tunnel must return false");
+    }
+
+    #[tokio::test]
+    async fn follow_tunnels_returns_connections() {
+        let (_db, connection) = crate::test_helpers::test_db().await;
+        create_tunnel(
+            &connection,
+            &CreateTunnelParams {
+                source_wing: "wing_api",
+                source_room: "design",
+                target_wing: "wing_db",
+                target_room: "schema",
+                label: "api design → db schema",
+                source_drawer_id: None,
+                target_drawer_id: None,
+            },
+        )
+        .await
+        .expect("create tunnel");
+
+        let connections = follow_tunnels(&connection, "wing_api", "design")
+            .await
+            .expect("follow_tunnels");
+        assert_eq!(connections.len(), 1);
+        assert_eq!(connections[0].direction, "outgoing");
+        assert_eq!(connections[0].connected_wing, "wing_db");
+        assert_eq!(connections[0].connected_room, "schema");
+
+        // Pair assertion: follow from the other end returns incoming.
+        let reverse = follow_tunnels(&connection, "wing_db", "schema")
+            .await
+            .expect("follow_tunnels reverse");
+        assert_eq!(reverse.len(), 1);
+        assert_eq!(reverse[0].direction, "incoming");
+        assert_eq!(reverse[0].connected_wing, "wing_api");
     }
 }

--- a/src/palace/query_sanitizer.rs
+++ b/src/palace/query_sanitizer.rs
@@ -9,13 +9,13 @@
 //!   1. Short-query passthrough (≤ 200 chars) — no action needed.
 //!   2. Question extraction — find a sentence ending with `?`.
 //!   3. Tail sentence — take the last meaningful newline-delimited segment.
-//!   4. Tail truncation — fallback, take the last 500 chars.
+//!   4. Tail truncation — fallback, take the last 250 chars.
 
 use std::sync::LazyLock;
 
 use regex::Regex;
 
-const MAX_QUERY_LEN: usize = 500;
+const MAX_QUERY_LEN: usize = 250;
 const SAFE_QUERY_LEN: usize = 200;
 const MIN_QUESTION_SEGMENT_LEN: usize = 3;
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -105,28 +105,6 @@ pub async fn ensure_schema(connection: &Connection) -> Result<()> {
         .execute("ALTER TABLE drawers ADD COLUMN source_mtime REAL", ())
         .await;
 
-    // Migration: add explicit_tunnels table and its indexes for existing databases.
-    // The CREATE TABLE IF NOT EXISTS in SCHEMA handles new databases; this migration
-    // covers databases created before tunnels were introduced.
-    let _ = connection
-        .execute_batch(
-            "CREATE TABLE IF NOT EXISTS explicit_tunnels (
-                id TEXT PRIMARY KEY,
-                source_wing TEXT NOT NULL,
-                source_room TEXT NOT NULL,
-                target_wing TEXT NOT NULL,
-                target_room TEXT NOT NULL,
-                source_drawer_id TEXT,
-                target_drawer_id TEXT,
-                label TEXT DEFAULT '',
-                created_at TEXT DEFAULT (datetime('now')),
-                updated_at TEXT
-            );
-            CREATE INDEX IF NOT EXISTS idx_tunnels_source ON explicit_tunnels(source_wing, source_room);
-            CREATE INDEX IF NOT EXISTS idx_tunnels_target ON explicit_tunnels(target_wing, target_room);",
-        )
-        .await;
-
     // Pair assertion: verify all six core tables were created.
     let rows = crate::db::query_all(
         connection,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -68,6 +68,26 @@ CREATE TABLE IF NOT EXISTS compressed (
     room TEXT,
     filed_at TEXT DEFAULT (datetime('now'))
 );
+
+-- Explicit cross-wing tunnels created by agents when they notice a connection
+-- between two specific rooms in different wings/projects.  Stored in SQLite
+-- rather than a JSON file so they survive palace rebuilds only if the file
+-- is preserved — but the DB is always available without extra state.
+CREATE TABLE IF NOT EXISTS explicit_tunnels (
+    id TEXT PRIMARY KEY,
+    source_wing TEXT NOT NULL,
+    source_room TEXT NOT NULL,
+    target_wing TEXT NOT NULL,
+    target_room TEXT NOT NULL,
+    source_drawer_id TEXT,
+    target_drawer_id TEXT,
+    label TEXT DEFAULT '',
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_tunnels_source ON explicit_tunnels(source_wing, source_room);
+CREATE INDEX IF NOT EXISTS idx_tunnels_target ON explicit_tunnels(target_wing, target_room);
 ";
 
 /// Create all tables and indexes if they don't already exist.
@@ -85,7 +105,29 @@ pub async fn ensure_schema(connection: &Connection) -> Result<()> {
         .execute("ALTER TABLE drawers ADD COLUMN source_mtime REAL", ())
         .await;
 
-    // Pair assertion: verify all five core tables were created.
+    // Migration: add explicit_tunnels table and its indexes for existing databases.
+    // The CREATE TABLE IF NOT EXISTS in SCHEMA handles new databases; this migration
+    // covers databases created before tunnels were introduced.
+    let _ = connection
+        .execute_batch(
+            "CREATE TABLE IF NOT EXISTS explicit_tunnels (
+                id TEXT PRIMARY KEY,
+                source_wing TEXT NOT NULL,
+                source_room TEXT NOT NULL,
+                target_wing TEXT NOT NULL,
+                target_room TEXT NOT NULL,
+                source_drawer_id TEXT,
+                target_drawer_id TEXT,
+                label TEXT DEFAULT '',
+                created_at TEXT DEFAULT (datetime('now')),
+                updated_at TEXT
+            );
+            CREATE INDEX IF NOT EXISTS idx_tunnels_source ON explicit_tunnels(source_wing, source_room);
+            CREATE INDEX IF NOT EXISTS idx_tunnels_target ON explicit_tunnels(target_wing, target_room);",
+        )
+        .await;
+
+    // Pair assertion: verify all six core tables were created.
     let rows = crate::db::query_all(
         connection,
         "SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name",
@@ -115,6 +157,10 @@ pub async fn ensure_schema(connection: &Connection) -> Result<()> {
     assert!(
         table_names.contains(&"compressed".to_string()),
         "compressed table must exist"
+    );
+    assert!(
+        table_names.contains(&"explicit_tunnels".to_string()),
+        "explicit_tunnels table must exist"
     );
 
     Ok(())


### PR DESCRIPTION
## Summary

- Add `strip_noise()` to the Claude Code normalizer: strips system-reminder tags, hook output, and Claude Code UI chrome from transcripts before storing
- Update the Claude.ai parser to accept the `sender` field (privacy exports), fall back to a top-level `text` key, and emit each conversation as a separate transcript block
- Reduce `MAX_QUERY_LEN` from 500 to 250 characters; update the MCP schema `maxLength` to match
- Remove the 8-line AI truncation cap in `chunk_by_exchange`; store full AI responses and split large exchanges into continuation drawers
- Add explicit tunnels: `explicit_tunnels` DB table, four new MCP tools (`mempalace_create_tunnel`, `mempalace_list_tunnels`, `mempalace_delete_tunnel`, `mempalace_follow_tunnels`); symmetric canonical ID via SHA256 of sorted endpoints
- Track `mempalace-py` on the `main` branch in `.gitmodules`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit tunnel management: create, list, delete, and follow persistent symmetric connections between wings/rooms.

* **Improvements**
  * Preserve full AI responses and safely split long exchanges with UTF‑8‑aware chunking.
  * Reduced search/query truncation limit from 500 → 250 characters.
  * Improved transcript parsing and added noise-stripping for clearer messages.

* **Documentation**
  * README updated: tunnel tools, schema, terminology, and updated tool count.

* **Chores**
  * Submodule now tracks an explicit branch and was bumped to a newer commit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->