### PR TITLE
Dependency cleanup and test coverage

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,6 @@
+[profile.default.env]
+# Redirect all config and WAL writes away from ~/.mempalace during test runs.
+# config_dir() checks MEMPALACE_DIR before falling back to the legacy default.
+# /tmp is cleaned up by the OS; no per-process subdirectory is needed since WAL
+# writes are append-only and test processes use in-memory databases.
+MEMPALACE_DIR = "/tmp/mempalace_test"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,6 +1,0 @@
-[profile.default.env]
-# Redirect all config and WAL writes away from ~/.mempalace during test runs.
-# config_dir() checks MEMPALACE_DIR before falling back to the legacy default.
-# /tmp is cleaned up by the OS; no per-process subdirectory is needed since WAL
-# writes are append-only and test processes use in-memory databases.
-MEMPALACE_DIR = "/tmp/mempalace_test"

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ mempalace.yaml
 
 # Claude local
 .claude/local
+.claude/worktrees
 .claude/settings.local.json
 .claude/CLAUDE.local.md
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ mempalace.yaml
 # Claude local
 .claude/local
 .claude/settings.local.json
+.claude/CLAUDE.local.md
 
 # Created by https://www.toptal.com/developers/gitignore/api/linux,macos,windows,sublimetext,intellij+all,visualstudio,visualstudiocode,rust,rust-analyzer
 # Edit at https://www.toptal.com/developers/gitignore?templates=linux,macos,windows,sublimetext,intellij+all,visualstudio,visualstudiocode,rust,rust-analyzer

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,3 +2,5 @@
 
 - Read @STYLEGUIDE.md and follow it as closely as possible
 - Whenever suppressing a Clippy Lint, an inline comment must be added explaining why
+- Lint: `cargo clippy --all-features --all-targets`
+- Format: `cargo fmt`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# LLMs
+
+- Read @STYLEGUIDE.md and follow it as closely as possible
+- Whenever suppressing a Clippy Lint, an inline comment must be added explaining why

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+./AGENTS.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,54 +66,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anstyle-parse"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "antithesis_sdk"
@@ -333,7 +289,6 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
- "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -375,10 +330,8 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
- "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
 ]
 
 [[package]]
@@ -400,12 +353,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
-name = "colorchoice"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
-
-[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,12 +360,6 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
-
-[[package]]
-name = "const-oid"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core-foundation-sys"
@@ -542,7 +483,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
  "block-buffer",
- "const-oid",
  "crypto-common 0.2.1",
 ]
 
@@ -883,12 +823,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
 name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -961,16 +895,6 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "libmimalloc-sys"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
-dependencies = [
- "cc",
- "libc",
-]
 
 [[package]]
 name = "linkme"
@@ -1098,15 +1022,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mimalloc"
-version = "0.1.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
-dependencies = [
- "libmimalloc-sys",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1170,12 +1085,6 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-
-[[package]]
-name = "once_cell_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opaque-debug"
@@ -1700,12 +1609,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fef461faaeb36c340b6c887167a9054a034f6acfc50a014ead26a02b4356b3de"
 
 [[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
 name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1924,7 +1827,6 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faba49ac70e21ea35cc963341485f3d17822f2cf433f42152a182117da21d29f"
 dependencies = [
- "mimalloc",
  "thiserror",
  "tracing",
  "tracing-subscriber",
@@ -2159,12 +2061,6 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,36 +630,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
-name = "futures-core"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-sink"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
-
-[[package]]
-name = "futures-task"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
-
-[[package]]
-name = "futures-util"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
-dependencies = [
- "futures-core",
- "futures-task",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
 name = "genawaiter"
 version = "0.99.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,7 +1062,6 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "clap",
- "futures-util",
  "ignore",
  "regex",
  "serde",
@@ -1102,7 +1071,6 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "tokio-util",
  "turso",
  "uuid",
 ]
@@ -1720,12 +1688,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
-name = "slab"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
-
-[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1881,19 +1843,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,6 +570,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "genawaiter"
 version = "0.99.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1598,6 +1686,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1660,6 +1754,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
 dependencies = [
+ "futures",
  "parking_lot",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,6 +992,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2",
+ "temp-env",
  "tempfile",
  "thiserror",
  "tokio",
@@ -1652,6 +1653,15 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "parking_lot",
+]
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,5 +51,5 @@ turso = { version = "0.5.3", default-features = false }
 uuid = { version = "1", default-features = false, features = ["v4"] }
 
 [dev-dependencies]
-temp-env = "0.3"
+temp-env = { version = "0.3", features = ["async_closure"] }
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,4 +51,5 @@ turso = { version = "0.5.3", default-features = false }
 uuid = { version = "1", default-features = false, features = ["v4"] }
 
 [dev-dependencies]
+temp-env = "0.3"
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ unwrap_used = "deny"
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
-futures-util = { version = "0.3", default-features = false, features = ["std"] }
 ignore = "0.4"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
@@ -36,7 +35,6 @@ tokio = { version = "1", features = [
   "io-std",
   "io-util",
 ] }
-tokio-util = { version = "0.7", features = ["codec"] }
 turso = "0.5.3"
 uuid = { version = "1", features = ["v4"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,23 +20,35 @@ pedantic = { level = "deny", priority = -1 }
 unwrap_used = "deny"
 
 [dependencies]
-chrono = { version = "0.4", features = ["serde"] }
-clap = { version = "4", features = ["derive"] }
-ignore = "0.4"
-regex = "1"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-serde_yaml = "0.9"
-sha2 = "0.11"
-thiserror = "2"
-tokio = { version = "1", features = [
+chrono = { version = "0.4", default-features = false, features = [
+  "clock",
+  "std",
+] }
+clap = { version = "4", default-features = false, features = [
+  "derive",
+  "error-context",
+  "help",
+  "std",
+  "usage",
+] }
+ignore = { version = "0.4", default-features = false }
+regex = { version = "1", default-features = false, features = ["std", "perf"] }
+serde = { version = "1", default-features = false, features = [
+  "derive",
+  "std",
+] }
+serde_json = { version = "1", default-features = false, features = ["std"] }
+serde_yaml = { version = "0.9", default-features = false }
+sha2 = { version = "0.11", default-features = false }
+thiserror = { version = "2", default-features = false, features = ["std"] }
+tokio = { version = "1", default-features = false, features = [
   "rt-multi-thread",
   "macros",
   "io-std",
   "io-util",
 ] }
-turso = "0.5.3"
-uuid = { version = "1", features = ["v4"] }
+turso = { version = "0.5.3", default-features = false }
+uuid = { version = "1", default-features = false, features = ["v4"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/cli/compress.rs
+++ b/src/cli/compress.rs
@@ -140,3 +140,98 @@ pub async fn run(
 
     Ok(())
 }
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_load_dialect_none_returns_empty() {
+        let dialect = run_load_dialect(None).expect("None config must return Ok");
+        // Dialect::empty() has zero entity codes — compress with it and verify
+        // it produces non-empty output (proves the dialect is usable).
+        let output = dialect.compress("hello world test content", None);
+        assert!(
+            !output.is_empty(),
+            "empty dialect must still produce output"
+        );
+        // AAAK content line always starts with "0:" entity prefix.
+        assert!(
+            output.contains("0:"),
+            "compressed output must contain entity prefix"
+        );
+    }
+
+    #[test]
+    fn run_load_dialect_valid_file() {
+        let dir = tempfile::tempdir().expect("must create temp dir");
+        let config_path = dir.path().join("dialect.json");
+        std::fs::write(
+            &config_path,
+            r#"{"entities": {"Rust": "RS", "Python": "PY"}, "skip_names": ["test"]}"#,
+        )
+        .expect("must write config file");
+
+        let path_str = config_path.to_str().expect("path must be valid utf-8");
+        let dialect = run_load_dialect(Some(path_str)).expect("valid config must return Ok");
+        // Verify the dialect loaded entities by compressing text that mentions them.
+        let output = dialect.compress("Rust and Python are languages for programming", None);
+        assert!(
+            !output.is_empty(),
+            "dialect with entities must produce output"
+        );
+        // AAAK content line always starts with "0:" entity prefix.
+        assert!(
+            output.contains("0:"),
+            "compressed output must contain entity prefix"
+        );
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod async_tests {
+    use super::*;
+
+    async fn seed_drawer(connection: &Connection) {
+        crate::palace::drawer::add_drawer(
+            connection,
+            &crate::palace::drawer::DrawerParams {
+                id: "compress-test-1",
+                wing: "test_wing",
+                room: "test_room",
+                content: "This is test content for compression with enough words to be meaningful",
+                source_file: "test.txt",
+                chunk_index: 0,
+                added_by: "test",
+                ingest_mode: "projects",
+                source_mtime: None,
+            },
+        )
+        .await
+        .expect("seeding drawer for compress test must succeed");
+    }
+
+    #[tokio::test]
+    async fn run_compress_row_returns_sizes() {
+        let (_db, connection) = crate::test_helpers::test_db().await;
+        seed_drawer(&connection).await;
+
+        let rows = crate::db::query_all(
+            &connection,
+            "SELECT id, content, wing, room, source_file, filed_at FROM drawers LIMIT 1",
+            (),
+        )
+        .await
+        .expect("query must succeed");
+        let row = rows.first().expect("must have at least one row");
+
+        let dialect = Dialect::empty();
+        let (orig, comp) = run_compress_row(&connection, row, &dialect, true, 1)
+            .await
+            .expect("compress row must succeed");
+        assert!(orig > 0, "original size must be positive");
+        assert!(comp > 0, "compressed size must be positive");
+    }
+}

--- a/src/cli/compress.rs
+++ b/src/cli/compress.rs
@@ -142,6 +142,7 @@ pub async fn run(
 }
 
 #[cfg(test)]
+// Acceptable in tests: .expect() produces immediate, clear failures.
 #[allow(clippy::expect_used)]
 mod tests {
     use super::*;
@@ -186,10 +187,17 @@ mod tests {
             output.contains("0:"),
             "compressed output must contain entity prefix"
         );
+        // Verify the loaded entity mappings were applied: "Rust" maps to "RS"
+        // and "Python" maps to "PY", so at least one code must appear.
+        assert!(
+            output.contains("RS") || output.contains("PY"),
+            "compressed output must contain entity codes from loaded dialect"
+        );
     }
 }
 
 #[cfg(test)]
+// Acceptable in tests: .expect() produces immediate, clear failures.
 #[allow(clippy::expect_used)]
 mod async_tests {
     use super::*;

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -44,6 +44,7 @@ pub async fn run(
 }
 
 #[cfg(test)]
+// Acceptable in tests: .expect() produces immediate, clear failures.
 #[allow(clippy::expect_used)]
 mod async_tests {
     use super::*;

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -42,3 +42,53 @@ pub async fn run(
     println!();
     Ok(())
 }
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod async_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn run_no_results_succeeds() {
+        let (_db, connection) = crate::test_helpers::test_db().await;
+        let result = run(&connection, "xyzzy_nonexistent_gibberish", None, None, 5).await;
+        assert!(result.is_ok(), "search for gibberish must not error");
+        assert_eq!(
+            result.expect("run should succeed"),
+            (),
+            "run must return unit on success"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_with_results_succeeds() {
+        let (_db, connection) = crate::test_helpers::test_db().await;
+        crate::palace::drawer::add_drawer(
+            &connection,
+            &crate::palace::drawer::DrawerParams {
+                id: "search-test-1",
+                wing: "docs",
+                room: "guides",
+                content: "quantum computing fundamentals and algorithms explained clearly",
+                source_file: "quantum.md",
+                chunk_index: 0,
+                added_by: "test",
+                ingest_mode: "projects",
+                source_mtime: None,
+            },
+        )
+        .await
+        .expect("seeding drawer for search test must succeed");
+
+        let result = run(&connection, "quantum algorithms", None, None, 5).await;
+        assert!(
+            result.is_ok(),
+            "search with matching content must not error"
+        );
+        assert_eq!(
+            result.expect("run should succeed"),
+            (),
+            "run must return unit on success"
+        );
+    }
+}

--- a/src/cli/split.rs
+++ b/src/cli/split.rs
@@ -365,6 +365,7 @@ pub fn run(
 }
 
 #[cfg(test)]
+// Acceptable in tests: .expect() produces immediate, clear failures.
 #[allow(clippy::expect_used)]
 mod tests {
     use super::*;

--- a/src/cli/split.rs
+++ b/src/cli/split.rs
@@ -363,3 +363,123 @@ pub fn run(
 
     Ok(())
 }
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    // --- find_session_boundaries ---
+
+    #[test]
+    fn find_session_boundaries_empty_input() {
+        let result = find_session_boundaries(&[]);
+        assert!(result.is_empty(), "empty input must produce empty vec");
+        assert_eq!(result.len(), 0);
+    }
+
+    #[test]
+    fn find_session_boundaries_no_sessions() {
+        let lines = &["hello world", "some random text", "no markers here"];
+        let result = find_session_boundaries(lines);
+        assert!(
+            result.is_empty(),
+            "lines without markers must produce empty vec"
+        );
+        assert_eq!(result.len(), 0);
+    }
+
+    #[test]
+    fn find_session_boundaries_finds_markers() {
+        let lines = &[
+            "╭──── Claude Code v1.0.0",
+            "some content here",
+            "more content",
+            "╭──── Claude Code v1.1.0",
+            "other content",
+            "╭──── Claude Code v1.2.0",
+        ];
+        let result = find_session_boundaries(lines);
+        assert_eq!(result.len(), 3, "must find all three session markers");
+        assert_eq!(
+            result,
+            vec![0, 3, 5],
+            "boundary positions must match marker lines"
+        );
+    }
+
+    #[test]
+    fn find_session_boundaries_skips_context_restore() {
+        // A marker followed by "Ctrl+E" within 6 lines should be excluded.
+        // The first marker is far enough away from the restore text to pass.
+        let lines = &[
+            "╭──── Claude Code v1.0.0",
+            "some content line 1",
+            "some content line 2",
+            "some content line 3",
+            "some content line 4",
+            "some content line 5",
+            "some content line 6",
+            "some content line 7",
+            "╭──── Claude Code v1.1.0",
+            "Ctrl+E to restore",
+            "more content",
+        ];
+        let result = find_session_boundaries(lines);
+        // First marker's nearby window (lines 0..6) has no restore text — kept.
+        // Second marker's nearby window (lines 8..11) contains "Ctrl+E" — skipped.
+        assert_eq!(result.len(), 1, "context-restore marker must be excluded");
+        assert_eq!(result[0], 0);
+    }
+
+    // --- extract_timestamp ---
+
+    #[test]
+    fn extract_timestamp_parses_valid() {
+        let lines = &[
+            "some header",
+            "⏺ 2:30 PM Monday, January 15, 2025",
+            "other content",
+        ];
+        let result = extract_timestamp(lines);
+        assert!(result.is_some(), "valid timestamp line must be parsed");
+        assert_eq!(result.expect("already checked Some"), "2025-01-15_230PM");
+    }
+
+    #[test]
+    fn extract_timestamp_no_match() {
+        let lines = &["no timestamp here", "just plain text", "nothing to see"];
+        let result = extract_timestamp(lines);
+        assert!(result.is_none(), "lines without timestamp must return None");
+        assert_eq!(result, None);
+    }
+
+    // --- extract_subject ---
+
+    #[test]
+    fn extract_subject_from_prompt() {
+        let lines = &[
+            "some header",
+            "> How do I fix bugs in Rust",
+            "other content",
+        ];
+        let result = extract_subject(lines);
+        assert!(
+            result.contains("How"),
+            "subject must contain 'How' from the prompt"
+        );
+        assert_ne!(result, "session", "must not fall through to default");
+    }
+
+    #[test]
+    fn extract_subject_default_for_commands() {
+        // Command-like prompts that match SKIP_RE should be skipped.
+        let lines = &["> git status", "> cd /tmp", "> ls -la"];
+        let result = extract_subject(lines);
+        assert_eq!(
+            result, "session",
+            "command-only prompts must return default 'session'"
+        );
+        assert!(!result.is_empty(), "subject must not be empty");
+    }
+}

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -111,3 +111,50 @@ pub async fn run(connection: &Connection) -> Result<()> {
 
     Ok(())
 }
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod async_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn run_empty_palace_succeeds() {
+        let (_db, connection) = crate::test_helpers::test_db().await;
+        let result = run(&connection).await;
+        assert!(result.is_ok(), "status on empty palace must not error");
+        assert_eq!(
+            result.expect("run should succeed"),
+            (),
+            "run must return unit on success"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_with_data_succeeds() {
+        let (_db, connection) = crate::test_helpers::test_db().await;
+        crate::palace::drawer::add_drawer(
+            &connection,
+            &crate::palace::drawer::DrawerParams {
+                id: "status-test-1",
+                wing: "docs",
+                room: "guides",
+                content: "status test content with enough words for indexing",
+                source_file: "readme.md",
+                chunk_index: 0,
+                added_by: "test",
+                ingest_mode: "projects",
+                source_mtime: None,
+            },
+        )
+        .await
+        .expect("seeding drawer for status test must succeed");
+
+        let result = run(&connection).await;
+        assert!(result.is_ok(), "status with data must not error");
+        assert_eq!(
+            result.expect("run should succeed"),
+            (),
+            "run must return unit on success"
+        );
+    }
+}

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -113,6 +113,7 @@ pub async fn run(connection: &Connection) -> Result<()> {
 }
 
 #[cfg(test)]
+// Acceptable in tests: .expect() produces immediate, clear failures.
 #[allow(clippy::expect_used)]
 mod async_tests {
     use super::*;

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,8 +31,33 @@ fn default_collection_name() -> String {
     "mempalace_drawers".to_string()
 }
 
-/// Returns ~/.mempalace/
+// Override for the config directory. Set once by `test_helpers::test_db()`
+// before any tool writes, redirecting WAL and config writes away from the real
+// `~/.mempalace` during test runs. The `OnceLock` makes this safe for parallel
+// test execution: whichever test sets it first wins, and all subsequent calls
+// to `config_dir()` see the same override.
+static CONFIG_DIR_OVERRIDE: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
+
+/// Override the config directory returned by `config_dir`.
+///
+/// Intended for test setup only. Must be called before any code that uses
+/// `config_dir()`. Subsequent calls are silently ignored (`OnceLock` semantics).
+// Called from test_helpers::redirect_config_dir() in the library target.
+// The binary compiles test_helpers only under #[cfg(test)], so the binary
+// linker sees this as unused — suppress rather than remove it.
+#[allow(dead_code)]
+pub fn set_config_dir_override(path: PathBuf) {
+    let _ = CONFIG_DIR_OVERRIDE.set(path);
+}
+
+/// Returns the mempalace config directory (`~/.mempalace` by default).
+///
+/// If `set_config_dir_override` has been called (e.g. by test setup), that
+/// path is returned instead.
 pub fn config_dir() -> PathBuf {
+    if let Some(path) = CONFIG_DIR_OVERRIDE.get() {
+        return path.clone();
+    }
     dirs_fallback().join(".mempalace")
 }
 
@@ -155,7 +180,9 @@ mod tests {
 
     #[test]
     fn config_dir_ends_with_mempalace() {
-        let directory = config_dir();
+        // Test the path formula directly rather than the public `config_dir()`,
+        // which may return an override path set by test infrastructure.
+        let directory = dirs_fallback().join(".mempalace");
         assert!(directory.to_string_lossy().ends_with(".mempalace"));
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,38 +31,22 @@ fn default_collection_name() -> String {
     "mempalace_drawers".to_string()
 }
 
-// Override for the config directory. Set once by `test_helpers::test_db()`
-// before any tool writes, redirecting WAL and config writes away from the real
-// `~/.mempalace` during test runs. The `OnceLock` makes this safe for parallel
-// test execution: whichever test sets it first wins, and all subsequent calls
-// to `config_dir()` see the same override.
-static CONFIG_DIR_OVERRIDE: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
-
-/// Override the config directory returned by `config_dir`.
+/// Returns the mempalace config directory.
 ///
-/// Intended for test setup only. Must be called before any code that uses
-/// `config_dir()`. Subsequent calls are silently ignored (`OnceLock` semantics).
-// Called from test_helpers::redirect_config_dir() in the library target.
-// The binary compiles test_helpers only under #[cfg(test)], so the binary
-// linker sees this as unused — suppress rather than remove it.
-#[allow(dead_code)]
-pub fn set_config_dir_override(path: PathBuf) {
-    let _ = CONFIG_DIR_OVERRIDE.set(path);
-}
-
-/// Returns the mempalace config directory (`~/.mempalace` by default).
-///
-/// If `set_config_dir_override` has been called (e.g. by test setup), that
-/// path is returned instead.
+/// Resolution order:
+///   1. `MEMPALACE_DIR` env var — explicit user, container, or test override.
+///   2. `~/.mempalace` — default.
 pub fn config_dir() -> PathBuf {
-    if let Some(path) = CONFIG_DIR_OVERRIDE.get() {
-        return path.clone();
+    if let Ok(env_path) = std::env::var("MEMPALACE_DIR")
+        && !env_path.is_empty()
+    {
+        return PathBuf::from(env_path);
     }
-    dirs_fallback().join(".mempalace")
+    home_dir().join(".mempalace")
 }
 
-/// Returns the user's home directory.
-fn dirs_fallback() -> PathBuf {
+/// Returns the user's home directory, or `.` if `HOME` is unset.
+fn home_dir() -> PathBuf {
     std::env::var("HOME").map_or_else(|_| PathBuf::from("."), PathBuf::from)
 }
 
@@ -172,18 +156,31 @@ mod tests {
 
     #[test]
     fn default_config_has_palace_path() {
-        let config = MempalaceConfig::default();
-        let path_str = config.palace_path.to_string_lossy();
+        // Test the default palace path formula directly: MempalaceConfig::default()
+        // calls config_dir() which may return MEMPALACE_DIR when set by the test runner.
+        let path = home_dir().join(".mempalace").join("palace.db");
+        let path_str = path.to_string_lossy();
         assert!(path_str.contains(".mempalace"));
         assert!(path_str.ends_with("palace.db"));
     }
 
     #[test]
     fn config_dir_ends_with_mempalace() {
-        // Test the path formula directly rather than the public `config_dir()`,
-        // which may return an override path set by test infrastructure.
-        let directory = dirs_fallback().join(".mempalace");
+        // Test the default path formula directly: config_dir() returns MEMPALACE_DIR
+        // when set, so we test the fallback formula via home_dir().
+        let directory = home_dir().join(".mempalace");
         assert!(directory.to_string_lossy().ends_with(".mempalace"));
+    }
+
+    #[test]
+    fn config_dir_respects_mempalace_dir_env_var() {
+        // Verify that MEMPALACE_DIR overrides the default path. temp_env safely
+        // sets the var for this test and restores the previous value afterwards,
+        // preventing interference with concurrent tests.
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        temp_env::with_var("MEMPALACE_DIR", Some(dir.path()), || {
+            assert_eq!(config_dir(), dir.path());
+        });
     }
 
     #[test]

--- a/src/db.rs
+++ b/src/db.rs
@@ -62,3 +62,67 @@ pub async fn query_all(
     }
     Ok(results)
 }
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn open_db_creates_and_connects() {
+        let dir = tempfile::tempdir().expect("tempdir creation should succeed");
+        let db_path = dir.path().join("test.db");
+        let path_str = db_path
+            .to_str()
+            .expect("tempdir path should be valid UTF-8");
+
+        let (_db, conn) = open_db(path_str)
+            .await
+            .expect("open_db should succeed for a fresh file path");
+
+        // Verify the connection is usable by running a trivial query.
+        let rows = query_all(&conn, "SELECT 42 AS answer", ())
+            .await
+            .expect("trivial SELECT should succeed on newly opened connection");
+        assert_eq!(rows.len(), 1, "SELECT 42 should return exactly 1 row");
+        let val: i64 = rows[0].get(0).expect("column 0 should be readable as i64");
+        assert_eq!(val, 42);
+    }
+
+    #[tokio::test]
+    async fn query_all_returns_rows() {
+        let (_db, conn) = crate::test_helpers::test_db().await;
+
+        // Insert a row into the drawers table (schema is already applied).
+        conn.execute(
+            "INSERT INTO drawers (id, wing, room, content) VALUES ('d1', 'w', 'r', 'hello')",
+            (),
+        )
+        .await
+        .expect("INSERT into drawers should succeed");
+
+        let rows = query_all(&conn, "SELECT id, content FROM drawers WHERE id = 'd1'", ())
+            .await
+            .expect("SELECT from drawers should succeed after insert");
+        assert_eq!(rows.len(), 1, "should find exactly the inserted row");
+        let id: String = rows[0]
+            .get(0)
+            .expect("column 0 (id) should be readable as String");
+        assert_eq!(id, "d1");
+    }
+
+    #[tokio::test]
+    async fn query_all_empty_result() {
+        let (_db, conn) = crate::test_helpers::test_db().await;
+
+        let rows = query_all(
+            &conn,
+            "SELECT id FROM drawers WHERE wing = 'nonexistent'",
+            (),
+        )
+        .await
+        .expect("SELECT with no matching rows should still succeed");
+        assert!(rows.is_empty(), "no rows should match a nonexistent wing");
+        assert_eq!(rows.len(), 0);
+    }
+}

--- a/src/db.rs
+++ b/src/db.rs
@@ -64,6 +64,7 @@ pub async fn query_all(
 }
 
 #[cfg(test)]
+// Acceptable in tests: .expect() produces immediate, clear failures.
 #[allow(clippy::expect_used)]
 mod tests {
     use super::*;

--- a/src/kg/query.rs
+++ b/src/kg/query.rs
@@ -274,3 +274,164 @@ pub async fn stats(connection: &Connection) -> Result<KgStats> {
         relationship_types,
     })
 }
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::kg::{TripleParams, add_entity, add_triple};
+
+    /// Seed a single "Alice knows Bob" triple for reuse across tests.
+    async fn seed_alice_knows_bob(connection: &turso::Connection) {
+        add_entity(connection, "Alice", "person", None)
+            .await
+            .expect("seed: add_entity Alice should succeed");
+        add_entity(connection, "Bob", "person", None)
+            .await
+            .expect("seed: add_entity Bob should succeed");
+        add_triple(
+            connection,
+            &TripleParams {
+                subject: "Alice",
+                predicate: "knows",
+                object: "Bob",
+                valid_from: Some("2024-01-01"),
+                valid_to: None,
+                confidence: 1.0,
+                source_closet: None,
+                source_file: None,
+            },
+        )
+        .await
+        .expect("seed: add_triple Alice->knows->Bob should succeed");
+    }
+
+    #[tokio::test]
+    async fn query_entity_outgoing() {
+        let (_db, conn) = crate::test_helpers::test_db().await;
+        seed_alice_knows_bob(&conn).await;
+
+        let facts = query_entity(&conn, "Alice", None, "outgoing")
+            .await
+            .expect("query_entity outgoing should succeed for seeded entity");
+        assert_eq!(facts.len(), 1, "Alice should have exactly 1 outgoing fact");
+        assert_eq!(facts[0].predicate, "knows");
+        assert_eq!(facts[0].direction, "outgoing");
+    }
+
+    #[tokio::test]
+    async fn query_entity_incoming() {
+        let (_db, conn) = crate::test_helpers::test_db().await;
+        seed_alice_knows_bob(&conn).await;
+
+        let facts = query_entity(&conn, "Bob", None, "incoming")
+            .await
+            .expect("query_entity incoming should succeed for seeded entity");
+        assert_eq!(facts.len(), 1, "Bob should have exactly 1 incoming fact");
+        assert_eq!(facts[0].predicate, "knows");
+        assert_eq!(facts[0].direction, "incoming");
+    }
+
+    #[tokio::test]
+    async fn query_entity_both_directions() {
+        let (_db, conn) = crate::test_helpers::test_db().await;
+        seed_alice_knows_bob(&conn).await;
+
+        // Alice has 1 outgoing, 0 incoming — "both" should still return 1
+        let facts = query_entity(&conn, "Alice", None, "both")
+            .await
+            .expect("query_entity both should succeed for seeded entity");
+        assert!(!facts.is_empty(), "both should return at least one fact");
+        assert_eq!(facts.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn query_entity_nonexistent() {
+        let (_db, conn) = crate::test_helpers::test_db().await;
+
+        let facts = query_entity(&conn, "NoSuchEntity", None, "both")
+            .await
+            .expect("query_entity should succeed even for unknown entity");
+        assert!(facts.is_empty(), "unknown entity should return no facts");
+        assert_eq!(facts.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn timeline_all_entities() {
+        let (_db, conn) = crate::test_helpers::test_db().await;
+        seed_alice_knows_bob(&conn).await;
+        add_triple(
+            &conn,
+            &TripleParams {
+                subject: "Bob",
+                predicate: "works_at",
+                object: "Acme",
+                valid_from: Some("2024-02-01"),
+                valid_to: None,
+                confidence: 1.0,
+                source_closet: None,
+                source_file: None,
+            },
+        )
+        .await
+        .expect("seed: add_triple Bob->works_at->Acme should succeed");
+
+        let facts = timeline(&conn, None)
+            .await
+            .expect("timeline(None) should succeed with seeded data");
+        assert!(facts.len() >= 2, "timeline should contain at least 2 facts");
+        // Timeline is ordered by valid_from ASC
+        assert_eq!(facts[0].valid_from.as_deref(), Some("2024-01-01"));
+    }
+
+    #[tokio::test]
+    async fn timeline_filtered_by_entity() {
+        let (_db, conn) = crate::test_helpers::test_db().await;
+        seed_alice_knows_bob(&conn).await;
+        add_triple(
+            &conn,
+            &TripleParams {
+                subject: "Carol",
+                predicate: "likes",
+                object: "Rust",
+                valid_from: Some("2024-03-01"),
+                valid_to: None,
+                confidence: 1.0,
+                source_closet: None,
+                source_file: None,
+            },
+        )
+        .await
+        .expect("seed: add_triple Carol->likes->Rust should succeed");
+
+        let facts = timeline(&conn, Some("Alice"))
+            .await
+            .expect("timeline(Some('Alice')) should succeed with seeded data");
+        assert_eq!(facts.len(), 1, "only Alice's triple should appear");
+        assert_eq!(facts[0].subject, "Alice");
+    }
+
+    #[tokio::test]
+    async fn stats_empty() {
+        let (_db, conn) = crate::test_helpers::test_db().await;
+
+        let s = stats(&conn)
+            .await
+            .expect("stats should succeed on empty database");
+        assert_eq!(s.entities, 0, "fresh DB should have 0 entities");
+        assert_eq!(s.triples, 0, "fresh DB should have 0 triples");
+    }
+
+    #[tokio::test]
+    async fn stats_with_data() {
+        let (_db, conn) = crate::test_helpers::test_db().await;
+        seed_alice_knows_bob(&conn).await;
+
+        let s = stats(&conn)
+            .await
+            .expect("stats should succeed after seeding data");
+        assert!(s.entities > 0, "seeded DB should have entities");
+        assert!(s.triples > 0, "seeded DB should have triples");
+        assert_eq!(s.current_facts, s.triples, "no expired facts yet");
+    }
+}

--- a/src/kg/query.rs
+++ b/src/kg/query.rs
@@ -276,6 +276,7 @@ pub async fn stats(connection: &Connection) -> Result<KgStats> {
 }
 
 #[cfg(test)]
+// Acceptable in tests: .expect() produces immediate, clear failures.
 #[allow(clippy::expect_used)]
 mod tests {
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,25 @@
+//! Mempalace library — local-first AI memory palace backed by embedded `SQLite`.
+//!
+//! Re-exports modules so integration tests can access palace, MCP,
+//! knowledge-graph, and normalization APIs. Not a public library API.
+
+// Library target exists only for integration test access — these doc-quality
+// lints don't apply since the public API is the CLI binary, not this crate.
+#![allow(
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::must_use_candidate
+)]
+
+pub mod config;
+pub mod db;
+pub mod dialect;
+pub mod error;
+#[allow(dead_code)]
+pub mod extract;
+pub mod kg;
+pub mod mcp;
+pub mod normalize;
+pub mod palace;
+pub mod schema;
+pub mod test_helpers;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,10 @@
 //! Re-exports modules so integration tests can access palace, MCP,
 //! knowledge-graph, and normalization APIs. Not a public library API.
 
-// Library target exists only for integration test access — these doc-quality
-// lints don't apply since the public API is the CLI binary, not this crate.
+// Library target exists only for integration test access — doc-quality lints
+// and `must_use_candidate` don't apply since the public API is the CLI binary,
+// not this crate, and callers are integration tests that discard return values
+// intentionally.
 #![allow(
     clippy::missing_errors_doc,
     clippy::missing_panics_doc,

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -30,6 +30,8 @@ enum LineRead {
     Line(String),
     /// The line exceeded the byte limit — stream resynced past the next newline.
     Overflow,
+    /// The line contained invalid UTF-8 and cannot be parsed as JSON.
+    Invalid,
     /// End-of-stream — stdin closed.
     Eof,
 }
@@ -51,6 +53,18 @@ pub async fn run(connection: &Connection) -> Result<()> {
                     "jsonrpc": "2.0",
                     "id": null,
                     "error": {"code": -32700, "message": "Request exceeds maximum frame size"}
+                });
+                let out = serde_json::to_string(&err_response).unwrap_or_default();
+                stdout.write_all(out.as_bytes()).await?;
+                stdout.write_all(b"\n").await?;
+                stdout.flush().await?;
+                continue;
+            }
+            Ok(LineRead::Invalid) => {
+                let err_response = json!({
+                    "jsonrpc": "2.0",
+                    "id": null,
+                    "error": {"code": -32700, "message": "Request contains invalid UTF-8"}
                 });
                 let out = serde_json::to_string(&err_response).unwrap_or_default();
                 stdout.write_all(out.as_bytes()).await?;
@@ -128,8 +142,10 @@ async fn run_read_line_impl<R: AsyncBufRead + Unpin>(
                 return Ok(LineRead::Eof);
             }
             debug_assert!(buffer.len() <= limit);
-            let line = String::from_utf8_lossy(buffer).into_owned();
-            return Ok(LineRead::Line(line));
+            return match String::from_utf8(buffer.clone()) {
+                Ok(line) => Ok(LineRead::Line(line)),
+                Err(_) => Ok(LineRead::Invalid),
+            };
         }
 
         let chunk_length = available.len();
@@ -151,8 +167,10 @@ async fn run_read_line_impl<R: AsyncBufRead + Unpin>(
                 buffer.pop();
             }
             debug_assert!(buffer.len() <= limit);
-            let line = String::from_utf8_lossy(buffer).into_owned();
-            return Ok(LineRead::Line(line));
+            return match String::from_utf8(buffer.clone()) {
+                Ok(line) => Ok(LineRead::Line(line)),
+                Err(_) => Ok(LineRead::Invalid),
+            };
         }
 
         // No newline in this chunk — accumulate if within limit.
@@ -610,10 +628,11 @@ mod tests {
 
     #[tokio::test]
     async fn read_line_overflow() {
-        // Line exceeds the limit — should return Overflow.
+        // Oversized line followed by a valid short line. After the Overflow the
+        // reader must resync past the newline so the next frame is recovered.
         let limit = 10;
-        let long_line = "a".repeat(limit + 5) + "\n";
-        let cursor = Cursor::new(long_line.into_bytes());
+        let input = "a".repeat(limit + 5) + "\n" + "ok\n";
+        let cursor = Cursor::new(input.into_bytes());
         let mut reader = BufReader::new(cursor);
         let mut buf = Vec::new();
         let result = run_read_line_impl(&mut reader, &mut buf, limit)
@@ -623,15 +642,36 @@ mod tests {
             matches!(result, LineRead::Overflow),
             "expected Overflow for line exceeding limit"
         );
-        // After overflow, the reader should have consumed past the newline,
-        // so a subsequent read on empty remaining data should return Eof.
+        // After overflow drain, the reader must resync and return the next line.
         buf.clear();
         let next = run_read_line_impl(&mut reader, &mut buf, limit)
             .await
             .expect("second read should succeed");
+        let LineRead::Line(recovered) = next else {
+            panic!("expected LineRead::Line after overflow resync, got Eof or Overflow");
+        };
+        assert_eq!(
+            recovered, "ok",
+            "valid line after overflow must be recovered"
+        );
+    }
+
+    #[tokio::test]
+    async fn read_line_invalid_utf8() {
+        // A line containing an invalid UTF-8 sequence must yield Invalid, not a
+        // silently repaired string that could produce unexpected JSON parse results.
+        let mut input = b"valid prefix \xFF\xFE invalid suffix\n".to_vec();
+        // Pair assertion: the bytes are definitely not valid UTF-8.
+        assert!(String::from_utf8(input.clone()).is_err());
+        let cursor = Cursor::new(std::mem::take(&mut input));
+        let mut reader = BufReader::new(cursor);
+        let mut buf = Vec::new();
+        let result = run_read_line_impl(&mut reader, &mut buf, 1024)
+            .await
+            .expect("read should succeed");
         assert!(
-            matches!(next, LineRead::Eof),
-            "stream should be at EOF after overflow drain"
+            matches!(result, LineRead::Invalid),
+            "expected Invalid for line with non-UTF-8 bytes"
         );
     }
 

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -260,6 +260,80 @@ async fn handle_request(connection: &Connection, request: &Value) -> Option<Valu
     }
 }
 
+// Generic version of `run_read_line` for testing — identical algorithm but accepts
+// any AsyncBufRead instead of the concrete Stdin type. Production code calls the
+// Stdin-specific version above; tests exercise this generic twin to verify the
+// line-reading, overflow, and EOF logic without needing a real stdin handle.
+#[cfg(test)]
+async fn run_read_line_generic<R: AsyncBufRead + Unpin>(
+    reader: &mut R,
+    buffer: &mut Vec<u8>,
+    limit: usize,
+) -> std::io::Result<LineRead> {
+    assert!(limit > 0);
+    buffer.clear();
+
+    loop {
+        let available = reader.fill_buf().await?;
+
+        if available.is_empty() {
+            if buffer.is_empty() {
+                return Ok(LineRead::Eof);
+            }
+            debug_assert!(buffer.len() <= limit);
+            let line = String::from_utf8_lossy(buffer).into_owned();
+            return Ok(LineRead::Line(line));
+        }
+
+        let chunk_length = available.len();
+
+        if let Some(newline_index) = available.iter().position(|&b| b == b'\n') {
+            let within_limit = buffer.len() + newline_index <= limit;
+            if within_limit {
+                buffer.extend_from_slice(&available[..newline_index]);
+            }
+            Pin::new(&mut *reader).consume(newline_index + 1);
+
+            if !within_limit {
+                return Ok(LineRead::Overflow);
+            }
+
+            if buffer.last() == Some(&b'\r') {
+                buffer.pop();
+            }
+            debug_assert!(buffer.len() <= limit);
+            let line = String::from_utf8_lossy(buffer).into_owned();
+            return Ok(LineRead::Line(line));
+        }
+
+        let within_limit = buffer.len() + chunk_length <= limit;
+        if within_limit {
+            buffer.extend_from_slice(available);
+        }
+        Pin::new(&mut *reader).consume(chunk_length);
+
+        if !within_limit {
+            // Drain to next newline or EOF for resync.
+            loop {
+                let avail = reader.fill_buf().await?;
+                if avail.is_empty() {
+                    return Ok(LineRead::Overflow);
+                }
+                let clen = avail.len();
+                let nl = avail.iter().position(|&b| b == b'\n');
+                let consume = match nl {
+                    Some(i) => i + 1,
+                    None => clen,
+                };
+                Pin::new(&mut *reader).consume(consume);
+                if nl.is_some() {
+                    return Ok(LineRead::Overflow);
+                }
+            }
+        }
+    }
+}
+
 /// Dispatch a `tools/call` request and return a sanitized JSON-RPC response.
 async fn handle_request_tools_call(
     connection: &Connection,
@@ -342,4 +416,287 @@ async fn handle_request_tools_call(
             "content": [{"type": "text", "text": text}]
         }
     })
+}
+
+#[cfg(test)]
+// Test code — .expect() is acceptable with a descriptive message.
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    // -- handle_request tests ------------------------------------------------
+
+    #[tokio::test]
+    async fn handle_request_initialize_supported_version() {
+        let (_db, conn) = crate::test_helpers::test_db().await;
+        let req = json!({
+            "method": "initialize",
+            "params": {"protocolVersion": "2024-11-05"},
+            "id": 1
+        });
+        let resp = handle_request(&conn, &req)
+            .await
+            .expect("should return Some");
+        let result = &resp["result"];
+        assert_eq!(result["protocolVersion"], "2024-11-05");
+        assert_eq!(result["serverInfo"]["name"], "mempalace");
+    }
+
+    #[tokio::test]
+    async fn handle_request_initialize_unsupported_falls_back() {
+        let (_db, conn) = crate::test_helpers::test_db().await;
+        let req = json!({
+            "method": "initialize",
+            "params": {"protocolVersion": "9999-01-01"},
+            "id": 1
+        });
+        let resp = handle_request(&conn, &req)
+            .await
+            .expect("should return Some");
+        let result = &resp["result"];
+        // Falls back to the latest supported version.
+        assert_eq!(result["protocolVersion"], SUPPORTED_PROTOCOL_VERSIONS[0]);
+        assert_eq!(result["serverInfo"]["name"], "mempalace");
+    }
+
+    #[tokio::test]
+    async fn handle_request_initialize_no_version() {
+        let (_db, conn) = crate::test_helpers::test_db().await;
+        let req = json!({
+            "method": "initialize",
+            "params": {},
+            "id": 1
+        });
+        let resp = handle_request(&conn, &req)
+            .await
+            .expect("should return Some");
+        let result = &resp["result"];
+        // Missing protocolVersion falls back to the latest supported version.
+        assert_eq!(result["protocolVersion"], SUPPORTED_PROTOCOL_VERSIONS[0]);
+        assert_eq!(result["serverInfo"]["name"], "mempalace");
+    }
+
+    #[tokio::test]
+    async fn handle_request_ping() {
+        let (_db, conn) = crate::test_helpers::test_db().await;
+        let req = json!({"method": "ping", "id": 2});
+        let resp = handle_request(&conn, &req)
+            .await
+            .expect("should return Some");
+        assert_eq!(resp["result"], json!({}));
+        assert_eq!(resp["id"], 2);
+    }
+
+    #[tokio::test]
+    async fn handle_request_notification_returns_none() {
+        let (_db, conn) = crate::test_helpers::test_db().await;
+        let req = json!({"method": "notifications/initialized"});
+        let resp = handle_request(&conn, &req).await;
+        assert!(resp.is_none(), "notifications must return None");
+        // Also verify a different notification prefix.
+        let req2 = json!({"method": "notifications/cancelled"});
+        let resp2 = handle_request(&conn, &req2).await;
+        assert!(resp2.is_none(), "all notifications/ must return None");
+    }
+
+    #[tokio::test]
+    async fn handle_request_tools_list() {
+        let (_db, conn) = crate::test_helpers::test_db().await;
+        let req = json!({"method": "tools/list", "id": 3});
+        let resp = handle_request(&conn, &req)
+            .await
+            .expect("should return Some");
+        let tools = resp["result"]["tools"]
+            .as_array()
+            .expect("tools should be an array");
+        assert!(!tools.is_empty(), "tools list must not be empty");
+        assert_eq!(tools.len(), 26, "expected 26 tool definitions");
+    }
+
+    #[tokio::test]
+    async fn handle_request_unknown_method() {
+        let (_db, conn) = crate::test_helpers::test_db().await;
+        let req = json!({"method": "bogus", "id": 4});
+        let resp = handle_request(&conn, &req)
+            .await
+            .expect("should return Some");
+        assert_eq!(resp["error"]["code"], -32601);
+        assert!(
+            resp["error"]["message"]
+                .as_str()
+                .expect("message should be a string")
+                .contains("bogus"),
+            "error message should mention the unknown method"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_request_non_object() {
+        let (_db, conn) = crate::test_helpers::test_db().await;
+        let req = json!("string");
+        let resp = handle_request(&conn, &req)
+            .await
+            .expect("should return Some");
+        assert_eq!(resp["error"]["code"], -32600);
+        assert!(
+            resp["error"]["message"]
+                .as_str()
+                .expect("message should be a string")
+                .contains("Invalid Request"),
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_request_missing_method() {
+        let (_db, conn) = crate::test_helpers::test_db().await;
+        let req = json!({"id": 1});
+        let resp = handle_request(&conn, &req)
+            .await
+            .expect("should return Some");
+        assert_eq!(resp["error"]["code"], -32600);
+        assert!(
+            resp["error"]["message"]
+                .as_str()
+                .expect("message should be a string")
+                .contains("method"),
+            "error message should mention missing method"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_request_tools_call_valid() {
+        let (_db, conn) = crate::test_helpers::test_db().await;
+        let req = json!({
+            "method": "tools/call",
+            "params": {"name": "mempalace_status", "arguments": {}},
+            "id": 5
+        });
+        let resp = handle_request(&conn, &req)
+            .await
+            .expect("should return Some");
+        let content = resp["result"]["content"]
+            .as_array()
+            .expect("content should be an array");
+        assert!(!content.is_empty(), "content array must not be empty");
+        assert_eq!(content[0]["type"], "text");
+    }
+
+    #[tokio::test]
+    async fn handle_request_tools_call_missing_name() {
+        let (_db, conn) = crate::test_helpers::test_db().await;
+        let req = json!({
+            "method": "tools/call",
+            "params": {"arguments": {}},
+            "id": 6
+        });
+        let resp = handle_request(&conn, &req)
+            .await
+            .expect("should return Some");
+        assert_eq!(resp["error"]["code"], -32602);
+        assert!(
+            resp["error"]["message"]
+                .as_str()
+                .expect("message should be a string")
+                .contains("name"),
+            "error message should mention missing name"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_request_tools_call_invalid_arguments() {
+        let (_db, conn) = crate::test_helpers::test_db().await;
+        let req = json!({
+            "method": "tools/call",
+            "params": {"name": "mempalace_status", "arguments": "string"},
+            "id": 7
+        });
+        let resp = handle_request(&conn, &req)
+            .await
+            .expect("should return Some");
+        assert_eq!(resp["error"]["code"], -32602);
+        assert!(
+            resp["error"]["message"]
+                .as_str()
+                .expect("message should be a string")
+                .contains("arguments"),
+            "error message should mention invalid arguments"
+        );
+    }
+
+    // -- run_read_line tests (via generic twin) ------------------------------
+
+    #[tokio::test]
+    async fn read_line_normal() {
+        let cursor = Cursor::new(b"hello\n".to_vec());
+        let mut reader = BufReader::new(cursor);
+        let mut buf = Vec::new();
+        let result = run_read_line_generic(&mut reader, &mut buf, 1024)
+            .await
+            .expect("read should succeed");
+        let LineRead::Line(line) = result else {
+            panic!("expected LineRead::Line, got Overflow or Eof");
+        };
+        assert_eq!(line, "hello");
+        // Verify buffer was used for accumulation.
+        assert_eq!(buf.len(), 5, "buffer should contain 'hello' (5 bytes)");
+    }
+
+    #[tokio::test]
+    async fn read_line_eof() {
+        let cursor = Cursor::new(Vec::new());
+        let mut reader = BufReader::new(cursor);
+        let mut buf = Vec::new();
+        let result = run_read_line_generic(&mut reader, &mut buf, 1024)
+            .await
+            .expect("read should succeed");
+        assert!(
+            matches!(result, LineRead::Eof),
+            "expected Eof on empty input"
+        );
+        assert!(buf.is_empty(), "buffer should remain empty on EOF");
+    }
+
+    #[tokio::test]
+    async fn read_line_overflow() {
+        // Line exceeds the limit — should return Overflow.
+        let limit = 10;
+        let long_line = "a".repeat(limit + 5) + "\n";
+        let cursor = Cursor::new(long_line.into_bytes());
+        let mut reader = BufReader::new(cursor);
+        let mut buf = Vec::new();
+        let result = run_read_line_generic(&mut reader, &mut buf, limit)
+            .await
+            .expect("read should succeed");
+        assert!(
+            matches!(result, LineRead::Overflow),
+            "expected Overflow for line exceeding limit"
+        );
+        // After overflow, the reader should have consumed past the newline,
+        // so a subsequent read on empty remaining data should return Eof.
+        buf.clear();
+        let next = run_read_line_generic(&mut reader, &mut buf, limit)
+            .await
+            .expect("second read should succeed");
+        assert!(
+            matches!(next, LineRead::Eof),
+            "stream should be at EOF after overflow drain"
+        );
+    }
+
+    #[tokio::test]
+    async fn read_line_crlf_stripped() {
+        let cursor = Cursor::new(b"hello\r\n".to_vec());
+        let mut reader = BufReader::new(cursor);
+        let mut buf = Vec::new();
+        let result = run_read_line_generic(&mut reader, &mut buf, 1024)
+            .await
+            .expect("read should succeed");
+        let LineRead::Line(line) = result else {
+            panic!("expected LineRead::Line, got Overflow or Eof");
+        };
+        assert_eq!(line, "hello", "\\r\\n should be stripped to just 'hello'");
+        // Buffer should have 'hello' without the \r.
+        assert_eq!(buf.len(), 5, "buffer should be 5 bytes after \\r strip");
+    }
 }

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -8,10 +8,10 @@
 pub mod protocol;
 pub mod tools;
 
-use futures_util::StreamExt;
+use std::pin::Pin;
+
 use serde_json::{Value, json};
-use tokio::io::AsyncWriteExt;
-use tokio_util::codec::{FramedRead, LinesCodec, LinesCodecError};
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWriteExt, BufReader};
 use turso::Connection;
 
 use crate::error::Result;
@@ -24,22 +24,29 @@ const SUPPORTED_PROTOCOL_VERSIONS: &[&str] =
 /// before any validation runs. 1 MiB comfortably fits any real tool payload.
 const MAX_REQUEST_BYTES: usize = 1024 * 1024; // 1 MiB
 
+/// Outcome of reading a single newline-delimited frame from the buffered reader.
+enum LineRead {
+    /// A complete line was read (trailing newline stripped).
+    Line(String),
+    /// The line exceeded the byte limit — stream resynced past the next newline.
+    Overflow,
+    /// End-of-stream — stdin closed.
+    Eof,
+}
+
 /// Run the MCP server: read JSON-RPC 2.0 requests from stdin, write responses to stdout.
 pub async fn run(connection: &Connection) -> Result<()> {
     let stdin = tokio::io::stdin();
     let mut stdout = tokio::io::stdout();
-    // LinesCodec rejects frames at the framing layer — overlong bytes are never
-    // buffered beyond MAX_REQUEST_BYTES before the error is returned, preventing
-    // memory exhaustion from a client-controlled line. The codec automatically
-    // drains to the next newline after an oversize frame so the stream resyncs.
-    let mut framed = FramedRead::new(stdin, LinesCodec::new_with_max_length(MAX_REQUEST_BYTES));
+    let mut reader = BufReader::new(stdin);
+    // Reusable buffer for line reading — allocated once, cleared each iteration.
+    let mut line_buffer: Vec<u8> = Vec::with_capacity(4096);
 
-    // Intentional server loop: runs until stdin closes (None signals EOF).
+    // Intentional server loop: runs until stdin closes (Eof signals EOF).
     loop {
-        let item = framed.next().await;
-        let line = match item {
-            None => break, // EOF — client disconnected.
-            Some(Err(LinesCodecError::MaxLineLengthExceeded)) => {
+        let line = match run_read_line(&mut reader, &mut line_buffer, MAX_REQUEST_BYTES).await {
+            Ok(LineRead::Eof) => break, // Client disconnected.
+            Ok(LineRead::Overflow) => {
                 let err_response = json!({
                     "jsonrpc": "2.0",
                     "id": null,
@@ -51,8 +58,8 @@ pub async fn run(connection: &Connection) -> Result<()> {
                 stdout.flush().await?;
                 continue;
             }
-            Some(Err(LinesCodecError::Io(e))) => return Err(e.into()),
-            Some(Ok(line)) => line,
+            Err(e) => return Err(e.into()),
+            Ok(LineRead::Line(line)) => line,
         };
 
         let trimmed = line.trim();
@@ -87,6 +94,98 @@ pub async fn run(connection: &Connection) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Read one newline-delimited line from stdin, enforcing a hard byte limit.
+///
+/// Prevents OOM by never buffering more than `limit` bytes from a client-controlled
+/// line. On overflow, drains forward to the next newline so the stream resyncs
+/// for subsequent reads (same resync behavior as `LinesCodec`).
+async fn run_read_line(
+    reader: &mut BufReader<tokio::io::Stdin>,
+    buffer: &mut Vec<u8>,
+    limit: usize,
+) -> std::io::Result<LineRead> {
+    assert!(limit > 0);
+    buffer.clear();
+
+    loop {
+        let available = reader.fill_buf().await?;
+
+        // EOF: return accumulated buffer or signal end-of-stream.
+        if available.is_empty() {
+            if buffer.is_empty() {
+                return Ok(LineRead::Eof);
+            }
+            debug_assert!(buffer.len() <= limit);
+            let line = String::from_utf8_lossy(buffer).into_owned();
+            return Ok(LineRead::Line(line));
+        }
+
+        let chunk_length = available.len();
+
+        if let Some(newline_index) = available.iter().position(|&b| b == b'\n') {
+            let within_limit = buffer.len() + newline_index <= limit;
+            if within_limit {
+                buffer.extend_from_slice(&available[..newline_index]);
+            }
+            // Last use of `available` — immutable borrow on reader ends here.
+            Pin::new(&mut *reader).consume(newline_index + 1);
+
+            if !within_limit {
+                return Ok(LineRead::Overflow);
+            }
+
+            // Strip trailing \r for \r\n line endings.
+            if buffer.last() == Some(&b'\r') {
+                buffer.pop();
+            }
+            debug_assert!(buffer.len() <= limit);
+            let line = String::from_utf8_lossy(buffer).into_owned();
+            return Ok(LineRead::Line(line));
+        }
+
+        // No newline in this chunk — accumulate if within limit.
+        let within_limit = buffer.len() + chunk_length <= limit;
+        if within_limit {
+            buffer.extend_from_slice(available);
+        }
+        // Last use of `available` — immutable borrow on reader ends here.
+        Pin::new(&mut *reader).consume(chunk_length);
+
+        if !within_limit {
+            // Overlong line with no newline yet — drain to resync.
+            return run_read_line_drain(reader).await;
+        }
+    }
+}
+
+/// Drain bytes from the reader until the next newline or EOF.
+/// Called after detecting an overlong line to resync the stream.
+async fn run_read_line_drain(
+    reader: &mut BufReader<tokio::io::Stdin>,
+) -> std::io::Result<LineRead> {
+    loop {
+        let available = reader.fill_buf().await?;
+        if available.is_empty() {
+            // EOF during drain — still report overflow so the error response is sent.
+            return Ok(LineRead::Overflow);
+        }
+        let chunk_length = available.len();
+        assert!(chunk_length > 0); // Progress guarantee: non-empty after EOF check.
+        let newline_position = available.iter().position(|&b| b == b'\n');
+        let consume_count = match newline_position {
+            Some(index) => index + 1,
+            None => chunk_length,
+        };
+        assert!(consume_count > 0); // Forward progress: always consume at least one byte.
+        // Last use of `available` — immutable borrow on reader ends here.
+        Pin::new(&mut *reader).consume(consume_count);
+
+        if newline_position.is_some() {
+            return Ok(LineRead::Overflow);
+        }
+    }
 }
 
 async fn handle_request(connection: &Connection, request: &Value) -> Option<Value> {

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -445,6 +445,24 @@ mod tests {
             .as_array()
             .expect("tools should be an array");
         assert!(!tools.is_empty(), "tools list must not be empty");
+        // Every entry must be an object with the required MCP tool keys.
+        for tool in tools {
+            assert!(tool.is_object(), "each tool must be a JSON object");
+            assert!(tool.get("name").is_some(), "each tool must have a 'name'");
+            assert!(
+                tool.get("description").is_some(),
+                "each tool must have a 'description'"
+            );
+            assert!(
+                tool.get("inputSchema").is_some(),
+                "each tool must have an 'inputSchema'"
+            );
+        }
+        // At least one well-known tool must be present.
+        assert!(
+            tools.iter().any(|t| t["name"] == "mempalace_status"),
+            "tools list must include 'mempalace_status'"
+        );
     }
 
     #[tokio::test]

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -106,6 +106,16 @@ async fn run_read_line(
     buffer: &mut Vec<u8>,
     limit: usize,
 ) -> std::io::Result<LineRead> {
+    run_read_line_impl(reader, buffer, limit).await
+}
+
+/// Generic core of `run_read_line` — accepts any `AsyncBufRead` so tests can
+/// drive the algorithm with a `Cursor` rather than a real stdin handle.
+async fn run_read_line_impl<R: AsyncBufRead + Unpin>(
+    reader: &mut R,
+    buffer: &mut Vec<u8>,
+    limit: usize,
+) -> std::io::Result<LineRead> {
     assert!(limit > 0);
     buffer.clear();
 
@@ -162,9 +172,7 @@ async fn run_read_line(
 
 /// Drain bytes from the reader until the next newline or EOF.
 /// Called after detecting an overlong line to resync the stream.
-async fn run_read_line_drain(
-    reader: &mut BufReader<tokio::io::Stdin>,
-) -> std::io::Result<LineRead> {
+async fn run_read_line_drain<R: AsyncBufRead + Unpin>(reader: &mut R) -> std::io::Result<LineRead> {
     loop {
         let available = reader.fill_buf().await?;
         if available.is_empty() {
@@ -257,80 +265,6 @@ async fn handle_request(connection: &Connection, request: &Value) -> Option<Valu
             "id": req_id,
             "error": {"code": -32601, "message": format!("Unknown method: {method}")}
         })),
-    }
-}
-
-// Generic version of `run_read_line` for testing — identical algorithm but accepts
-// any AsyncBufRead instead of the concrete Stdin type. Production code calls the
-// Stdin-specific version above; tests exercise this generic twin to verify the
-// line-reading, overflow, and EOF logic without needing a real stdin handle.
-#[cfg(test)]
-async fn run_read_line_generic<R: AsyncBufRead + Unpin>(
-    reader: &mut R,
-    buffer: &mut Vec<u8>,
-    limit: usize,
-) -> std::io::Result<LineRead> {
-    assert!(limit > 0);
-    buffer.clear();
-
-    loop {
-        let available = reader.fill_buf().await?;
-
-        if available.is_empty() {
-            if buffer.is_empty() {
-                return Ok(LineRead::Eof);
-            }
-            debug_assert!(buffer.len() <= limit);
-            let line = String::from_utf8_lossy(buffer).into_owned();
-            return Ok(LineRead::Line(line));
-        }
-
-        let chunk_length = available.len();
-
-        if let Some(newline_index) = available.iter().position(|&b| b == b'\n') {
-            let within_limit = buffer.len() + newline_index <= limit;
-            if within_limit {
-                buffer.extend_from_slice(&available[..newline_index]);
-            }
-            Pin::new(&mut *reader).consume(newline_index + 1);
-
-            if !within_limit {
-                return Ok(LineRead::Overflow);
-            }
-
-            if buffer.last() == Some(&b'\r') {
-                buffer.pop();
-            }
-            debug_assert!(buffer.len() <= limit);
-            let line = String::from_utf8_lossy(buffer).into_owned();
-            return Ok(LineRead::Line(line));
-        }
-
-        let within_limit = buffer.len() + chunk_length <= limit;
-        if within_limit {
-            buffer.extend_from_slice(available);
-        }
-        Pin::new(&mut *reader).consume(chunk_length);
-
-        if !within_limit {
-            // Drain to next newline or EOF for resync.
-            loop {
-                let avail = reader.fill_buf().await?;
-                if avail.is_empty() {
-                    return Ok(LineRead::Overflow);
-                }
-                let clen = avail.len();
-                let nl = avail.iter().position(|&b| b == b'\n');
-                let consume = match nl {
-                    Some(i) => i + 1,
-                    None => clen,
-                };
-                Pin::new(&mut *reader).consume(consume);
-                if nl.is_some() {
-                    return Ok(LineRead::Overflow);
-                }
-            }
-        }
     }
 }
 
@@ -511,7 +445,6 @@ mod tests {
             .as_array()
             .expect("tools should be an array");
         assert!(!tools.is_empty(), "tools list must not be empty");
-        assert_eq!(tools.len(), 26, "expected 26 tool definitions");
     }
 
     #[tokio::test]
@@ -624,14 +557,14 @@ mod tests {
         );
     }
 
-    // -- run_read_line tests (via generic twin) ------------------------------
+    // -- run_read_line tests (via run_read_line_impl) ------------------------
 
     #[tokio::test]
     async fn read_line_normal() {
         let cursor = Cursor::new(b"hello\n".to_vec());
         let mut reader = BufReader::new(cursor);
         let mut buf = Vec::new();
-        let result = run_read_line_generic(&mut reader, &mut buf, 1024)
+        let result = run_read_line_impl(&mut reader, &mut buf, 1024)
             .await
             .expect("read should succeed");
         let LineRead::Line(line) = result else {
@@ -647,7 +580,7 @@ mod tests {
         let cursor = Cursor::new(Vec::new());
         let mut reader = BufReader::new(cursor);
         let mut buf = Vec::new();
-        let result = run_read_line_generic(&mut reader, &mut buf, 1024)
+        let result = run_read_line_impl(&mut reader, &mut buf, 1024)
             .await
             .expect("read should succeed");
         assert!(
@@ -665,7 +598,7 @@ mod tests {
         let cursor = Cursor::new(long_line.into_bytes());
         let mut reader = BufReader::new(cursor);
         let mut buf = Vec::new();
-        let result = run_read_line_generic(&mut reader, &mut buf, limit)
+        let result = run_read_line_impl(&mut reader, &mut buf, limit)
             .await
             .expect("read should succeed");
         assert!(
@@ -675,7 +608,7 @@ mod tests {
         // After overflow, the reader should have consumed past the newline,
         // so a subsequent read on empty remaining data should return Eof.
         buf.clear();
-        let next = run_read_line_generic(&mut reader, &mut buf, limit)
+        let next = run_read_line_impl(&mut reader, &mut buf, limit)
             .await
             .expect("second read should succeed");
         assert!(
@@ -689,7 +622,7 @@ mod tests {
         let cursor = Cursor::new(b"hello\r\n".to_vec());
         let mut reader = BufReader::new(cursor);
         let mut buf = Vec::new();
-        let result = run_read_line_generic(&mut reader, &mut buf, 1024)
+        let result = run_read_line_impl(&mut reader, &mut buf, 1024)
             .await
             .expect("read should succeed");
         let LineRead::Line(line) = result else {

--- a/src/mcp/protocol.rs
+++ b/src/mcp/protocol.rs
@@ -334,3 +334,39 @@ pub fn tool_definitions() -> Vec<serde_json::Value> {
         .expect("json!([...]) is always Value::Array; as_array() cannot return None here")
         .clone()
 }
+
+#[cfg(test)]
+// Test code — .expect() is acceptable with a descriptive message.
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_definitions_count() {
+        let tools = tool_definitions();
+        assert_eq!(tools.len(), 26, "expected 26 tool definitions");
+        // Verify the first and last tool names as a structural sanity check.
+        assert_eq!(tools[0]["name"], "mempalace_status");
+        assert_eq!(tools[25]["name"], "mempalace_follow_tunnels");
+    }
+
+    #[test]
+    fn tool_definitions_all_have_required_fields() {
+        let tools = tool_definitions();
+        for tool in &tools {
+            let name = tool["name"]
+                .as_str()
+                .expect("every tool should have a string 'name'");
+            assert!(
+                tool.get("description").and_then(|v| v.as_str()).is_some(),
+                "tool {name} missing 'description'"
+            );
+            assert!(
+                tool.get("inputSchema")
+                    .and_then(|v| v.as_object())
+                    .is_some(),
+                "tool {name} missing 'inputSchema' object"
+            );
+        }
+    }
+}

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1496,4 +1496,931 @@ mod tests {
         .await;
         assert_eq!(r["success"], false);
     }
+
+    // --- Helper: seed a drawer for tests that need pre-existing data ---
+
+    async fn seed_drawer(connection: &Connection, wing: &str, room: &str, content: &str) -> Value {
+        let args = json!({"wing": wing, "room": room, "content": content});
+        let result = tool_add_drawer(connection, &args).await;
+        assert_eq!(result["success"], true, "seed_drawer must succeed");
+        result
+    }
+
+    // --- tool_status ---
+
+    #[tokio::test]
+    async fn status_empty_db_returns_zero_totals() {
+        let (_db, connection) = test_conn().await;
+        let result = tool_status(&connection).await;
+        assert_eq!(result["total_drawers"], 0);
+        assert!(result["protocol"].is_string(), "protocol must be present");
+    }
+
+    #[tokio::test]
+    async fn status_with_drawers_counts_correctly() {
+        let (_db, connection) = test_conn().await;
+        seed_drawer(&connection, "alpha", "notes", "first drawer content here").await;
+        seed_drawer(&connection, "alpha", "code", "second drawer content here").await;
+        seed_drawer(&connection, "beta", "notes", "third drawer content here").await;
+
+        let result = tool_status(&connection).await;
+        assert_eq!(result["total_drawers"], 3);
+        assert_eq!(result["wings"]["alpha"], 2);
+        assert_eq!(result["wings"]["beta"], 1);
+    }
+
+    // --- tool_list_wings ---
+
+    #[tokio::test]
+    async fn list_wings_empty_db() {
+        let (_db, connection) = test_conn().await;
+        let result = tool_list_wings(&connection).await;
+        let wings = result["wings"].as_object().expect("wings must be object");
+        assert!(wings.is_empty(), "empty DB should have no wings");
+        assert!(result.get("error").is_none(), "must not return error");
+    }
+
+    #[tokio::test]
+    async fn list_wings_with_data() {
+        let (_db, connection) = test_conn().await;
+        seed_drawer(&connection, "personal", "notes", "my personal note content").await;
+        seed_drawer(&connection, "work", "tasks", "my work task content here").await;
+
+        let result = tool_list_wings(&connection).await;
+        let wings = result["wings"].as_object().expect("wings must be object");
+        assert_eq!(wings.len(), 2);
+        assert_eq!(result["wings"]["personal"], 1);
+    }
+
+    // --- tool_list_rooms ---
+
+    #[tokio::test]
+    async fn list_rooms_empty_db() {
+        let (_db, connection) = test_conn().await;
+        let result = tool_list_rooms(&connection, &json!({})).await;
+        let rooms = result["rooms"].as_object().expect("rooms must be object");
+        assert!(rooms.is_empty(), "empty DB should have no rooms");
+        assert_eq!(result["wing"], "all");
+    }
+
+    #[tokio::test]
+    async fn list_rooms_with_wing_filter() {
+        let (_db, connection) = test_conn().await;
+        seed_drawer(&connection, "proj", "code", "some code content here").await;
+        seed_drawer(&connection, "proj", "docs", "some docs content here").await;
+        seed_drawer(&connection, "other", "misc", "other misc content here").await;
+
+        let result = tool_list_rooms(&connection, &json!({"wing": "proj"})).await;
+        let rooms = result["rooms"].as_object().expect("rooms must be object");
+        assert_eq!(rooms.len(), 2);
+        assert_eq!(result["wing"], "proj");
+    }
+
+    // --- tool_get_taxonomy ---
+
+    #[tokio::test]
+    async fn get_taxonomy_empty_db() {
+        let (_db, connection) = test_conn().await;
+        let result = tool_get_taxonomy(&connection).await;
+        let taxonomy = result["taxonomy"]
+            .as_object()
+            .expect("taxonomy must be object");
+        assert!(taxonomy.is_empty(), "empty DB should have no taxonomy");
+        assert!(result.get("error").is_none(), "must not return error");
+    }
+
+    #[tokio::test]
+    async fn get_taxonomy_with_data() {
+        let (_db, connection) = test_conn().await;
+        seed_drawer(
+            &connection,
+            "proj",
+            "code",
+            "code content for taxonomy test",
+        )
+        .await;
+        seed_drawer(
+            &connection,
+            "proj",
+            "docs",
+            "docs content for taxonomy test",
+        )
+        .await;
+
+        let result = tool_get_taxonomy(&connection).await;
+        let taxonomy = result["taxonomy"]
+            .as_object()
+            .expect("taxonomy must be object");
+        assert!(taxonomy.contains_key("proj"), "must contain proj wing");
+        assert_eq!(result["taxonomy"]["proj"]["code"], 1);
+    }
+
+    // --- tool_search ---
+
+    #[tokio::test]
+    async fn search_empty_query_returns_error() {
+        let (_db, connection) = test_conn().await;
+        let result = tool_search(&connection, &json!({"query": ""})).await;
+        assert!(
+            result["error"].is_string(),
+            "must return error for empty query"
+        );
+        assert!(result.get("results").is_none(), "must not return results");
+    }
+
+    #[tokio::test]
+    async fn search_happy_path_returns_results() {
+        let (_db, connection) = test_conn().await;
+        seed_drawer(
+            &connection,
+            "tech",
+            "rust",
+            "rust programming language memory safety ownership borrowing",
+        )
+        .await;
+
+        let result = tool_search(&connection, &json!({"query": "rust programming"})).await;
+        assert!(result.get("error").is_none(), "search must not error");
+        assert!(result["count"].as_i64().expect("count must be int") >= 1);
+    }
+
+    #[tokio::test]
+    async fn search_with_wing_filter() {
+        let (_db, connection) = test_conn().await;
+        seed_drawer(
+            &connection,
+            "tech",
+            "notes",
+            "rust programming language systems",
+        )
+        .await;
+        seed_drawer(
+            &connection,
+            "personal",
+            "notes",
+            "rust belt vacation travel plans",
+        )
+        .await;
+
+        let result = tool_search(&connection, &json!({"query": "rust", "wing": "tech"})).await;
+        assert!(result.get("error").is_none(), "search must not error");
+        // All returned results should be from the "tech" wing
+        let results = result["results"].as_array().expect("results must be array");
+        for r in results {
+            assert_eq!(r["wing"], "tech");
+        }
+    }
+
+    // --- tool_check_duplicate ---
+
+    #[tokio::test]
+    async fn check_duplicate_no_match() {
+        let (_db, connection) = test_conn().await;
+        let result = tool_check_duplicate(
+            &connection,
+            &json!({"content": "completely unique content that has no match"}),
+        )
+        .await;
+        assert_eq!(result["is_duplicate"], false);
+        assert!(
+            result["matches"]
+                .as_array()
+                .expect("matches must be array")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn check_duplicate_with_matching_content() {
+        let (_db, connection) = test_conn().await;
+        seed_drawer(
+            &connection,
+            "tech",
+            "notes",
+            "rust programming language memory safety ownership borrowing lifetimes",
+        )
+        .await;
+
+        // Check with very similar content — duplicate detection uses word overlap
+        let result = tool_check_duplicate(
+            &connection,
+            &json!({"content": "rust programming language memory safety ownership borrowing lifetimes"}),
+        )
+        .await;
+        assert!(result.get("error").is_none(), "must not error");
+        // is_duplicate is present regardless
+        assert!(
+            result.get("is_duplicate").is_some(),
+            "is_duplicate key must exist"
+        );
+    }
+
+    // --- tool_delete_drawer ---
+
+    #[tokio::test]
+    async fn delete_drawer_success() {
+        let (_db, connection) = test_conn().await;
+        let seeded = seed_drawer(&connection, "temp", "notes", "content to be deleted").await;
+        let drawer_id = seeded["drawer_id"]
+            .as_str()
+            .expect("drawer_id must be string");
+
+        let result = tool_delete_drawer(&connection, &json!({"drawer_id": drawer_id})).await;
+        assert_eq!(result["success"], true);
+        assert_eq!(result["drawer_id"], drawer_id);
+    }
+
+    #[tokio::test]
+    async fn delete_drawer_invalid_format() {
+        let (_db, connection) = test_conn().await;
+        let result =
+            tool_delete_drawer(&connection, &json!({"drawer_id": "not_a_drawer_id"})).await;
+        assert_eq!(result["success"], false);
+        assert!(
+            result["error"]
+                .as_str()
+                .expect("error must be string")
+                .contains("invalid format")
+        );
+    }
+
+    // --- tool_get_drawer ---
+
+    #[tokio::test]
+    async fn get_drawer_success() {
+        let (_db, connection) = test_conn().await;
+        let seeded = seed_drawer(&connection, "proj", "code", "fn main for get test").await;
+        let drawer_id = seeded["drawer_id"]
+            .as_str()
+            .expect("drawer_id must be string");
+
+        let result = tool_get_drawer(&connection, &json!({"drawer_id": drawer_id})).await;
+        assert_eq!(result["drawer_id"], drawer_id);
+        assert_eq!(result["content"], "fn main for get test");
+        assert_eq!(result["wing"], "proj");
+    }
+
+    #[tokio::test]
+    async fn get_drawer_not_found() {
+        let (_db, connection) = test_conn().await;
+        let result = tool_get_drawer(
+            &connection,
+            &json!({"drawer_id": "drawer_x_y_aaaaaaaabbbbbbbbcccccccc"}),
+        )
+        .await;
+        assert!(result["error"].is_string(), "must return error");
+        assert!(
+            result["error"]
+                .as_str()
+                .expect("error string")
+                .contains("not found"),
+            "error must mention not found"
+        );
+    }
+
+    // --- tool_list_drawers ---
+
+    #[tokio::test]
+    async fn list_drawers_empty_db() {
+        let (_db, connection) = test_conn().await;
+        let result = tool_list_drawers(&connection, &json!({})).await;
+        assert_eq!(result["count"], 0);
+        assert!(
+            result["drawers"]
+                .as_array()
+                .expect("drawers must be array")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn list_drawers_with_pagination() {
+        let (_db, connection) = test_conn().await;
+        seed_drawer(&connection, "w", "r", "first content for pagination test").await;
+        seed_drawer(&connection, "w", "r", "second content for pagination test").await;
+        seed_drawer(&connection, "w", "r", "third content for pagination test").await;
+
+        // Limit to 2
+        let result = tool_list_drawers(&connection, &json!({"limit": 2})).await;
+        assert_eq!(result["count"], 2);
+        assert_eq!(result["limit"], 2);
+
+        // Offset to get the third
+        let result2 = tool_list_drawers(&connection, &json!({"limit": 2, "offset": 2})).await;
+        assert_eq!(result2["count"], 1);
+        assert_eq!(result2["offset"], 2);
+    }
+
+    #[tokio::test]
+    async fn list_drawers_wing_filter() {
+        let (_db, connection) = test_conn().await;
+        seed_drawer(
+            &connection,
+            "alpha",
+            "notes",
+            "alpha content for filter test",
+        )
+        .await;
+        seed_drawer(&connection, "beta", "notes", "beta content for filter test").await;
+
+        let result = tool_list_drawers(&connection, &json!({"wing": "alpha"})).await;
+        assert_eq!(result["count"], 1);
+        let d = &result["drawers"][0];
+        assert_eq!(d["wing"], "alpha");
+    }
+
+    // --- tool_update_drawer ---
+
+    #[tokio::test]
+    async fn update_drawer_content() {
+        let (_db, connection) = test_conn().await;
+        let seeded = seed_drawer(&connection, "proj", "code", "original content for update").await;
+        let old_id = seeded["drawer_id"]
+            .as_str()
+            .expect("drawer_id must be string");
+
+        let result = tool_update_drawer(
+            &connection,
+            &json!({"drawer_id": old_id, "content": "updated content after mutation"}),
+        )
+        .await;
+        assert_eq!(result["success"], true);
+        // ID changes because content changed (deterministic ID includes content)
+        assert_ne!(
+            result["drawer_id"].as_str().expect("new id"),
+            old_id,
+            "ID must change when content changes"
+        );
+    }
+
+    #[tokio::test]
+    async fn update_drawer_not_found() {
+        let (_db, connection) = test_conn().await;
+        let result = tool_update_drawer(
+            &connection,
+            &json!({
+                "drawer_id": "drawer_x_y_aaaaaaaabbbbbbbbcccccccc",
+                "content": "new content for nonexistent drawer"
+            }),
+        )
+        .await;
+        assert_eq!(result["success"], false);
+        assert!(
+            result["error"]
+                .as_str()
+                .expect("error string")
+                .contains("not found"),
+            "error must mention not found"
+        );
+    }
+
+    #[tokio::test]
+    async fn update_drawer_noop_when_nothing_changes() {
+        let (_db, connection) = test_conn().await;
+        let seeded = seed_drawer(&connection, "proj", "code", "stable content no change").await;
+        let drawer_id = seeded["drawer_id"]
+            .as_str()
+            .expect("drawer_id must be string");
+
+        // Send update with no actual changes
+        let result = tool_update_drawer(&connection, &json!({"drawer_id": drawer_id})).await;
+        assert_eq!(result["success"], true);
+        assert_eq!(result["noop"], true);
+    }
+
+    // --- tool_kg_add ---
+
+    #[tokio::test]
+    async fn kg_add_triple() {
+        let (_db, connection) = test_conn().await;
+        let result = tool_kg_add(
+            &connection,
+            &json!({
+                "subject": "Rust",
+                "predicate": "is",
+                "object": "fast",
+            }),
+        )
+        .await;
+        assert_eq!(result["success"], true);
+        assert!(
+            result["triple_id"].is_string(),
+            "triple_id must be a string"
+        );
+    }
+
+    #[tokio::test]
+    async fn kg_add_missing_field_returns_error() {
+        let (_db, connection) = test_conn().await;
+        // Missing object
+        let result = tool_kg_add(&connection, &json!({"subject": "Rust", "predicate": "is"})).await;
+        assert_eq!(result["success"], false);
+        assert!(result["error"].is_string(), "must return error message");
+    }
+
+    // --- tool_kg_query ---
+
+    #[tokio::test]
+    async fn kg_query_entity() {
+        let (_db, connection) = test_conn().await;
+        // Add a triple first
+        tool_kg_add(
+            &connection,
+            &json!({"subject": "Rust", "predicate": "compilesTo", "object": "binary"}),
+        )
+        .await;
+
+        let result = tool_kg_query(&connection, &json!({"entity": "Rust"})).await;
+        assert!(result.get("error").is_none(), "query must not error");
+        assert_eq!(result["entity"], "Rust");
+        assert!(result["count"].as_i64().expect("count") >= 1);
+    }
+
+    #[tokio::test]
+    async fn kg_query_invalid_direction() {
+        let (_db, connection) = test_conn().await;
+        let result = tool_kg_query(
+            &connection,
+            &json!({"entity": "Rust", "direction": "sideways"}),
+        )
+        .await;
+        assert!(result["error"].is_string(), "must return error");
+        assert!(
+            result["error"]
+                .as_str()
+                .expect("error string")
+                .contains("direction")
+        );
+    }
+
+    // --- tool_kg_invalidate ---
+
+    #[tokio::test]
+    async fn kg_invalidate_triple() {
+        let (_db, connection) = test_conn().await;
+        tool_kg_add(
+            &connection,
+            &json!({"subject": "Alice", "predicate": "worksAt", "object": "Acme"}),
+        )
+        .await;
+
+        let result = tool_kg_invalidate(
+            &connection,
+            &json!({"subject": "Alice", "predicate": "worksAt", "object": "Acme"}),
+        )
+        .await;
+        assert_eq!(result["success"], true);
+        assert!(
+            result["ended"].is_string(),
+            "ended timestamp must be present"
+        );
+    }
+
+    #[tokio::test]
+    async fn kg_invalidate_with_explicit_ended_date() {
+        let (_db, connection) = test_conn().await;
+        tool_kg_add(
+            &connection,
+            &json!({"subject": "Bob", "predicate": "livesIn", "object": "NYC"}),
+        )
+        .await;
+
+        let result = tool_kg_invalidate(
+            &connection,
+            &json!({
+                "subject": "Bob",
+                "predicate": "livesIn",
+                "object": "NYC",
+                "ended": "2025-01-01"
+            }),
+        )
+        .await;
+        assert_eq!(result["success"], true);
+        assert_eq!(result["ended"], "2025-01-01");
+    }
+
+    // --- tool_kg_timeline ---
+
+    #[tokio::test]
+    async fn kg_timeline_empty() {
+        let (_db, connection) = test_conn().await;
+        let result = tool_kg_timeline(&connection, &json!({})).await;
+        assert!(result.get("error").is_none(), "must not error");
+        assert_eq!(result["count"], 0);
+    }
+
+    #[tokio::test]
+    async fn kg_timeline_with_data() {
+        let (_db, connection) = test_conn().await;
+        tool_kg_add(
+            &connection,
+            &json!({"subject": "Eve", "predicate": "knows", "object": "Alice"}),
+        )
+        .await;
+
+        let result = tool_kg_timeline(&connection, &json!({"entity": "Eve"})).await;
+        assert!(result.get("error").is_none(), "must not error");
+        assert!(result["count"].as_i64().expect("count") >= 1);
+    }
+
+    // --- tool_kg_stats ---
+
+    #[tokio::test]
+    async fn kg_stats_empty_db() {
+        let (_db, connection) = test_conn().await;
+        let result = tool_kg_stats(&connection).await;
+        assert!(result.get("error").is_none(), "must not error");
+        assert_eq!(result["entities"], 0);
+        assert_eq!(result["triples"], 0);
+    }
+
+    #[tokio::test]
+    async fn kg_stats_after_adding_triples() {
+        let (_db, connection) = test_conn().await;
+        tool_kg_add(
+            &connection,
+            &json!({"subject": "X", "predicate": "rel", "object": "Y"}),
+        )
+        .await;
+
+        let result = tool_kg_stats(&connection).await;
+        assert!(result.get("error").is_none(), "must not error");
+        assert!(result["triples"].as_i64().expect("triples") >= 1);
+        assert!(result["entities"].as_i64().expect("entities") >= 1);
+    }
+
+    // --- tool_create_tunnel ---
+
+    async fn seed_tunnel(connection: &Connection) -> Value {
+        tool_create_tunnel(
+            connection,
+            &json!({
+                "source_wing": "alpha",
+                "source_room": "code",
+                "target_wing": "beta",
+                "target_room": "docs",
+                "label": "cross-reference link",
+            }),
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn create_tunnel_success() {
+        let (_db, connection) = test_conn().await;
+        let result = seed_tunnel(&connection).await;
+        assert!(result.get("error").is_none(), "must not error");
+        assert!(result["id"].is_string(), "tunnel must have an id");
+        assert_eq!(result["source_wing"], "alpha");
+    }
+
+    #[tokio::test]
+    async fn create_tunnel_missing_label_returns_error() {
+        let (_db, connection) = test_conn().await;
+        let result = tool_create_tunnel(
+            &connection,
+            &json!({
+                "source_wing": "a",
+                "source_room": "b",
+                "target_wing": "c",
+                "target_room": "d",
+            }),
+        )
+        .await;
+        assert_eq!(result["success"], false);
+        assert!(
+            result["error"].is_string(),
+            "must return error for missing label"
+        );
+    }
+
+    // --- tool_list_tunnels ---
+
+    #[tokio::test]
+    async fn list_tunnels_empty() {
+        let (_db, connection) = test_conn().await;
+        let result = tool_list_tunnels(&connection, &json!({})).await;
+        assert!(result.get("error").is_none(), "must not error");
+        assert_eq!(result["count"], 0);
+    }
+
+    #[tokio::test]
+    async fn list_tunnels_after_create() {
+        let (_db, connection) = test_conn().await;
+        seed_tunnel(&connection).await;
+
+        let result = tool_list_tunnels(&connection, &json!({})).await;
+        assert!(result.get("error").is_none(), "must not error");
+        assert!(result["count"].as_i64().expect("count") >= 1);
+    }
+
+    // --- tool_delete_tunnel ---
+
+    #[tokio::test]
+    async fn delete_tunnel_success() {
+        let (_db, connection) = test_conn().await;
+        let tunnel = seed_tunnel(&connection).await;
+        let tunnel_id = tunnel["id"].as_str().expect("tunnel must have id");
+
+        let result = tool_delete_tunnel(&connection, &json!({"tunnel_id": tunnel_id})).await;
+        assert!(result.get("error").is_none(), "delete must not error");
+        assert_eq!(result["deleted"], true);
+    }
+
+    #[tokio::test]
+    async fn delete_tunnel_invalid_id_format() {
+        let (_db, connection) = test_conn().await;
+        let result = tool_delete_tunnel(&connection, &json!({"tunnel_id": "not-valid"})).await;
+        assert!(result["error"].is_string(), "must return error");
+        assert!(
+            result["error"]
+                .as_str()
+                .expect("error string")
+                .contains("16-character hex")
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_tunnel_nonexistent_returns_false() {
+        let (_db, connection) = test_conn().await;
+        // Valid 16-char hex that doesn't exist
+        let result =
+            tool_delete_tunnel(&connection, &json!({"tunnel_id": "0000000000000000"})).await;
+        assert!(result.get("error").is_none(), "must not error");
+        assert_eq!(result["deleted"], false);
+    }
+
+    // --- tool_follow_tunnels ---
+
+    #[tokio::test]
+    async fn follow_tunnels_no_connections() {
+        let (_db, connection) = test_conn().await;
+        let result =
+            tool_follow_tunnels(&connection, &json!({"wing": "alpha", "room": "code"})).await;
+        assert!(result.get("error").is_none(), "must not error");
+        assert!(
+            result["connections"]
+                .as_array()
+                .expect("connections must be array")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn follow_tunnels_with_tunnel() {
+        let (_db, connection) = test_conn().await;
+        seed_tunnel(&connection).await;
+
+        let result =
+            tool_follow_tunnels(&connection, &json!({"wing": "alpha", "room": "code"})).await;
+        assert!(result.get("error").is_none(), "must not error");
+        assert_eq!(result["wing"], "alpha");
+        // Should find at least one connection from the seeded tunnel
+        let conns = result["connections"]
+            .as_array()
+            .expect("connections must be array");
+        assert!(!conns.is_empty(), "must find the seeded tunnel");
+    }
+
+    // --- tool_traverse ---
+
+    #[tokio::test]
+    async fn traverse_empty_graph() {
+        let (_db, connection) = test_conn().await;
+        let result = tool_traverse(&connection, &json!({"start_room": "nonexistent"})).await;
+        assert!(
+            result.get("error").is_none(),
+            "must not error on empty graph"
+        );
+        assert!(result.get("results").is_some(), "must have results key");
+    }
+
+    #[tokio::test]
+    async fn traverse_with_shared_room() {
+        let (_db, connection) = test_conn().await;
+        // Two wings sharing the same room name creates a graph edge
+        seed_drawer(
+            &connection,
+            "alpha",
+            "shared",
+            "alpha shared drawer content",
+        )
+        .await;
+        seed_drawer(&connection, "beta", "shared", "beta shared drawer content").await;
+
+        let result =
+            tool_traverse(&connection, &json!({"start_room": "shared", "max_hops": 1})).await;
+        assert!(result.get("error").is_none(), "must not error");
+        let results = result["results"].as_array().expect("results must be array");
+        assert!(
+            !results.is_empty(),
+            "shared room should yield traversal results"
+        );
+    }
+
+    // --- tool_find_tunnels ---
+
+    #[tokio::test]
+    async fn find_tunnels_empty_graph() {
+        let (_db, connection) = test_conn().await;
+        let result = tool_find_tunnels(&connection, &json!({})).await;
+        assert!(result.get("error").is_none(), "must not error");
+        assert!(
+            result["tunnels"]
+                .as_array()
+                .expect("tunnels must be array")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn find_tunnels_between_wings() {
+        let (_db, connection) = test_conn().await;
+        // Create drawers in two wings sharing a room name
+        seed_drawer(&connection, "alpha", "shared", "alpha shared content here").await;
+        seed_drawer(&connection, "beta", "shared", "beta shared content here").await;
+
+        let result =
+            tool_find_tunnels(&connection, &json!({"wing_a": "alpha", "wing_b": "beta"})).await;
+        assert!(result.get("error").is_none(), "must not error");
+        let tunnels = result["tunnels"].as_array().expect("tunnels must be array");
+        assert!(
+            !tunnels.is_empty(),
+            "wings sharing a room should have tunnels"
+        );
+    }
+
+    // --- tool_graph_stats ---
+
+    #[tokio::test]
+    async fn graph_stats_empty_db() {
+        let (_db, connection) = test_conn().await;
+        let result = tool_graph_stats(&connection).await;
+        assert!(result.get("error").is_none(), "must not error");
+        assert_eq!(result["total_rooms"], 0);
+        assert_eq!(result["total_edges"], 0);
+    }
+
+    #[tokio::test]
+    async fn graph_stats_with_data() {
+        let (_db, connection) = test_conn().await;
+        seed_drawer(&connection, "alpha", "notes", "alpha notes for graph stats").await;
+        seed_drawer(&connection, "beta", "notes", "beta notes for graph stats").await;
+
+        let result = tool_graph_stats(&connection).await;
+        assert!(result.get("error").is_none(), "must not error");
+        assert!(
+            result["total_rooms"].as_i64().expect("total_rooms") >= 1,
+            "must count at least one room"
+        );
+    }
+
+    // --- tool_diary_write ---
+
+    #[tokio::test]
+    async fn diary_write_success() {
+        let (_db, connection) = test_conn().await;
+        let result = tool_diary_write(
+            &connection,
+            &json!({
+                "agent_name": "TestAgent",
+                "entry": "Today I learned about Rust lifetimes and borrowing",
+            }),
+        )
+        .await;
+        assert_eq!(result["success"], true);
+        assert!(result["entry_id"].is_string(), "must return entry_id");
+        assert_eq!(result["agent"], "TestAgent");
+        assert_eq!(result["topic"], "general");
+    }
+
+    #[tokio::test]
+    async fn diary_write_with_topic() {
+        let (_db, connection) = test_conn().await;
+        let result = tool_diary_write(
+            &connection,
+            &json!({
+                "agent_name": "TestAgent",
+                "entry": "Debugging session notes about async runtime",
+                "topic": "debugging",
+            }),
+        )
+        .await;
+        assert_eq!(result["success"], true);
+        assert_eq!(result["topic"], "debugging");
+    }
+
+    #[tokio::test]
+    async fn diary_write_missing_entry_returns_error() {
+        let (_db, connection) = test_conn().await;
+        let result = tool_diary_write(&connection, &json!({"agent_name": "TestAgent"})).await;
+        assert_eq!(result["success"], false);
+        assert!(result["error"].is_string(), "must return error");
+    }
+
+    // --- tool_diary_read ---
+
+    #[tokio::test]
+    async fn diary_read_empty() {
+        let (_db, connection) = test_conn().await;
+        let result = tool_diary_read(&connection, &json!({"agent_name": "TestAgent"})).await;
+        assert!(result.get("error").is_none(), "must not error");
+        assert_eq!(result["total"], 0);
+        assert_eq!(result["agent"], "TestAgent");
+    }
+
+    #[tokio::test]
+    async fn diary_read_after_write() {
+        let (_db, connection) = test_conn().await;
+        tool_diary_write(
+            &connection,
+            &json!({
+                "agent_name": "TestAgent",
+                "entry": "diary entry content for read test",
+                "topic": "testing",
+            }),
+        )
+        .await;
+
+        let result = tool_diary_read(&connection, &json!({"agent_name": "TestAgent"})).await;
+        assert!(result.get("error").is_none(), "must not error");
+        assert_eq!(result["total"], 1);
+        let entries = result["entries"].as_array().expect("entries must be array");
+        assert_eq!(entries[0]["topic"], "testing");
+    }
+
+    // --- dispatch ---
+
+    #[tokio::test]
+    async fn dispatch_unknown_tool_returns_error() {
+        let (_db, connection) = test_conn().await;
+        let result = dispatch(&connection, "nonexistent_tool", &json!({})).await;
+        assert!(result["error"].is_string(), "must return error");
+        assert!(
+            result["error"]
+                .as_str()
+                .expect("error string")
+                .contains("Unknown tool")
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_empty_name_returns_error() {
+        let (_db, connection) = test_conn().await;
+        let result = dispatch(&connection, "", &json!({})).await;
+        assert!(
+            result["error"].is_string(),
+            "must return error for empty name"
+        );
+        assert!(
+            result["error"]
+                .as_str()
+                .expect("error string")
+                .contains("empty")
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_non_object_args_returns_error() {
+        let (_db, connection) = test_conn().await;
+        let result = dispatch(&connection, "mempalace_status", &json!("not an object")).await;
+        assert!(
+            result["error"].is_string(),
+            "must return error for non-object args"
+        );
+        assert!(
+            result["error"]
+                .as_str()
+                .expect("error string")
+                .contains("JSON object")
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_routes_to_correct_tool() {
+        let (_db, connection) = test_conn().await;
+        let result = dispatch(&connection, "mempalace_status", &json!({})).await;
+        // tool_status returns total_drawers, proving it was routed correctly
+        assert!(
+            result.get("total_drawers").is_some(),
+            "must route to tool_status"
+        );
+        assert!(
+            result.get("protocol").is_some(),
+            "status must include protocol"
+        );
+    }
+
+    // --- get_aaak_spec (via dispatch) ---
+
+    #[tokio::test]
+    async fn get_aaak_spec_returns_non_empty() {
+        let (_db, connection) = test_conn().await;
+        let result = dispatch(&connection, "mempalace_get_aaak_spec", &json!({})).await;
+        let spec = result["aaak_spec"]
+            .as_str()
+            .expect("aaak_spec must be string");
+        assert!(!spec.is_empty(), "spec must not be empty");
+        assert!(spec.contains("AAAK"), "spec must mention AAAK");
+    }
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1396,9 +1396,7 @@ mod tests {
     #[tokio::test]
     async fn add_drawer_inserts_and_returns_success() {
         // Each test gets its own temp dir so WAL writes are isolated.
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             let args = json!({
                 "wing": "personal",
                 "room": "notes",
@@ -1422,9 +1420,7 @@ mod tests {
 
     #[tokio::test]
     async fn add_drawer_idempotent_returns_already_exists() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             let args = json!({
                 "wing": "personal",
                 "room": "notes",
@@ -1444,9 +1440,7 @@ mod tests {
 
     #[tokio::test]
     async fn add_drawer_deterministic_id_same_content() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             // Verify the ID is derived from sha256(wing+room+content)[:24].
             let content = "fn main() { println!(\"hello\"); }";
             let args = json!({
@@ -1473,9 +1467,7 @@ mod tests {
 
     #[tokio::test]
     async fn add_drawer_different_content_different_id() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             let ra = tool_add_drawer(
                 &connection,
                 &json!({"wing": "w", "room": "r", "content": "first piece of content"}),
@@ -1493,10 +1485,7 @@ mod tests {
 
     #[tokio::test]
     async fn add_drawer_missing_required_fields_returns_error() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
-
+        with_isolated_env(|connection| async move {
             // Missing content
             let r = tool_add_drawer(&connection, &json!({"wing": "w", "room": "r"})).await;
             assert_eq!(r["success"], false);
@@ -1529,13 +1518,29 @@ mod tests {
         result
     }
 
+    // --- Helper: isolated WAL dir + env override + fresh connection ---
+
+    // Wraps the three-line test setup (tempdir, async_with_vars, test_conn) so
+    // callers only express what is under test.  The connection is passed by value
+    // so the closure can borrow it as `&connection` without lifetime complications.
+    async fn with_isolated_env<F, Fut>(test: F)
+    where
+        F: FnOnce(turso::Connection) -> Fut,
+        Fut: std::future::Future<Output = ()>,
+    {
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async move {
+            let (_db, connection) = test_conn().await;
+            test(connection).await;
+        })
+        .await;
+    }
+
     // --- tool_status ---
 
     #[tokio::test]
     async fn status_empty_db_returns_zero_totals() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             let result = tool_status(&connection).await;
             assert_eq!(result["total_drawers"], 0);
             assert!(result["protocol"].is_string(), "protocol must be present");
@@ -1545,9 +1550,7 @@ mod tests {
 
     #[tokio::test]
     async fn status_with_drawers_counts_correctly() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             seed_drawer(&connection, "alpha", "notes", "first drawer content here").await;
             seed_drawer(&connection, "alpha", "code", "second drawer content here").await;
             seed_drawer(&connection, "beta", "notes", "third drawer content here").await;
@@ -1564,9 +1567,7 @@ mod tests {
 
     #[tokio::test]
     async fn list_wings_empty_db() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             let result = tool_list_wings(&connection).await;
             let wings = result["wings"].as_object().expect("wings must be object");
             assert!(wings.is_empty(), "empty DB should have no wings");
@@ -1577,9 +1578,7 @@ mod tests {
 
     #[tokio::test]
     async fn list_wings_with_data() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             seed_drawer(&connection, "personal", "notes", "my personal note content").await;
             seed_drawer(&connection, "work", "tasks", "my work task content here").await;
 
@@ -1595,9 +1594,7 @@ mod tests {
 
     #[tokio::test]
     async fn list_rooms_empty_db() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             let result = tool_list_rooms(&connection, &json!({})).await;
             let rooms = result["rooms"].as_object().expect("rooms must be object");
             assert!(rooms.is_empty(), "empty DB should have no rooms");
@@ -1608,9 +1605,7 @@ mod tests {
 
     #[tokio::test]
     async fn list_rooms_with_wing_filter() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             seed_drawer(&connection, "proj", "code", "some code content here").await;
             seed_drawer(&connection, "proj", "docs", "some docs content here").await;
             seed_drawer(&connection, "other", "misc", "other misc content here").await;
@@ -1627,9 +1622,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_taxonomy_empty_db() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             let result = tool_get_taxonomy(&connection).await;
             let taxonomy = result["taxonomy"]
                 .as_object()
@@ -1642,9 +1635,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_taxonomy_with_data() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             seed_drawer(
                 &connection,
                 "proj",
@@ -1674,9 +1665,7 @@ mod tests {
 
     #[tokio::test]
     async fn search_empty_query_returns_error() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             let result = tool_search(&connection, &json!({"query": ""})).await;
             assert!(
                 result["error"].is_string(),
@@ -1689,9 +1678,7 @@ mod tests {
 
     #[tokio::test]
     async fn search_happy_path_returns_results() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             seed_drawer(
                 &connection,
                 "tech",
@@ -1709,9 +1696,7 @@ mod tests {
 
     #[tokio::test]
     async fn search_with_wing_filter() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             seed_drawer(
                 &connection,
                 "tech",
@@ -1742,9 +1727,7 @@ mod tests {
 
     #[tokio::test]
     async fn check_duplicate_no_match() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             let result = tool_check_duplicate(
                 &connection,
                 &json!({"content": "completely unique content that has no match"}),
@@ -1763,9 +1746,7 @@ mod tests {
 
     #[tokio::test]
     async fn check_duplicate_with_matching_content() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             seed_drawer(
                 &connection,
                 "tech",
@@ -1794,9 +1775,7 @@ mod tests {
 
     #[tokio::test]
     async fn delete_drawer_success() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             let seeded = seed_drawer(&connection, "temp", "notes", "content to be deleted").await;
             let drawer_id = seeded["drawer_id"]
                 .as_str()
@@ -1811,9 +1790,7 @@ mod tests {
 
     #[tokio::test]
     async fn delete_drawer_invalid_format() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             let result =
                 tool_delete_drawer(&connection, &json!({"drawer_id": "not_a_drawer_id"})).await;
             assert_eq!(result["success"], false);
@@ -1831,9 +1808,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_drawer_success() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             let seeded = seed_drawer(&connection, "proj", "code", "fn main for get test").await;
             let drawer_id = seeded["drawer_id"]
                 .as_str()
@@ -1849,9 +1824,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_drawer_not_found() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             let result = tool_get_drawer(
                 &connection,
                 &json!({"drawer_id": "drawer_x_y_aaaaaaaabbbbbbbbcccccccc"}),
@@ -1873,9 +1846,7 @@ mod tests {
 
     #[tokio::test]
     async fn list_drawers_empty_db() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             let result = tool_list_drawers(&connection, &json!({})).await;
             assert_eq!(result["count"], 0);
             assert!(
@@ -1890,9 +1861,7 @@ mod tests {
 
     #[tokio::test]
     async fn list_drawers_with_pagination() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             seed_drawer(&connection, "w", "r", "first content for pagination test").await;
             seed_drawer(&connection, "w", "r", "second content for pagination test").await;
             seed_drawer(&connection, "w", "r", "third content for pagination test").await;
@@ -1912,9 +1881,7 @@ mod tests {
 
     #[tokio::test]
     async fn list_drawers_wing_filter() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             seed_drawer(
                 &connection,
                 "alpha",
@@ -1936,9 +1903,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_drawer_content() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             let seeded =
                 seed_drawer(&connection, "proj", "code", "original content for update").await;
             let old_id = seeded["drawer_id"]
@@ -1963,9 +1928,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_drawer_not_found() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             let result = tool_update_drawer(
                 &connection,
                 &json!({
@@ -1988,9 +1951,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_drawer_noop_when_nothing_changes() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             let seeded = seed_drawer(&connection, "proj", "code", "stable content no change").await;
             let drawer_id = seeded["drawer_id"]
                 .as_str()
@@ -2008,9 +1969,7 @@ mod tests {
 
     #[tokio::test]
     async fn kg_add_triple() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             let result = tool_kg_add(
                 &connection,
                 &json!({
@@ -2031,9 +1990,7 @@ mod tests {
 
     #[tokio::test]
     async fn kg_add_missing_field_returns_error() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             // Missing object
             let result =
                 tool_kg_add(&connection, &json!({"subject": "Rust", "predicate": "is"})).await;
@@ -2047,9 +2004,7 @@ mod tests {
 
     #[tokio::test]
     async fn kg_query_entity() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             // Add a triple first
             tool_kg_add(
                 &connection,
@@ -2067,9 +2022,7 @@ mod tests {
 
     #[tokio::test]
     async fn kg_query_invalid_direction() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             let result = tool_kg_query(
                 &connection,
                 &json!({"entity": "Rust", "direction": "sideways"}),
@@ -2090,9 +2043,7 @@ mod tests {
 
     #[tokio::test]
     async fn kg_invalidate_triple() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             tool_kg_add(
                 &connection,
                 &json!({"subject": "Alice", "predicate": "worksAt", "object": "Acme"}),
@@ -2115,9 +2066,7 @@ mod tests {
 
     #[tokio::test]
     async fn kg_invalidate_with_explicit_ended_date() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             tool_kg_add(
                 &connection,
                 &json!({"subject": "Bob", "predicate": "livesIn", "object": "NYC"}),
@@ -2144,9 +2093,7 @@ mod tests {
 
     #[tokio::test]
     async fn kg_timeline_empty() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             let result = tool_kg_timeline(&connection, &json!({})).await;
             assert!(result.get("error").is_none(), "must not error");
             assert_eq!(result["count"], 0);
@@ -2156,9 +2103,7 @@ mod tests {
 
     #[tokio::test]
     async fn kg_timeline_with_data() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             tool_kg_add(
                 &connection,
                 &json!({"subject": "Eve", "predicate": "knows", "object": "Alice"}),
@@ -2176,9 +2121,7 @@ mod tests {
 
     #[tokio::test]
     async fn kg_stats_empty_db() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             let result = tool_kg_stats(&connection).await;
             assert!(result.get("error").is_none(), "must not error");
             assert_eq!(result["entities"], 0);
@@ -2189,9 +2132,7 @@ mod tests {
 
     #[tokio::test]
     async fn kg_stats_after_adding_triples() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             tool_kg_add(
                 &connection,
                 &json!({"subject": "X", "predicate": "rel", "object": "Y"}),
@@ -2224,9 +2165,7 @@ mod tests {
 
     #[tokio::test]
     async fn create_tunnel_success() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             let result = seed_tunnel(&connection).await;
             assert!(result.get("error").is_none(), "must not error");
             assert!(result["id"].is_string(), "tunnel must have an id");
@@ -2237,9 +2176,7 @@ mod tests {
 
     #[tokio::test]
     async fn create_tunnel_missing_label_returns_error() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             let result = tool_create_tunnel(
                 &connection,
                 &json!({
@@ -2263,9 +2200,7 @@ mod tests {
 
     #[tokio::test]
     async fn list_tunnels_empty() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             let result = tool_list_tunnels(&connection, &json!({})).await;
             assert!(result.get("error").is_none(), "must not error");
             assert_eq!(result["count"], 0);
@@ -2275,9 +2210,7 @@ mod tests {
 
     #[tokio::test]
     async fn list_tunnels_after_create() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             seed_tunnel(&connection).await;
 
             let result = tool_list_tunnels(&connection, &json!({})).await;
@@ -2291,9 +2224,7 @@ mod tests {
 
     #[tokio::test]
     async fn delete_tunnel_success() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             let tunnel = seed_tunnel(&connection).await;
             let tunnel_id = tunnel["id"].as_str().expect("tunnel must have id");
 
@@ -2306,9 +2237,7 @@ mod tests {
 
     #[tokio::test]
     async fn delete_tunnel_invalid_id_format() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             let result = tool_delete_tunnel(&connection, &json!({"tunnel_id": "not-valid"})).await;
             assert!(result["error"].is_string(), "must return error");
             assert!(
@@ -2323,9 +2252,7 @@ mod tests {
 
     #[tokio::test]
     async fn delete_tunnel_nonexistent_returns_false() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             // Valid 16-char hex that doesn't exist
             let result =
                 tool_delete_tunnel(&connection, &json!({"tunnel_id": "0000000000000000"})).await;
@@ -2339,9 +2266,7 @@ mod tests {
 
     #[tokio::test]
     async fn follow_tunnels_no_connections() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             let result =
                 tool_follow_tunnels(&connection, &json!({"wing": "alpha", "room": "code"})).await;
             assert!(result.get("error").is_none(), "must not error");
@@ -2357,9 +2282,7 @@ mod tests {
 
     #[tokio::test]
     async fn follow_tunnels_with_tunnel() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             seed_tunnel(&connection).await;
 
             let result =
@@ -2379,9 +2302,7 @@ mod tests {
 
     #[tokio::test]
     async fn traverse_empty_graph() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             let result = tool_traverse(&connection, &json!({"start_room": "nonexistent"})).await;
             assert!(
                 result.get("error").is_none(),
@@ -2394,9 +2315,7 @@ mod tests {
 
     #[tokio::test]
     async fn traverse_with_shared_room() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             // Two wings sharing the same room name creates a graph edge
             seed_drawer(
                 &connection,
@@ -2423,9 +2342,7 @@ mod tests {
 
     #[tokio::test]
     async fn find_tunnels_empty_graph() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             let result = tool_find_tunnels(&connection, &json!({})).await;
             assert!(result.get("error").is_none(), "must not error");
             assert!(
@@ -2440,9 +2357,7 @@ mod tests {
 
     #[tokio::test]
     async fn find_tunnels_between_wings() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             // Create drawers in two wings sharing a room name
             seed_drawer(&connection, "alpha", "shared", "alpha shared content here").await;
             seed_drawer(&connection, "beta", "shared", "beta shared content here").await;
@@ -2463,9 +2378,7 @@ mod tests {
 
     #[tokio::test]
     async fn graph_stats_empty_db() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             let result = tool_graph_stats(&connection).await;
             assert!(result.get("error").is_none(), "must not error");
             assert_eq!(result["total_rooms"], 0);
@@ -2476,9 +2389,7 @@ mod tests {
 
     #[tokio::test]
     async fn graph_stats_with_data() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             seed_drawer(&connection, "alpha", "notes", "alpha notes for graph stats").await;
             seed_drawer(&connection, "beta", "notes", "beta notes for graph stats").await;
 
@@ -2496,9 +2407,7 @@ mod tests {
 
     #[tokio::test]
     async fn diary_write_success() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             let result = tool_diary_write(
                 &connection,
                 &json!({
@@ -2517,9 +2426,7 @@ mod tests {
 
     #[tokio::test]
     async fn diary_write_with_topic() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             let result = tool_diary_write(
                 &connection,
                 &json!({
@@ -2537,9 +2444,7 @@ mod tests {
 
     #[tokio::test]
     async fn diary_write_missing_entry_returns_error() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             let result = tool_diary_write(&connection, &json!({"agent_name": "TestAgent"})).await;
             assert_eq!(result["success"], false);
             assert!(result["error"].is_string(), "must return error");
@@ -2551,9 +2456,7 @@ mod tests {
 
     #[tokio::test]
     async fn diary_read_empty() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             let result = tool_diary_read(&connection, &json!({"agent_name": "TestAgent"})).await;
             assert!(result.get("error").is_none(), "must not error");
             assert_eq!(result["total"], 0);
@@ -2564,9 +2467,7 @@ mod tests {
 
     #[tokio::test]
     async fn diary_read_after_write() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             tool_diary_write(
                 &connection,
                 &json!({
@@ -2590,9 +2491,7 @@ mod tests {
 
     #[tokio::test]
     async fn dispatch_unknown_tool_returns_error() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             let result = dispatch(&connection, "nonexistent_tool", &json!({})).await;
             assert!(result["error"].is_string(), "must return error");
             assert!(
@@ -2607,9 +2506,7 @@ mod tests {
 
     #[tokio::test]
     async fn dispatch_empty_name_returns_error() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             let result = dispatch(&connection, "", &json!({})).await;
             assert!(
                 result["error"].is_string(),
@@ -2627,9 +2524,7 @@ mod tests {
 
     #[tokio::test]
     async fn dispatch_non_object_args_returns_error() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             let result = dispatch(&connection, "mempalace_status", &json!("not an object")).await;
             assert!(
                 result["error"].is_string(),
@@ -2647,9 +2542,7 @@ mod tests {
 
     #[tokio::test]
     async fn dispatch_routes_to_correct_tool() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             let result = dispatch(&connection, "mempalace_status", &json!({})).await;
             // tool_status returns total_drawers, proving it was routed correctly
             assert!(
@@ -2668,9 +2561,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_aaak_spec_returns_non_empty() {
-        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
-        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
-            let (_db, connection) = test_conn().await;
+        with_isolated_env(|connection| async move {
             let result = dispatch(&connection, "mempalace_get_aaak_spec", &json!({})).await;
             let spec = result["aaak_spec"]
                 .as_str()

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1395,108 +1395,129 @@ mod tests {
 
     #[tokio::test]
     async fn add_drawer_inserts_and_returns_success() {
-        let (_db, connection) = test_conn().await;
-        let args = json!({
-            "wing": "personal",
-            "room": "notes",
-            "content": "the quick brown fox jumps over the lazy dog",
-        });
-        let result = tool_add_drawer(&connection, &args).await;
-        assert_eq!(result["success"], true);
-        assert!(
-            result["drawer_id"]
-                .as_str()
-                .expect("drawer_id must be a string")
-                .starts_with("drawer_personal_notes_")
-        );
-        assert!(
-            result.get("reason").is_none(),
-            "fresh insert must not carry a reason"
-        );
+        // Each test gets its own temp dir so WAL writes are isolated.
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            let args = json!({
+                "wing": "personal",
+                "room": "notes",
+                "content": "the quick brown fox jumps over the lazy dog",
+            });
+            let result = tool_add_drawer(&connection, &args).await;
+            assert_eq!(result["success"], true);
+            assert!(
+                result["drawer_id"]
+                    .as_str()
+                    .expect("drawer_id must be a string")
+                    .starts_with("drawer_personal_notes_")
+            );
+            assert!(
+                result.get("reason").is_none(),
+                "fresh insert must not carry a reason"
+            );
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn add_drawer_idempotent_returns_already_exists() {
-        let (_db, connection) = test_conn().await;
-        let args = json!({
-            "wing": "personal",
-            "room": "notes",
-            "content": "idempotent content for testing",
-        });
-        let first = tool_add_drawer(&connection, &args).await;
-        assert_eq!(first["success"], true);
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            let args = json!({
+                "wing": "personal",
+                "room": "notes",
+                "content": "idempotent content for testing",
+            });
+            let first = tool_add_drawer(&connection, &args).await;
+            assert_eq!(first["success"], true);
 
-        let second = tool_add_drawer(&connection, &args).await;
-        assert_eq!(second["success"], true);
-        assert_eq!(second["reason"], "already_exists");
-        // The same deterministic ID must be returned both times.
-        assert_eq!(first["drawer_id"], second["drawer_id"]);
+            let second = tool_add_drawer(&connection, &args).await;
+            assert_eq!(second["success"], true);
+            assert_eq!(second["reason"], "already_exists");
+            // The same deterministic ID must be returned both times.
+            assert_eq!(first["drawer_id"], second["drawer_id"]);
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn add_drawer_deterministic_id_same_content() {
-        let (_db, connection) = test_conn().await;
-        // Verify the ID is derived from sha256(wing+room+content)[:24].
-        let content = "fn main() { println!(\"hello\"); }";
-        let args = json!({
-            "wing": "proj",
-            "room": "code",
-            "content": content,
-        });
-        let result = tool_add_drawer(&connection, &args).await;
-        let id = result["drawer_id"]
-            .as_str()
-            .expect("drawer_id must be a string");
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            // Verify the ID is derived from sha256(wing+room+content)[:24].
+            let content = "fn main() { println!(\"hello\"); }";
+            let args = json!({
+                "wing": "proj",
+                "room": "code",
+                "content": content,
+            });
+            let result = tool_add_drawer(&connection, &args).await;
+            let id = result["drawer_id"]
+                .as_str()
+                .expect("drawer_id must be a string");
 
-        let hash = sha2::Sha256::digest(format!("proj\u{1f}code\u{1f}{content}").as_bytes());
-        let hex: String = hash.iter().fold(String::new(), |mut s, b| {
-            use std::fmt::Write as _;
-            let _ = write!(s, "{b:02x}");
-            s
-        });
-        let expected = format!("drawer_proj_code_{}", &hex[..24]);
-        assert_eq!(id, expected);
+            let hash = sha2::Sha256::digest(format!("proj\u{1f}code\u{1f}{content}").as_bytes());
+            let hex: String = hash.iter().fold(String::new(), |mut s, b| {
+                use std::fmt::Write as _;
+                let _ = write!(s, "{b:02x}");
+                s
+            });
+            let expected = format!("drawer_proj_code_{}", &hex[..24]);
+            assert_eq!(id, expected);
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn add_drawer_different_content_different_id() {
-        let (_db, connection) = test_conn().await;
-        let ra = tool_add_drawer(
-            &connection,
-            &json!({"wing": "w", "room": "r", "content": "first piece of content"}),
-        )
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            let ra = tool_add_drawer(
+                &connection,
+                &json!({"wing": "w", "room": "r", "content": "first piece of content"}),
+            )
+            .await;
+            let rb = tool_add_drawer(
+                &connection,
+                &json!({"wing": "w", "room": "r", "content": "second piece of content"}),
+            )
+            .await;
+            assert_ne!(ra["drawer_id"], rb["drawer_id"]);
+        })
         .await;
-        let rb = tool_add_drawer(
-            &connection,
-            &json!({"wing": "w", "room": "r", "content": "second piece of content"}),
-        )
-        .await;
-        assert_ne!(ra["drawer_id"], rb["drawer_id"]);
     }
 
     #[tokio::test]
     async fn add_drawer_missing_required_fields_returns_error() {
-        let (_db, connection) = test_conn().await;
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
 
-        // Missing content
-        let r = tool_add_drawer(&connection, &json!({"wing": "w", "room": "r"})).await;
-        assert_eq!(r["success"], false);
+            // Missing content
+            let r = tool_add_drawer(&connection, &json!({"wing": "w", "room": "r"})).await;
+            assert_eq!(r["success"], false);
 
-        // Missing wing
-        let r = tool_add_drawer(
-            &connection,
-            &json!({"room": "r", "content": "some text here for testing"}),
-        )
+            // Missing wing
+            let r = tool_add_drawer(
+                &connection,
+                &json!({"room": "r", "content": "some text here for testing"}),
+            )
+            .await;
+            assert_eq!(r["success"], false);
+
+            // Missing room
+            let r = tool_add_drawer(
+                &connection,
+                &json!({"wing": "w", "content": "some text here for testing"}),
+            )
+            .await;
+            assert_eq!(r["success"], false);
+        })
         .await;
-        assert_eq!(r["success"], false);
-
-        // Missing room
-        let r = tool_add_drawer(
-            &connection,
-            &json!({"wing": "w", "content": "some text here for testing"}),
-        )
-        .await;
-        assert_eq!(r["success"], false);
     }
 
     // --- Helper: seed a drawer for tests that need pre-existing data ---
@@ -1512,543 +1533,677 @@ mod tests {
 
     #[tokio::test]
     async fn status_empty_db_returns_zero_totals() {
-        let (_db, connection) = test_conn().await;
-        let result = tool_status(&connection).await;
-        assert_eq!(result["total_drawers"], 0);
-        assert!(result["protocol"].is_string(), "protocol must be present");
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            let result = tool_status(&connection).await;
+            assert_eq!(result["total_drawers"], 0);
+            assert!(result["protocol"].is_string(), "protocol must be present");
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn status_with_drawers_counts_correctly() {
-        let (_db, connection) = test_conn().await;
-        seed_drawer(&connection, "alpha", "notes", "first drawer content here").await;
-        seed_drawer(&connection, "alpha", "code", "second drawer content here").await;
-        seed_drawer(&connection, "beta", "notes", "third drawer content here").await;
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            seed_drawer(&connection, "alpha", "notes", "first drawer content here").await;
+            seed_drawer(&connection, "alpha", "code", "second drawer content here").await;
+            seed_drawer(&connection, "beta", "notes", "third drawer content here").await;
 
-        let result = tool_status(&connection).await;
-        assert_eq!(result["total_drawers"], 3);
-        assert_eq!(result["wings"]["alpha"], 2);
-        assert_eq!(result["wings"]["beta"], 1);
+            let result = tool_status(&connection).await;
+            assert_eq!(result["total_drawers"], 3);
+            assert_eq!(result["wings"]["alpha"], 2);
+            assert_eq!(result["wings"]["beta"], 1);
+        })
+        .await;
     }
 
     // --- tool_list_wings ---
 
     #[tokio::test]
     async fn list_wings_empty_db() {
-        let (_db, connection) = test_conn().await;
-        let result = tool_list_wings(&connection).await;
-        let wings = result["wings"].as_object().expect("wings must be object");
-        assert!(wings.is_empty(), "empty DB should have no wings");
-        assert!(result.get("error").is_none(), "must not return error");
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            let result = tool_list_wings(&connection).await;
+            let wings = result["wings"].as_object().expect("wings must be object");
+            assert!(wings.is_empty(), "empty DB should have no wings");
+            assert!(result.get("error").is_none(), "must not return error");
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn list_wings_with_data() {
-        let (_db, connection) = test_conn().await;
-        seed_drawer(&connection, "personal", "notes", "my personal note content").await;
-        seed_drawer(&connection, "work", "tasks", "my work task content here").await;
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            seed_drawer(&connection, "personal", "notes", "my personal note content").await;
+            seed_drawer(&connection, "work", "tasks", "my work task content here").await;
 
-        let result = tool_list_wings(&connection).await;
-        let wings = result["wings"].as_object().expect("wings must be object");
-        assert_eq!(wings.len(), 2);
-        assert_eq!(result["wings"]["personal"], 1);
+            let result = tool_list_wings(&connection).await;
+            let wings = result["wings"].as_object().expect("wings must be object");
+            assert_eq!(wings.len(), 2);
+            assert_eq!(result["wings"]["personal"], 1);
+        })
+        .await;
     }
 
     // --- tool_list_rooms ---
 
     #[tokio::test]
     async fn list_rooms_empty_db() {
-        let (_db, connection) = test_conn().await;
-        let result = tool_list_rooms(&connection, &json!({})).await;
-        let rooms = result["rooms"].as_object().expect("rooms must be object");
-        assert!(rooms.is_empty(), "empty DB should have no rooms");
-        assert_eq!(result["wing"], "all");
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            let result = tool_list_rooms(&connection, &json!({})).await;
+            let rooms = result["rooms"].as_object().expect("rooms must be object");
+            assert!(rooms.is_empty(), "empty DB should have no rooms");
+            assert_eq!(result["wing"], "all");
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn list_rooms_with_wing_filter() {
-        let (_db, connection) = test_conn().await;
-        seed_drawer(&connection, "proj", "code", "some code content here").await;
-        seed_drawer(&connection, "proj", "docs", "some docs content here").await;
-        seed_drawer(&connection, "other", "misc", "other misc content here").await;
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            seed_drawer(&connection, "proj", "code", "some code content here").await;
+            seed_drawer(&connection, "proj", "docs", "some docs content here").await;
+            seed_drawer(&connection, "other", "misc", "other misc content here").await;
 
-        let result = tool_list_rooms(&connection, &json!({"wing": "proj"})).await;
-        let rooms = result["rooms"].as_object().expect("rooms must be object");
-        assert_eq!(rooms.len(), 2);
-        assert_eq!(result["wing"], "proj");
+            let result = tool_list_rooms(&connection, &json!({"wing": "proj"})).await;
+            let rooms = result["rooms"].as_object().expect("rooms must be object");
+            assert_eq!(rooms.len(), 2);
+            assert_eq!(result["wing"], "proj");
+        })
+        .await;
     }
 
     // --- tool_get_taxonomy ---
 
     #[tokio::test]
     async fn get_taxonomy_empty_db() {
-        let (_db, connection) = test_conn().await;
-        let result = tool_get_taxonomy(&connection).await;
-        let taxonomy = result["taxonomy"]
-            .as_object()
-            .expect("taxonomy must be object");
-        assert!(taxonomy.is_empty(), "empty DB should have no taxonomy");
-        assert!(result.get("error").is_none(), "must not return error");
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            let result = tool_get_taxonomy(&connection).await;
+            let taxonomy = result["taxonomy"]
+                .as_object()
+                .expect("taxonomy must be object");
+            assert!(taxonomy.is_empty(), "empty DB should have no taxonomy");
+            assert!(result.get("error").is_none(), "must not return error");
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn get_taxonomy_with_data() {
-        let (_db, connection) = test_conn().await;
-        seed_drawer(
-            &connection,
-            "proj",
-            "code",
-            "code content for taxonomy test",
-        )
-        .await;
-        seed_drawer(
-            &connection,
-            "proj",
-            "docs",
-            "docs content for taxonomy test",
-        )
-        .await;
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            seed_drawer(
+                &connection,
+                "proj",
+                "code",
+                "code content for taxonomy test",
+            )
+            .await;
+            seed_drawer(
+                &connection,
+                "proj",
+                "docs",
+                "docs content for taxonomy test",
+            )
+            .await;
 
-        let result = tool_get_taxonomy(&connection).await;
-        let taxonomy = result["taxonomy"]
-            .as_object()
-            .expect("taxonomy must be object");
-        assert!(taxonomy.contains_key("proj"), "must contain proj wing");
-        assert_eq!(result["taxonomy"]["proj"]["code"], 1);
+            let result = tool_get_taxonomy(&connection).await;
+            let taxonomy = result["taxonomy"]
+                .as_object()
+                .expect("taxonomy must be object");
+            assert!(taxonomy.contains_key("proj"), "must contain proj wing");
+            assert_eq!(result["taxonomy"]["proj"]["code"], 1);
+        })
+        .await;
     }
 
     // --- tool_search ---
 
     #[tokio::test]
     async fn search_empty_query_returns_error() {
-        let (_db, connection) = test_conn().await;
-        let result = tool_search(&connection, &json!({"query": ""})).await;
-        assert!(
-            result["error"].is_string(),
-            "must return error for empty query"
-        );
-        assert!(result.get("results").is_none(), "must not return results");
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            let result = tool_search(&connection, &json!({"query": ""})).await;
+            assert!(
+                result["error"].is_string(),
+                "must return error for empty query"
+            );
+            assert!(result.get("results").is_none(), "must not return results");
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn search_happy_path_returns_results() {
-        let (_db, connection) = test_conn().await;
-        seed_drawer(
-            &connection,
-            "tech",
-            "rust",
-            "rust programming language memory safety ownership borrowing",
-        )
-        .await;
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            seed_drawer(
+                &connection,
+                "tech",
+                "rust",
+                "rust programming language memory safety ownership borrowing",
+            )
+            .await;
 
-        let result = tool_search(&connection, &json!({"query": "rust programming"})).await;
-        assert!(result.get("error").is_none(), "search must not error");
-        assert!(result["count"].as_i64().expect("count must be int") >= 1);
+            let result = tool_search(&connection, &json!({"query": "rust programming"})).await;
+            assert!(result.get("error").is_none(), "search must not error");
+            assert!(result["count"].as_i64().expect("count must be int") >= 1);
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn search_with_wing_filter() {
-        let (_db, connection) = test_conn().await;
-        seed_drawer(
-            &connection,
-            "tech",
-            "notes",
-            "rust programming language systems",
-        )
-        .await;
-        seed_drawer(
-            &connection,
-            "personal",
-            "notes",
-            "rust belt vacation travel plans",
-        )
-        .await;
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            seed_drawer(
+                &connection,
+                "tech",
+                "notes",
+                "rust programming language systems",
+            )
+            .await;
+            seed_drawer(
+                &connection,
+                "personal",
+                "notes",
+                "rust belt vacation travel plans",
+            )
+            .await;
 
-        let result = tool_search(&connection, &json!({"query": "rust", "wing": "tech"})).await;
-        assert!(result.get("error").is_none(), "search must not error");
-        // All returned results should be from the "tech" wing
-        let results = result["results"].as_array().expect("results must be array");
-        for r in results {
-            assert_eq!(r["wing"], "tech");
-        }
+            let result = tool_search(&connection, &json!({"query": "rust", "wing": "tech"})).await;
+            assert!(result.get("error").is_none(), "search must not error");
+            // All returned results should be from the "tech" wing
+            let results = result["results"].as_array().expect("results must be array");
+            for r in results {
+                assert_eq!(r["wing"], "tech");
+            }
+        })
+        .await;
     }
 
     // --- tool_check_duplicate ---
 
     #[tokio::test]
     async fn check_duplicate_no_match() {
-        let (_db, connection) = test_conn().await;
-        let result = tool_check_duplicate(
-            &connection,
-            &json!({"content": "completely unique content that has no match"}),
-        )
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            let result = tool_check_duplicate(
+                &connection,
+                &json!({"content": "completely unique content that has no match"}),
+            )
+            .await;
+            assert_eq!(result["is_duplicate"], false);
+            assert!(
+                result["matches"]
+                    .as_array()
+                    .expect("matches must be array")
+                    .is_empty()
+            );
+        })
         .await;
-        assert_eq!(result["is_duplicate"], false);
-        assert!(
-            result["matches"]
-                .as_array()
-                .expect("matches must be array")
-                .is_empty()
-        );
     }
 
     #[tokio::test]
     async fn check_duplicate_with_matching_content() {
-        let (_db, connection) = test_conn().await;
-        seed_drawer(
-            &connection,
-            "tech",
-            "notes",
-            "rust programming language memory safety ownership borrowing lifetimes",
-        )
-        .await;
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            seed_drawer(
+                &connection,
+                "tech",
+                "notes",
+                "rust programming language memory safety ownership borrowing lifetimes",
+            )
+            .await;
 
-        // Check with very similar content — duplicate detection uses word overlap
-        let result = tool_check_duplicate(
-            &connection,
-            &json!({"content": "rust programming language memory safety ownership borrowing lifetimes"}),
-        )
+            // Check with very similar content — duplicate detection uses word overlap
+            let result = tool_check_duplicate(
+                &connection,
+                &json!({"content": "rust programming language memory safety ownership borrowing lifetimes"}),
+            )
+            .await;
+            assert!(result.get("error").is_none(), "must not error");
+            // is_duplicate is present regardless
+            assert!(
+                result.get("is_duplicate").is_some(),
+                "is_duplicate key must exist"
+            );
+        })
         .await;
-        assert!(result.get("error").is_none(), "must not error");
-        // is_duplicate is present regardless
-        assert!(
-            result.get("is_duplicate").is_some(),
-            "is_duplicate key must exist"
-        );
     }
 
     // --- tool_delete_drawer ---
 
     #[tokio::test]
     async fn delete_drawer_success() {
-        let (_db, connection) = test_conn().await;
-        let seeded = seed_drawer(&connection, "temp", "notes", "content to be deleted").await;
-        let drawer_id = seeded["drawer_id"]
-            .as_str()
-            .expect("drawer_id must be string");
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            let seeded = seed_drawer(&connection, "temp", "notes", "content to be deleted").await;
+            let drawer_id = seeded["drawer_id"]
+                .as_str()
+                .expect("drawer_id must be string");
 
-        let result = tool_delete_drawer(&connection, &json!({"drawer_id": drawer_id})).await;
-        assert_eq!(result["success"], true);
-        assert_eq!(result["drawer_id"], drawer_id);
+            let result = tool_delete_drawer(&connection, &json!({"drawer_id": drawer_id})).await;
+            assert_eq!(result["success"], true);
+            assert_eq!(result["drawer_id"], drawer_id);
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn delete_drawer_invalid_format() {
-        let (_db, connection) = test_conn().await;
-        let result =
-            tool_delete_drawer(&connection, &json!({"drawer_id": "not_a_drawer_id"})).await;
-        assert_eq!(result["success"], false);
-        assert!(
-            result["error"]
-                .as_str()
-                .expect("error must be string")
-                .contains("invalid format")
-        );
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            let result =
+                tool_delete_drawer(&connection, &json!({"drawer_id": "not_a_drawer_id"})).await;
+            assert_eq!(result["success"], false);
+            assert!(
+                result["error"]
+                    .as_str()
+                    .expect("error must be string")
+                    .contains("invalid format")
+            );
+        })
+        .await;
     }
 
     // --- tool_get_drawer ---
 
     #[tokio::test]
     async fn get_drawer_success() {
-        let (_db, connection) = test_conn().await;
-        let seeded = seed_drawer(&connection, "proj", "code", "fn main for get test").await;
-        let drawer_id = seeded["drawer_id"]
-            .as_str()
-            .expect("drawer_id must be string");
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            let seeded = seed_drawer(&connection, "proj", "code", "fn main for get test").await;
+            let drawer_id = seeded["drawer_id"]
+                .as_str()
+                .expect("drawer_id must be string");
 
-        let result = tool_get_drawer(&connection, &json!({"drawer_id": drawer_id})).await;
-        assert_eq!(result["drawer_id"], drawer_id);
-        assert_eq!(result["content"], "fn main for get test");
-        assert_eq!(result["wing"], "proj");
+            let result = tool_get_drawer(&connection, &json!({"drawer_id": drawer_id})).await;
+            assert_eq!(result["drawer_id"], drawer_id);
+            assert_eq!(result["content"], "fn main for get test");
+            assert_eq!(result["wing"], "proj");
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn get_drawer_not_found() {
-        let (_db, connection) = test_conn().await;
-        let result = tool_get_drawer(
-            &connection,
-            &json!({"drawer_id": "drawer_x_y_aaaaaaaabbbbbbbbcccccccc"}),
-        )
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            let result = tool_get_drawer(
+                &connection,
+                &json!({"drawer_id": "drawer_x_y_aaaaaaaabbbbbbbbcccccccc"}),
+            )
+            .await;
+            assert!(result["error"].is_string(), "must return error");
+            assert!(
+                result["error"]
+                    .as_str()
+                    .expect("error string")
+                    .contains("not found"),
+                "error must mention not found"
+            );
+        })
         .await;
-        assert!(result["error"].is_string(), "must return error");
-        assert!(
-            result["error"]
-                .as_str()
-                .expect("error string")
-                .contains("not found"),
-            "error must mention not found"
-        );
     }
 
     // --- tool_list_drawers ---
 
     #[tokio::test]
     async fn list_drawers_empty_db() {
-        let (_db, connection) = test_conn().await;
-        let result = tool_list_drawers(&connection, &json!({})).await;
-        assert_eq!(result["count"], 0);
-        assert!(
-            result["drawers"]
-                .as_array()
-                .expect("drawers must be array")
-                .is_empty()
-        );
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            let result = tool_list_drawers(&connection, &json!({})).await;
+            assert_eq!(result["count"], 0);
+            assert!(
+                result["drawers"]
+                    .as_array()
+                    .expect("drawers must be array")
+                    .is_empty()
+            );
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn list_drawers_with_pagination() {
-        let (_db, connection) = test_conn().await;
-        seed_drawer(&connection, "w", "r", "first content for pagination test").await;
-        seed_drawer(&connection, "w", "r", "second content for pagination test").await;
-        seed_drawer(&connection, "w", "r", "third content for pagination test").await;
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            seed_drawer(&connection, "w", "r", "first content for pagination test").await;
+            seed_drawer(&connection, "w", "r", "second content for pagination test").await;
+            seed_drawer(&connection, "w", "r", "third content for pagination test").await;
 
-        // Limit to 2
-        let result = tool_list_drawers(&connection, &json!({"limit": 2})).await;
-        assert_eq!(result["count"], 2);
-        assert_eq!(result["limit"], 2);
+            // Limit to 2
+            let result = tool_list_drawers(&connection, &json!({"limit": 2})).await;
+            assert_eq!(result["count"], 2);
+            assert_eq!(result["limit"], 2);
 
-        // Offset to get the third
-        let result2 = tool_list_drawers(&connection, &json!({"limit": 2, "offset": 2})).await;
-        assert_eq!(result2["count"], 1);
-        assert_eq!(result2["offset"], 2);
+            // Offset to get the third
+            let result2 = tool_list_drawers(&connection, &json!({"limit": 2, "offset": 2})).await;
+            assert_eq!(result2["count"], 1);
+            assert_eq!(result2["offset"], 2);
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn list_drawers_wing_filter() {
-        let (_db, connection) = test_conn().await;
-        seed_drawer(
-            &connection,
-            "alpha",
-            "notes",
-            "alpha content for filter test",
-        )
-        .await;
-        seed_drawer(&connection, "beta", "notes", "beta content for filter test").await;
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            seed_drawer(
+                &connection,
+                "alpha",
+                "notes",
+                "alpha content for filter test",
+            )
+            .await;
+            seed_drawer(&connection, "beta", "notes", "beta content for filter test").await;
 
-        let result = tool_list_drawers(&connection, &json!({"wing": "alpha"})).await;
-        assert_eq!(result["count"], 1);
-        let d = &result["drawers"][0];
-        assert_eq!(d["wing"], "alpha");
+            let result = tool_list_drawers(&connection, &json!({"wing": "alpha"})).await;
+            assert_eq!(result["count"], 1);
+            let d = &result["drawers"][0];
+            assert_eq!(d["wing"], "alpha");
+        })
+        .await;
     }
 
     // --- tool_update_drawer ---
 
     #[tokio::test]
     async fn update_drawer_content() {
-        let (_db, connection) = test_conn().await;
-        let seeded = seed_drawer(&connection, "proj", "code", "original content for update").await;
-        let old_id = seeded["drawer_id"]
-            .as_str()
-            .expect("drawer_id must be string");
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            let seeded =
+                seed_drawer(&connection, "proj", "code", "original content for update").await;
+            let old_id = seeded["drawer_id"]
+                .as_str()
+                .expect("drawer_id must be string");
 
-        let result = tool_update_drawer(
-            &connection,
-            &json!({"drawer_id": old_id, "content": "updated content after mutation"}),
-        )
+            let result = tool_update_drawer(
+                &connection,
+                &json!({"drawer_id": old_id, "content": "updated content after mutation"}),
+            )
+            .await;
+            assert_eq!(result["success"], true);
+            // ID changes because content changed (deterministic ID includes content)
+            assert_ne!(
+                result["drawer_id"].as_str().expect("new id"),
+                old_id,
+                "ID must change when content changes"
+            );
+        })
         .await;
-        assert_eq!(result["success"], true);
-        // ID changes because content changed (deterministic ID includes content)
-        assert_ne!(
-            result["drawer_id"].as_str().expect("new id"),
-            old_id,
-            "ID must change when content changes"
-        );
     }
 
     #[tokio::test]
     async fn update_drawer_not_found() {
-        let (_db, connection) = test_conn().await;
-        let result = tool_update_drawer(
-            &connection,
-            &json!({
-                "drawer_id": "drawer_x_y_aaaaaaaabbbbbbbbcccccccc",
-                "content": "new content for nonexistent drawer"
-            }),
-        )
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            let result = tool_update_drawer(
+                &connection,
+                &json!({
+                    "drawer_id": "drawer_x_y_aaaaaaaabbbbbbbbcccccccc",
+                    "content": "new content for nonexistent drawer"
+                }),
+            )
+            .await;
+            assert_eq!(result["success"], false);
+            assert!(
+                result["error"]
+                    .as_str()
+                    .expect("error string")
+                    .contains("not found"),
+                "error must mention not found"
+            );
+        })
         .await;
-        assert_eq!(result["success"], false);
-        assert!(
-            result["error"]
-                .as_str()
-                .expect("error string")
-                .contains("not found"),
-            "error must mention not found"
-        );
     }
 
     #[tokio::test]
     async fn update_drawer_noop_when_nothing_changes() {
-        let (_db, connection) = test_conn().await;
-        let seeded = seed_drawer(&connection, "proj", "code", "stable content no change").await;
-        let drawer_id = seeded["drawer_id"]
-            .as_str()
-            .expect("drawer_id must be string");
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            let seeded = seed_drawer(&connection, "proj", "code", "stable content no change").await;
+            let drawer_id = seeded["drawer_id"]
+                .as_str()
+                .expect("drawer_id must be string");
 
-        // Send update with no actual changes
-        let result = tool_update_drawer(&connection, &json!({"drawer_id": drawer_id})).await;
-        assert_eq!(result["success"], true);
-        assert_eq!(result["noop"], true);
+            // Send update with no actual changes
+            let result = tool_update_drawer(&connection, &json!({"drawer_id": drawer_id})).await;
+            assert_eq!(result["success"], true);
+            assert_eq!(result["noop"], true);
+        })
+        .await;
     }
 
     // --- tool_kg_add ---
 
     #[tokio::test]
     async fn kg_add_triple() {
-        let (_db, connection) = test_conn().await;
-        let result = tool_kg_add(
-            &connection,
-            &json!({
-                "subject": "Rust",
-                "predicate": "is",
-                "object": "fast",
-            }),
-        )
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            let result = tool_kg_add(
+                &connection,
+                &json!({
+                    "subject": "Rust",
+                    "predicate": "is",
+                    "object": "fast",
+                }),
+            )
+            .await;
+            assert_eq!(result["success"], true);
+            assert!(
+                result["triple_id"].is_string(),
+                "triple_id must be a string"
+            );
+        })
         .await;
-        assert_eq!(result["success"], true);
-        assert!(
-            result["triple_id"].is_string(),
-            "triple_id must be a string"
-        );
     }
 
     #[tokio::test]
     async fn kg_add_missing_field_returns_error() {
-        let (_db, connection) = test_conn().await;
-        // Missing object
-        let result = tool_kg_add(&connection, &json!({"subject": "Rust", "predicate": "is"})).await;
-        assert_eq!(result["success"], false);
-        assert!(result["error"].is_string(), "must return error message");
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            // Missing object
+            let result =
+                tool_kg_add(&connection, &json!({"subject": "Rust", "predicate": "is"})).await;
+            assert_eq!(result["success"], false);
+            assert!(result["error"].is_string(), "must return error message");
+        })
+        .await;
     }
 
     // --- tool_kg_query ---
 
     #[tokio::test]
     async fn kg_query_entity() {
-        let (_db, connection) = test_conn().await;
-        // Add a triple first
-        tool_kg_add(
-            &connection,
-            &json!({"subject": "Rust", "predicate": "compilesTo", "object": "binary"}),
-        )
-        .await;
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            // Add a triple first
+            tool_kg_add(
+                &connection,
+                &json!({"subject": "Rust", "predicate": "compilesTo", "object": "binary"}),
+            )
+            .await;
 
-        let result = tool_kg_query(&connection, &json!({"entity": "Rust"})).await;
-        assert!(result.get("error").is_none(), "query must not error");
-        assert_eq!(result["entity"], "Rust");
-        assert!(result["count"].as_i64().expect("count") >= 1);
+            let result = tool_kg_query(&connection, &json!({"entity": "Rust"})).await;
+            assert!(result.get("error").is_none(), "query must not error");
+            assert_eq!(result["entity"], "Rust");
+            assert!(result["count"].as_i64().expect("count") >= 1);
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn kg_query_invalid_direction() {
-        let (_db, connection) = test_conn().await;
-        let result = tool_kg_query(
-            &connection,
-            &json!({"entity": "Rust", "direction": "sideways"}),
-        )
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            let result = tool_kg_query(
+                &connection,
+                &json!({"entity": "Rust", "direction": "sideways"}),
+            )
+            .await;
+            assert!(result["error"].is_string(), "must return error");
+            assert!(
+                result["error"]
+                    .as_str()
+                    .expect("error string")
+                    .contains("direction")
+            );
+        })
         .await;
-        assert!(result["error"].is_string(), "must return error");
-        assert!(
-            result["error"]
-                .as_str()
-                .expect("error string")
-                .contains("direction")
-        );
     }
 
     // --- tool_kg_invalidate ---
 
     #[tokio::test]
     async fn kg_invalidate_triple() {
-        let (_db, connection) = test_conn().await;
-        tool_kg_add(
-            &connection,
-            &json!({"subject": "Alice", "predicate": "worksAt", "object": "Acme"}),
-        )
-        .await;
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            tool_kg_add(
+                &connection,
+                &json!({"subject": "Alice", "predicate": "worksAt", "object": "Acme"}),
+            )
+            .await;
 
-        let result = tool_kg_invalidate(
-            &connection,
-            &json!({"subject": "Alice", "predicate": "worksAt", "object": "Acme"}),
-        )
+            let result = tool_kg_invalidate(
+                &connection,
+                &json!({"subject": "Alice", "predicate": "worksAt", "object": "Acme"}),
+            )
+            .await;
+            assert_eq!(result["success"], true);
+            assert!(
+                result["ended"].is_string(),
+                "ended timestamp must be present"
+            );
+        })
         .await;
-        assert_eq!(result["success"], true);
-        assert!(
-            result["ended"].is_string(),
-            "ended timestamp must be present"
-        );
     }
 
     #[tokio::test]
     async fn kg_invalidate_with_explicit_ended_date() {
-        let (_db, connection) = test_conn().await;
-        tool_kg_add(
-            &connection,
-            &json!({"subject": "Bob", "predicate": "livesIn", "object": "NYC"}),
-        )
-        .await;
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            tool_kg_add(
+                &connection,
+                &json!({"subject": "Bob", "predicate": "livesIn", "object": "NYC"}),
+            )
+            .await;
 
-        let result = tool_kg_invalidate(
-            &connection,
-            &json!({
-                "subject": "Bob",
-                "predicate": "livesIn",
-                "object": "NYC",
-                "ended": "2025-01-01"
-            }),
-        )
+            let result = tool_kg_invalidate(
+                &connection,
+                &json!({
+                    "subject": "Bob",
+                    "predicate": "livesIn",
+                    "object": "NYC",
+                    "ended": "2025-01-01"
+                }),
+            )
+            .await;
+            assert_eq!(result["success"], true);
+            assert_eq!(result["ended"], "2025-01-01");
+        })
         .await;
-        assert_eq!(result["success"], true);
-        assert_eq!(result["ended"], "2025-01-01");
     }
 
     // --- tool_kg_timeline ---
 
     #[tokio::test]
     async fn kg_timeline_empty() {
-        let (_db, connection) = test_conn().await;
-        let result = tool_kg_timeline(&connection, &json!({})).await;
-        assert!(result.get("error").is_none(), "must not error");
-        assert_eq!(result["count"], 0);
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            let result = tool_kg_timeline(&connection, &json!({})).await;
+            assert!(result.get("error").is_none(), "must not error");
+            assert_eq!(result["count"], 0);
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn kg_timeline_with_data() {
-        let (_db, connection) = test_conn().await;
-        tool_kg_add(
-            &connection,
-            &json!({"subject": "Eve", "predicate": "knows", "object": "Alice"}),
-        )
-        .await;
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            tool_kg_add(
+                &connection,
+                &json!({"subject": "Eve", "predicate": "knows", "object": "Alice"}),
+            )
+            .await;
 
-        let result = tool_kg_timeline(&connection, &json!({"entity": "Eve"})).await;
-        assert!(result.get("error").is_none(), "must not error");
-        assert!(result["count"].as_i64().expect("count") >= 1);
+            let result = tool_kg_timeline(&connection, &json!({"entity": "Eve"})).await;
+            assert!(result.get("error").is_none(), "must not error");
+            assert!(result["count"].as_i64().expect("count") >= 1);
+        })
+        .await;
     }
 
     // --- tool_kg_stats ---
 
     #[tokio::test]
     async fn kg_stats_empty_db() {
-        let (_db, connection) = test_conn().await;
-        let result = tool_kg_stats(&connection).await;
-        assert!(result.get("error").is_none(), "must not error");
-        assert_eq!(result["entities"], 0);
-        assert_eq!(result["triples"], 0);
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            let result = tool_kg_stats(&connection).await;
+            assert!(result.get("error").is_none(), "must not error");
+            assert_eq!(result["entities"], 0);
+            assert_eq!(result["triples"], 0);
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn kg_stats_after_adding_triples() {
-        let (_db, connection) = test_conn().await;
-        tool_kg_add(
-            &connection,
-            &json!({"subject": "X", "predicate": "rel", "object": "Y"}),
-        )
-        .await;
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            tool_kg_add(
+                &connection,
+                &json!({"subject": "X", "predicate": "rel", "object": "Y"}),
+            )
+            .await;
 
-        let result = tool_kg_stats(&connection).await;
-        assert!(result.get("error").is_none(), "must not error");
-        assert!(result["triples"].as_i64().expect("triples") >= 1);
-        assert!(result["entities"].as_i64().expect("entities") >= 1);
+            let result = tool_kg_stats(&connection).await;
+            assert!(result.get("error").is_none(), "must not error");
+            assert!(result["triples"].as_i64().expect("triples") >= 1);
+            assert!(result["entities"].as_i64().expect("entities") >= 1);
+        })
+        .await;
     }
 
     // --- tool_create_tunnel ---
@@ -2069,360 +2224,460 @@ mod tests {
 
     #[tokio::test]
     async fn create_tunnel_success() {
-        let (_db, connection) = test_conn().await;
-        let result = seed_tunnel(&connection).await;
-        assert!(result.get("error").is_none(), "must not error");
-        assert!(result["id"].is_string(), "tunnel must have an id");
-        assert_eq!(result["source_wing"], "alpha");
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            let result = seed_tunnel(&connection).await;
+            assert!(result.get("error").is_none(), "must not error");
+            assert!(result["id"].is_string(), "tunnel must have an id");
+            assert_eq!(result["source_wing"], "alpha");
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn create_tunnel_missing_label_returns_error() {
-        let (_db, connection) = test_conn().await;
-        let result = tool_create_tunnel(
-            &connection,
-            &json!({
-                "source_wing": "a",
-                "source_room": "b",
-                "target_wing": "c",
-                "target_room": "d",
-            }),
-        )
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            let result = tool_create_tunnel(
+                &connection,
+                &json!({
+                    "source_wing": "a",
+                    "source_room": "b",
+                    "target_wing": "c",
+                    "target_room": "d",
+                }),
+            )
+            .await;
+            assert_eq!(result["success"], false);
+            assert!(
+                result["error"].is_string(),
+                "must return error for missing label"
+            );
+        })
         .await;
-        assert_eq!(result["success"], false);
-        assert!(
-            result["error"].is_string(),
-            "must return error for missing label"
-        );
     }
 
     // --- tool_list_tunnels ---
 
     #[tokio::test]
     async fn list_tunnels_empty() {
-        let (_db, connection) = test_conn().await;
-        let result = tool_list_tunnels(&connection, &json!({})).await;
-        assert!(result.get("error").is_none(), "must not error");
-        assert_eq!(result["count"], 0);
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            let result = tool_list_tunnels(&connection, &json!({})).await;
+            assert!(result.get("error").is_none(), "must not error");
+            assert_eq!(result["count"], 0);
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn list_tunnels_after_create() {
-        let (_db, connection) = test_conn().await;
-        seed_tunnel(&connection).await;
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            seed_tunnel(&connection).await;
 
-        let result = tool_list_tunnels(&connection, &json!({})).await;
-        assert!(result.get("error").is_none(), "must not error");
-        assert!(result["count"].as_i64().expect("count") >= 1);
+            let result = tool_list_tunnels(&connection, &json!({})).await;
+            assert!(result.get("error").is_none(), "must not error");
+            assert!(result["count"].as_i64().expect("count") >= 1);
+        })
+        .await;
     }
 
     // --- tool_delete_tunnel ---
 
     #[tokio::test]
     async fn delete_tunnel_success() {
-        let (_db, connection) = test_conn().await;
-        let tunnel = seed_tunnel(&connection).await;
-        let tunnel_id = tunnel["id"].as_str().expect("tunnel must have id");
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            let tunnel = seed_tunnel(&connection).await;
+            let tunnel_id = tunnel["id"].as_str().expect("tunnel must have id");
 
-        let result = tool_delete_tunnel(&connection, &json!({"tunnel_id": tunnel_id})).await;
-        assert!(result.get("error").is_none(), "delete must not error");
-        assert_eq!(result["deleted"], true);
+            let result = tool_delete_tunnel(&connection, &json!({"tunnel_id": tunnel_id})).await;
+            assert!(result.get("error").is_none(), "delete must not error");
+            assert_eq!(result["deleted"], true);
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn delete_tunnel_invalid_id_format() {
-        let (_db, connection) = test_conn().await;
-        let result = tool_delete_tunnel(&connection, &json!({"tunnel_id": "not-valid"})).await;
-        assert!(result["error"].is_string(), "must return error");
-        assert!(
-            result["error"]
-                .as_str()
-                .expect("error string")
-                .contains("16-character hex")
-        );
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            let result = tool_delete_tunnel(&connection, &json!({"tunnel_id": "not-valid"})).await;
+            assert!(result["error"].is_string(), "must return error");
+            assert!(
+                result["error"]
+                    .as_str()
+                    .expect("error string")
+                    .contains("16-character hex")
+            );
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn delete_tunnel_nonexistent_returns_false() {
-        let (_db, connection) = test_conn().await;
-        // Valid 16-char hex that doesn't exist
-        let result =
-            tool_delete_tunnel(&connection, &json!({"tunnel_id": "0000000000000000"})).await;
-        assert!(result.get("error").is_none(), "must not error");
-        assert_eq!(result["deleted"], false);
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            // Valid 16-char hex that doesn't exist
+            let result =
+                tool_delete_tunnel(&connection, &json!({"tunnel_id": "0000000000000000"})).await;
+            assert!(result.get("error").is_none(), "must not error");
+            assert_eq!(result["deleted"], false);
+        })
+        .await;
     }
 
     // --- tool_follow_tunnels ---
 
     #[tokio::test]
     async fn follow_tunnels_no_connections() {
-        let (_db, connection) = test_conn().await;
-        let result =
-            tool_follow_tunnels(&connection, &json!({"wing": "alpha", "room": "code"})).await;
-        assert!(result.get("error").is_none(), "must not error");
-        assert!(
-            result["connections"]
-                .as_array()
-                .expect("connections must be array")
-                .is_empty()
-        );
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            let result =
+                tool_follow_tunnels(&connection, &json!({"wing": "alpha", "room": "code"})).await;
+            assert!(result.get("error").is_none(), "must not error");
+            assert!(
+                result["connections"]
+                    .as_array()
+                    .expect("connections must be array")
+                    .is_empty()
+            );
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn follow_tunnels_with_tunnel() {
-        let (_db, connection) = test_conn().await;
-        seed_tunnel(&connection).await;
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            seed_tunnel(&connection).await;
 
-        let result =
-            tool_follow_tunnels(&connection, &json!({"wing": "alpha", "room": "code"})).await;
-        assert!(result.get("error").is_none(), "must not error");
-        assert_eq!(result["wing"], "alpha");
-        // Should find at least one connection from the seeded tunnel
-        let conns = result["connections"]
-            .as_array()
-            .expect("connections must be array");
-        assert!(!conns.is_empty(), "must find the seeded tunnel");
+            let result =
+                tool_follow_tunnels(&connection, &json!({"wing": "alpha", "room": "code"})).await;
+            assert!(result.get("error").is_none(), "must not error");
+            assert_eq!(result["wing"], "alpha");
+            // Should find at least one connection from the seeded tunnel
+            let conns = result["connections"]
+                .as_array()
+                .expect("connections must be array");
+            assert!(!conns.is_empty(), "must find the seeded tunnel");
+        })
+        .await;
     }
 
     // --- tool_traverse ---
 
     #[tokio::test]
     async fn traverse_empty_graph() {
-        let (_db, connection) = test_conn().await;
-        let result = tool_traverse(&connection, &json!({"start_room": "nonexistent"})).await;
-        assert!(
-            result.get("error").is_none(),
-            "must not error on empty graph"
-        );
-        assert!(result.get("results").is_some(), "must have results key");
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            let result = tool_traverse(&connection, &json!({"start_room": "nonexistent"})).await;
+            assert!(
+                result.get("error").is_none(),
+                "must not error on empty graph"
+            );
+            assert!(result.get("results").is_some(), "must have results key");
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn traverse_with_shared_room() {
-        let (_db, connection) = test_conn().await;
-        // Two wings sharing the same room name creates a graph edge
-        seed_drawer(
-            &connection,
-            "alpha",
-            "shared",
-            "alpha shared drawer content",
-        )
-        .await;
-        seed_drawer(&connection, "beta", "shared", "beta shared drawer content").await;
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            // Two wings sharing the same room name creates a graph edge
+            seed_drawer(
+                &connection,
+                "alpha",
+                "shared",
+                "alpha shared drawer content",
+            )
+            .await;
+            seed_drawer(&connection, "beta", "shared", "beta shared drawer content").await;
 
-        let result =
-            tool_traverse(&connection, &json!({"start_room": "shared", "max_hops": 1})).await;
-        assert!(result.get("error").is_none(), "must not error");
-        let results = result["results"].as_array().expect("results must be array");
-        assert!(
-            !results.is_empty(),
-            "shared room should yield traversal results"
-        );
+            let result =
+                tool_traverse(&connection, &json!({"start_room": "shared", "max_hops": 1})).await;
+            assert!(result.get("error").is_none(), "must not error");
+            let results = result["results"].as_array().expect("results must be array");
+            assert!(
+                !results.is_empty(),
+                "shared room should yield traversal results"
+            );
+        })
+        .await;
     }
 
     // --- tool_find_tunnels ---
 
     #[tokio::test]
     async fn find_tunnels_empty_graph() {
-        let (_db, connection) = test_conn().await;
-        let result = tool_find_tunnels(&connection, &json!({})).await;
-        assert!(result.get("error").is_none(), "must not error");
-        assert!(
-            result["tunnels"]
-                .as_array()
-                .expect("tunnels must be array")
-                .is_empty()
-        );
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            let result = tool_find_tunnels(&connection, &json!({})).await;
+            assert!(result.get("error").is_none(), "must not error");
+            assert!(
+                result["tunnels"]
+                    .as_array()
+                    .expect("tunnels must be array")
+                    .is_empty()
+            );
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn find_tunnels_between_wings() {
-        let (_db, connection) = test_conn().await;
-        // Create drawers in two wings sharing a room name
-        seed_drawer(&connection, "alpha", "shared", "alpha shared content here").await;
-        seed_drawer(&connection, "beta", "shared", "beta shared content here").await;
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            // Create drawers in two wings sharing a room name
+            seed_drawer(&connection, "alpha", "shared", "alpha shared content here").await;
+            seed_drawer(&connection, "beta", "shared", "beta shared content here").await;
 
-        let result =
-            tool_find_tunnels(&connection, &json!({"wing_a": "alpha", "wing_b": "beta"})).await;
-        assert!(result.get("error").is_none(), "must not error");
-        let tunnels = result["tunnels"].as_array().expect("tunnels must be array");
-        assert!(
-            !tunnels.is_empty(),
-            "wings sharing a room should have tunnels"
-        );
+            let result =
+                tool_find_tunnels(&connection, &json!({"wing_a": "alpha", "wing_b": "beta"})).await;
+            assert!(result.get("error").is_none(), "must not error");
+            let tunnels = result["tunnels"].as_array().expect("tunnels must be array");
+            assert!(
+                !tunnels.is_empty(),
+                "wings sharing a room should have tunnels"
+            );
+        })
+        .await;
     }
 
     // --- tool_graph_stats ---
 
     #[tokio::test]
     async fn graph_stats_empty_db() {
-        let (_db, connection) = test_conn().await;
-        let result = tool_graph_stats(&connection).await;
-        assert!(result.get("error").is_none(), "must not error");
-        assert_eq!(result["total_rooms"], 0);
-        assert_eq!(result["total_edges"], 0);
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            let result = tool_graph_stats(&connection).await;
+            assert!(result.get("error").is_none(), "must not error");
+            assert_eq!(result["total_rooms"], 0);
+            assert_eq!(result["total_edges"], 0);
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn graph_stats_with_data() {
-        let (_db, connection) = test_conn().await;
-        seed_drawer(&connection, "alpha", "notes", "alpha notes for graph stats").await;
-        seed_drawer(&connection, "beta", "notes", "beta notes for graph stats").await;
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            seed_drawer(&connection, "alpha", "notes", "alpha notes for graph stats").await;
+            seed_drawer(&connection, "beta", "notes", "beta notes for graph stats").await;
 
-        let result = tool_graph_stats(&connection).await;
-        assert!(result.get("error").is_none(), "must not error");
-        assert!(
-            result["total_rooms"].as_i64().expect("total_rooms") >= 1,
-            "must count at least one room"
-        );
+            let result = tool_graph_stats(&connection).await;
+            assert!(result.get("error").is_none(), "must not error");
+            assert!(
+                result["total_rooms"].as_i64().expect("total_rooms") >= 1,
+                "must count at least one room"
+            );
+        })
+        .await;
     }
 
     // --- tool_diary_write ---
 
     #[tokio::test]
     async fn diary_write_success() {
-        let (_db, connection) = test_conn().await;
-        let result = tool_diary_write(
-            &connection,
-            &json!({
-                "agent_name": "TestAgent",
-                "entry": "Today I learned about Rust lifetimes and borrowing",
-            }),
-        )
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            let result = tool_diary_write(
+                &connection,
+                &json!({
+                    "agent_name": "TestAgent",
+                    "entry": "Today I learned about Rust lifetimes and borrowing",
+                }),
+            )
+            .await;
+            assert_eq!(result["success"], true);
+            assert!(result["entry_id"].is_string(), "must return entry_id");
+            assert_eq!(result["agent"], "TestAgent");
+            assert_eq!(result["topic"], "general");
+        })
         .await;
-        assert_eq!(result["success"], true);
-        assert!(result["entry_id"].is_string(), "must return entry_id");
-        assert_eq!(result["agent"], "TestAgent");
-        assert_eq!(result["topic"], "general");
     }
 
     #[tokio::test]
     async fn diary_write_with_topic() {
-        let (_db, connection) = test_conn().await;
-        let result = tool_diary_write(
-            &connection,
-            &json!({
-                "agent_name": "TestAgent",
-                "entry": "Debugging session notes about async runtime",
-                "topic": "debugging",
-            }),
-        )
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            let result = tool_diary_write(
+                &connection,
+                &json!({
+                    "agent_name": "TestAgent",
+                    "entry": "Debugging session notes about async runtime",
+                    "topic": "debugging",
+                }),
+            )
+            .await;
+            assert_eq!(result["success"], true);
+            assert_eq!(result["topic"], "debugging");
+        })
         .await;
-        assert_eq!(result["success"], true);
-        assert_eq!(result["topic"], "debugging");
     }
 
     #[tokio::test]
     async fn diary_write_missing_entry_returns_error() {
-        let (_db, connection) = test_conn().await;
-        let result = tool_diary_write(&connection, &json!({"agent_name": "TestAgent"})).await;
-        assert_eq!(result["success"], false);
-        assert!(result["error"].is_string(), "must return error");
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            let result = tool_diary_write(&connection, &json!({"agent_name": "TestAgent"})).await;
+            assert_eq!(result["success"], false);
+            assert!(result["error"].is_string(), "must return error");
+        })
+        .await;
     }
 
     // --- tool_diary_read ---
 
     #[tokio::test]
     async fn diary_read_empty() {
-        let (_db, connection) = test_conn().await;
-        let result = tool_diary_read(&connection, &json!({"agent_name": "TestAgent"})).await;
-        assert!(result.get("error").is_none(), "must not error");
-        assert_eq!(result["total"], 0);
-        assert_eq!(result["agent"], "TestAgent");
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            let result = tool_diary_read(&connection, &json!({"agent_name": "TestAgent"})).await;
+            assert!(result.get("error").is_none(), "must not error");
+            assert_eq!(result["total"], 0);
+            assert_eq!(result["agent"], "TestAgent");
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn diary_read_after_write() {
-        let (_db, connection) = test_conn().await;
-        tool_diary_write(
-            &connection,
-            &json!({
-                "agent_name": "TestAgent",
-                "entry": "diary entry content for read test",
-                "topic": "testing",
-            }),
-        )
-        .await;
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            tool_diary_write(
+                &connection,
+                &json!({
+                    "agent_name": "TestAgent",
+                    "entry": "diary entry content for read test",
+                    "topic": "testing",
+                }),
+            )
+            .await;
 
-        let result = tool_diary_read(&connection, &json!({"agent_name": "TestAgent"})).await;
-        assert!(result.get("error").is_none(), "must not error");
-        assert_eq!(result["total"], 1);
-        let entries = result["entries"].as_array().expect("entries must be array");
-        assert_eq!(entries[0]["topic"], "testing");
+            let result = tool_diary_read(&connection, &json!({"agent_name": "TestAgent"})).await;
+            assert!(result.get("error").is_none(), "must not error");
+            assert_eq!(result["total"], 1);
+            let entries = result["entries"].as_array().expect("entries must be array");
+            assert_eq!(entries[0]["topic"], "testing");
+        })
+        .await;
     }
 
     // --- dispatch ---
 
     #[tokio::test]
     async fn dispatch_unknown_tool_returns_error() {
-        let (_db, connection) = test_conn().await;
-        let result = dispatch(&connection, "nonexistent_tool", &json!({})).await;
-        assert!(result["error"].is_string(), "must return error");
-        assert!(
-            result["error"]
-                .as_str()
-                .expect("error string")
-                .contains("Unknown tool")
-        );
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            let result = dispatch(&connection, "nonexistent_tool", &json!({})).await;
+            assert!(result["error"].is_string(), "must return error");
+            assert!(
+                result["error"]
+                    .as_str()
+                    .expect("error string")
+                    .contains("Unknown tool")
+            );
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn dispatch_empty_name_returns_error() {
-        let (_db, connection) = test_conn().await;
-        let result = dispatch(&connection, "", &json!({})).await;
-        assert!(
-            result["error"].is_string(),
-            "must return error for empty name"
-        );
-        assert!(
-            result["error"]
-                .as_str()
-                .expect("error string")
-                .contains("empty")
-        );
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            let result = dispatch(&connection, "", &json!({})).await;
+            assert!(
+                result["error"].is_string(),
+                "must return error for empty name"
+            );
+            assert!(
+                result["error"]
+                    .as_str()
+                    .expect("error string")
+                    .contains("empty")
+            );
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn dispatch_non_object_args_returns_error() {
-        let (_db, connection) = test_conn().await;
-        let result = dispatch(&connection, "mempalace_status", &json!("not an object")).await;
-        assert!(
-            result["error"].is_string(),
-            "must return error for non-object args"
-        );
-        assert!(
-            result["error"]
-                .as_str()
-                .expect("error string")
-                .contains("JSON object")
-        );
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            let result = dispatch(&connection, "mempalace_status", &json!("not an object")).await;
+            assert!(
+                result["error"].is_string(),
+                "must return error for non-object args"
+            );
+            assert!(
+                result["error"]
+                    .as_str()
+                    .expect("error string")
+                    .contains("JSON object")
+            );
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn dispatch_routes_to_correct_tool() {
-        let (_db, connection) = test_conn().await;
-        let result = dispatch(&connection, "mempalace_status", &json!({})).await;
-        // tool_status returns total_drawers, proving it was routed correctly
-        assert!(
-            result.get("total_drawers").is_some(),
-            "must route to tool_status"
-        );
-        assert!(
-            result.get("protocol").is_some(),
-            "status must include protocol"
-        );
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            let result = dispatch(&connection, "mempalace_status", &json!({})).await;
+            // tool_status returns total_drawers, proving it was routed correctly
+            assert!(
+                result.get("total_drawers").is_some(),
+                "must route to tool_status"
+            );
+            assert!(
+                result.get("protocol").is_some(),
+                "status must include protocol"
+            );
+        })
+        .await;
     }
 
     // --- get_aaak_spec (via dispatch) ---
 
     #[tokio::test]
     async fn get_aaak_spec_returns_non_empty() {
-        let (_db, connection) = test_conn().await;
-        let result = dispatch(&connection, "mempalace_get_aaak_spec", &json!({})).await;
-        let spec = result["aaak_spec"]
-            .as_str()
-            .expect("aaak_spec must be string");
-        assert!(!spec.is_empty(), "spec must not be empty");
-        assert!(spec.contains("AAAK"), "spec must mention AAAK");
+        let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+        temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+            let (_db, connection) = test_conn().await;
+            let result = dispatch(&connection, "mempalace_get_aaak_spec", &json!({})).await;
+            let spec = result["aaak_spec"]
+                .as_str()
+                .expect("aaak_spec must be string");
+            assert!(!spec.is_empty(), "spec must not be empty");
+            assert!(spec.contains("AAAK"), "spec must mention AAAK");
+        })
+        .await;
     }
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -251,10 +251,12 @@ async fn wal_log(operation: &str, params: Value) {
         return;
     }
 
+    // Evaluate config_dir() here, in the async context, so the path is captured
+    // by the move closure. Evaluating inside spawn_blocking would race with
+    // temp_env::async_with_vars restoring the env var before the task runs.
+    let wal_dir = crate::config::config_dir().join("wal");
     let operation = operation.to_string();
     let _ = tokio::task::spawn_blocking(move || {
-        let wal_dir = crate::config::config_dir().join("wal");
-
         // Create directory with restrictive permissions atomically on Unix.
         #[cfg(unix)]
         {

--- a/src/palace/entity_detect.rs
+++ b/src/palace/entity_detect.rs
@@ -441,3 +441,198 @@ fn classify_entity_build(
         }
     }
 }
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use std::io::Write as _;
+    use tempfile;
+
+    #[test]
+    fn extract_candidates_finds_capitalized_names() {
+        // "Alice" appears 5 times — well above the frequency threshold of 3.
+        let text =
+            "Alice went to the store. Alice bought milk. Alice came home. Alice cooked. Alice ate.";
+        let candidates = extract_candidates(text);
+        assert!(
+            candidates.contains_key("Alice"),
+            "Alice should be detected as a candidate"
+        );
+        assert!(
+            *candidates.get("Alice").expect("Alice must be present") >= 3,
+            "Alice frequency should be at least 3"
+        );
+    }
+
+    #[test]
+    fn extract_candidates_ignores_low_frequency() {
+        // "Bartholomew" appears only once — below the threshold of 3.
+        let text = "Bartholomew visited the library. Xander Xander Xander was there.";
+        let candidates = extract_candidates(text);
+        assert!(
+            !candidates.contains_key("Bartholomew"),
+            "Single-occurrence names should be filtered out"
+        );
+        assert!(
+            candidates.contains_key("Xander"),
+            "Names at threshold should survive"
+        );
+    }
+
+    #[test]
+    fn extract_candidates_multi_word_names() {
+        // "John Smith" repeated 3 times should be detected as a multi-word candidate.
+        let text =
+            "John Smith led the team. John Smith reviewed the code. John Smith merged the PR.";
+        let candidates = extract_candidates(text);
+        assert!(
+            candidates.contains_key("John Smith"),
+            "Multi-word names should be detected"
+        );
+        assert!(
+            *candidates
+                .get("John Smith")
+                .expect("John Smith must be present")
+                >= 3,
+            "John Smith frequency should be at least 3"
+        );
+    }
+
+    #[test]
+    fn extract_candidates_filters_stop_words() {
+        // "The" and "This" are stop words — they should never appear as candidates
+        // even at high frequency.
+        let text =
+            "The quick fox. The lazy dog. The bright sun. This is great. This is fine. This works.";
+        let candidates = extract_candidates(text);
+        assert!(
+            !candidates.contains_key("The"),
+            "Stop word 'The' should be filtered"
+        );
+        assert!(
+            !candidates.contains_key("This"),
+            "Stop word 'This' should be filtered"
+        );
+    }
+
+    #[test]
+    fn score_entity_person_detects_speech_verbs() {
+        let name = "Alice";
+        let text = "Alice said hello. Alice asked a question. Alice told a story.";
+        let lines: Vec<String> = text.lines().map(String::from).collect();
+        let scores = score_entity(name, text, &lines);
+        assert!(
+            scores.person_score > 0,
+            "Person score should be positive when speech verbs are present"
+        );
+        assert!(
+            !scores.person_signals.is_empty(),
+            "Person signals should be non-empty for speech verb matches"
+        );
+    }
+
+    #[test]
+    fn score_entity_project_detects_build_verbs() {
+        let text =
+            "building Mempalace from scratch. deploying Mempalace to prod. shipping Mempalace v2.";
+        let lines: Vec<String> = text.lines().map(String::from).collect();
+        let scores = score_entity("Mempalace", text, &lines);
+        assert!(
+            scores.project_score > 0,
+            "Project score should be positive when build verbs are present"
+        );
+        assert!(
+            !scores.project_signals.is_empty(),
+            "Project signals should be non-empty for build verb matches"
+        );
+    }
+
+    #[test]
+    fn classify_entity_as_person() {
+        // High person score with multiple signal categories triggers person classification.
+        let scores = EntityScores {
+            person_score: 12,
+            project_score: 0,
+            person_signals: vec![
+                "'Alice said' (3x)".to_string(),
+                "dialogue marker (2x)".to_string(),
+                "pronoun nearby (1x)".to_string(),
+            ],
+            project_signals: vec![],
+        };
+        let entity = classify_entity("Alice", 10, &scores);
+        assert_eq!(
+            entity.entity_type, "person",
+            "Entity with high person score and multiple signal categories should be classified as person"
+        );
+        assert!(
+            entity.confidence > 0.5,
+            "Person confidence should be above 0.5"
+        );
+    }
+
+    #[test]
+    fn classify_entity_as_project() {
+        // Project score dominates — person_ratio <= 0.3 triggers project classification.
+        let scores = EntityScores {
+            person_score: 0,
+            project_score: 10,
+            person_signals: vec![],
+            project_signals: vec!["project verb (5x)".to_string()],
+        };
+        let entity = classify_entity("Mempalace", 8, &scores);
+        assert_eq!(
+            entity.entity_type, "project",
+            "Entity with dominant project score should be classified as project"
+        );
+        assert!(
+            entity.confidence > 0.5,
+            "Project confidence should be above 0.5"
+        );
+    }
+
+    #[test]
+    fn detect_entities_end_to_end() {
+        // Write temp files with a name repeated enough times to cross the threshold.
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+        let file_path = dir.path().join("story.txt");
+        let mut f = std::fs::File::create(&file_path).expect("file should be created");
+        let content = "Alice said hello. Alice asked why. Alice told Bob. Alice replied quickly. Alice laughed.\n";
+        f.write_all(content.as_bytes())
+            .expect("write should succeed");
+
+        let paths: Vec<&Path> = vec![file_path.as_path()];
+        let result = detect_entities(&paths, 10);
+
+        // At least one category should be non-empty since "Alice" appears 5 times
+        // with person-verb signals.
+        let total = result.people.len() + result.projects.len() + result.uncertain.len();
+        assert!(total > 0, "Should detect at least one entity");
+        assert!(
+            result.people.iter().any(|e| e.name == "Alice")
+                || result.uncertain.iter().any(|e| e.name == "Alice"),
+            "Alice should appear in people or uncertain"
+        );
+    }
+
+    #[test]
+    fn detect_entities_empty_files() {
+        // Empty files should produce no candidates — but extract_candidates asserts
+        // non-empty text, so detect_entities handles the empty-read case by
+        // producing an empty all_text only if no files are readable.
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+        let file_path = dir.path().join("empty.txt");
+        std::fs::write(&file_path, "").expect("write should succeed");
+
+        // The file is empty so read_to_string returns "" which gets appended as
+        // just a newline. detect_entities calls extract_candidates only when
+        // all_text is non-empty after accumulation. With a single empty file,
+        // all_text is "\n" which is non-empty but has no capitalized words.
+        let paths: Vec<&Path> = vec![file_path.as_path()];
+        let result = detect_entities(&paths, 10);
+
+        assert!(result.people.is_empty(), "No people from empty file");
+        assert!(result.projects.is_empty(), "No projects from empty file");
+    }
+}

--- a/src/palace/entity_detect.rs
+++ b/src/palace/entity_detect.rs
@@ -443,6 +443,7 @@ fn classify_entity_build(
 }
 
 #[cfg(test)]
+// Acceptable in tests: .expect() produces immediate, clear failures.
 #[allow(clippy::expect_used)]
 mod tests {
     use super::*;

--- a/src/palace/layers.rs
+++ b/src/palace/layers.rs
@@ -226,8 +226,12 @@ mod tests {
             "layer1 output should contain the essential story header"
         );
         assert!(
-            result.contains("Rust compiler") || result.contains("UI mockups"),
-            "layer1 output should contain content snippets from seeded drawers"
+            result.contains("Rust compiler"),
+            "layer1 output should contain content from the first seeded drawer"
+        );
+        assert!(
+            result.contains("UI mockups"),
+            "layer1 output should contain content from the second seeded drawer"
         );
     }
 

--- a/src/palace/layers.rs
+++ b/src/palace/layers.rs
@@ -141,3 +141,127 @@ pub async fn wake_up(connection: &Connection, wing: Option<&str>) -> Result<Stri
     let tokens = text.len() / 4;
     Ok(format!("{text}\n\n(~{tokens} tokens)"))
 }
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::palace::drawer::{self, DrawerParams};
+
+    #[test]
+    fn layer0_returns_string() {
+        let result = layer0();
+        assert!(
+            !result.is_empty(),
+            "layer0 should return a non-empty string"
+        );
+        assert!(
+            result.contains("L0"),
+            "layer0 output should contain the L0 section header"
+        );
+    }
+
+    #[tokio::test]
+    async fn layer1_empty_palace() {
+        let (_db, connection) = crate::test_helpers::test_db().await;
+        let result = layer1(&connection, None)
+            .await
+            .expect("layer1 should succeed on empty DB");
+        assert!(
+            result.contains("No memories yet"),
+            "Empty palace should indicate no memories"
+        );
+        assert!(
+            result.contains("L1"),
+            "layer1 output should contain the L1 section header"
+        );
+    }
+
+    #[tokio::test]
+    async fn layer1_with_seeded_drawers() {
+        let (_db, connection) = crate::test_helpers::test_db().await;
+
+        // Seed two drawers in different rooms.
+        drawer::add_drawer(
+            &connection,
+            &DrawerParams {
+                id: "d_layer_1",
+                wing: "testwing",
+                room: "engineering",
+                content: "Rust compiler internals and borrow checker details for the project",
+                source_file: "notes.md",
+                chunk_index: 0,
+                added_by: "test",
+                ingest_mode: "projects",
+                source_mtime: None,
+            },
+        )
+        .await
+        .expect("first add_drawer should succeed");
+
+        drawer::add_drawer(
+            &connection,
+            &DrawerParams {
+                id: "d_layer_2",
+                wing: "testwing",
+                room: "design",
+                content: "UI mockups and wireframes for the dashboard redesign project",
+                source_file: "design.md",
+                chunk_index: 0,
+                added_by: "test",
+                ingest_mode: "projects",
+                source_mtime: None,
+            },
+        )
+        .await
+        .expect("second add_drawer should succeed");
+
+        let result = layer1(&connection, Some("testwing"))
+            .await
+            .expect("layer1 should succeed with seeded drawers");
+
+        assert!(
+            result.contains("ESSENTIAL STORY"),
+            "layer1 output should contain the essential story header"
+        );
+        assert!(
+            result.contains("Rust compiler") || result.contains("UI mockups"),
+            "layer1 output should contain content snippets from seeded drawers"
+        );
+    }
+
+    #[tokio::test]
+    async fn wake_up_includes_token_estimate() {
+        let (_db, connection) = crate::test_helpers::test_db().await;
+
+        drawer::add_drawer(
+            &connection,
+            &DrawerParams {
+                id: "d_wake_1",
+                wing: "testwing",
+                room: "general",
+                content: "Important context about the mempalace architecture and design decisions",
+                source_file: "arch.md",
+                chunk_index: 0,
+                added_by: "test",
+                ingest_mode: "projects",
+                source_mtime: None,
+            },
+        )
+        .await
+        .expect("add_drawer should succeed");
+
+        let result = wake_up(&connection, Some("testwing"))
+            .await
+            .expect("wake_up should succeed with seeded data");
+
+        assert!(
+            result.contains("token"),
+            "wake_up output should contain a token estimate"
+        );
+        assert!(
+            result.contains("L0") && result.contains("L1"),
+            "wake_up output should contain both L0 and L1 sections"
+        );
+    }
+}

--- a/src/palace/layers.rs
+++ b/src/palace/layers.rs
@@ -143,6 +143,7 @@ pub async fn wake_up(connection: &Connection, wing: Option<&str>) -> Result<Stri
 }
 
 #[cfg(test)]
+// Acceptable in tests: .expect() produces immediate, clear failures.
 #[allow(clippy::expect_used)]
 mod tests {
     use super::*;

--- a/src/palace/miner.rs
+++ b/src/palace/miner.rs
@@ -412,3 +412,183 @@ pub async fn mine(connection: &Connection, project_dir: &Path, opts: &MineParams
     );
     Ok(())
 }
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scan_project_finds_text_files() {
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+
+        // Create files with readable extensions.
+        std::fs::write(dir.path().join("main.rs"), "fn main() {}")
+            .expect("write .rs should succeed");
+        std::fs::write(dir.path().join("notes.txt"), "hello world")
+            .expect("write .txt should succeed");
+
+        let files = scan_project(dir.path());
+        let names: Vec<String> = files
+            .iter()
+            .map(|p| {
+                p.file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .to_string()
+            })
+            .collect();
+
+        assert!(
+            names.contains(&"main.rs".to_string()),
+            "Should find .rs files"
+        );
+        assert!(
+            names.contains(&"notes.txt".to_string()),
+            "Should find .txt files"
+        );
+    }
+
+    #[test]
+    fn scan_project_respects_gitignore() {
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+
+        // Initialize a git repo so the ignore crate respects .gitignore.
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(dir.path())
+            .output()
+            .expect("git init should succeed");
+
+        // Gitignore a .rs file — .log is not in READABLE_EXTENSIONS so it would
+        // be skipped regardless of .gitignore.
+        std::fs::write(dir.path().join(".gitignore"), "ignored.rs\n")
+            .expect("write .gitignore should succeed");
+        std::fs::write(dir.path().join("app.rs"), "fn main() {}")
+            .expect("write .rs should succeed");
+        std::fs::write(dir.path().join("ignored.rs"), "// ignored")
+            .expect("write ignored.rs should succeed");
+
+        let files = scan_project(dir.path());
+        let names: Vec<String> = files
+            .iter()
+            .map(|p| {
+                p.file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .to_string()
+            })
+            .collect();
+
+        assert!(
+            names.contains(&"app.rs".to_string()),
+            "Non-ignored .rs should be found"
+        );
+        assert!(
+            !names.contains(&"ignored.rs".to_string()),
+            "Gitignored file should be excluded"
+        );
+    }
+
+    #[test]
+    fn scan_project_with_opts_ignores_gitignore() {
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+
+        // Initialize a git repo so .gitignore is meaningful.
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(dir.path())
+            .output()
+            .expect("git init should succeed");
+
+        std::fs::write(dir.path().join(".gitignore"), "ignored.rs\n")
+            .expect("write .gitignore should succeed");
+        std::fs::write(dir.path().join("app.rs"), "fn main() {}")
+            .expect("write .rs should succeed");
+        std::fs::write(dir.path().join("ignored.rs"), "// should appear")
+            .expect("write ignored.rs should succeed");
+
+        let files = scan_project_with_opts(dir.path(), false);
+        let names: Vec<String> = files
+            .iter()
+            .map(|p| {
+                p.file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .to_string()
+            })
+            .collect();
+
+        assert!(
+            names.contains(&"app.rs".to_string()),
+            "Non-ignored .rs should be found"
+        );
+        assert!(
+            names.contains(&"ignored.rs".to_string()),
+            "With respect_gitignore=false, gitignored file should be included"
+        );
+    }
+
+    #[test]
+    fn scan_project_skips_node_modules() {
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+
+        let nm = dir.path().join("node_modules");
+        std::fs::create_dir(&nm).expect("create node_modules should succeed");
+        std::fs::write(nm.join("foo.js"), "console.log('hi')")
+            .expect("write foo.js should succeed");
+        std::fs::write(dir.path().join("index.js"), "console.log('main')")
+            .expect("write index.js should succeed");
+
+        let files = scan_project(dir.path());
+        let names: Vec<String> = files
+            .iter()
+            .map(|p| {
+                p.file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .to_string()
+            })
+            .collect();
+
+        assert!(
+            names.contains(&"index.js".to_string()),
+            "Top-level .js should be found"
+        );
+        assert!(
+            !names.iter().any(|n| n == "foo.js"),
+            "Files inside node_modules should be skipped"
+        );
+    }
+
+    #[test]
+    fn scan_project_skips_binary_extensions() {
+        // Files with extensions not in READABLE_EXTENSIONS should be excluded.
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+
+        std::fs::write(dir.path().join("image.png"), [0x89, 0x50, 0x4E, 0x47])
+            .expect("write .png should succeed");
+        std::fs::write(dir.path().join("code.rs"), "fn main() {}")
+            .expect("write .rs should succeed");
+
+        let files = scan_project(dir.path());
+        let names: Vec<String> = files
+            .iter()
+            .map(|p| {
+                p.file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .to_string()
+            })
+            .collect();
+
+        assert!(
+            names.contains(&"code.rs".to_string()),
+            "Readable extension should be found"
+        );
+        assert!(
+            !names.contains(&"image.png".to_string()),
+            "Non-readable extension should be excluded"
+        );
+    }
+}

--- a/src/palace/miner.rs
+++ b/src/palace/miner.rs
@@ -414,6 +414,7 @@ pub async fn mine(connection: &Connection, project_dir: &Path, opts: &MineParams
 }
 
 #[cfg(test)]
+// Acceptable in tests: .expect() produces immediate, clear failures.
 #[allow(clippy::expect_used)]
 mod tests {
     use super::*;
@@ -454,11 +455,18 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir should be created");
 
         // Initialize a git repo so the ignore crate respects .gitignore.
-        std::process::Command::new("git")
+        let git_init_output = std::process::Command::new("git")
             .args(["init"])
             .current_dir(dir.path())
             .output()
-            .expect("git init should succeed");
+            .expect("git init command should run");
+        assert!(
+            git_init_output.status.success(),
+            "git init failed: {:?} stdout={:?} stderr={:?}",
+            git_init_output.status,
+            String::from_utf8_lossy(&git_init_output.stdout),
+            String::from_utf8_lossy(&git_init_output.stderr),
+        );
 
         // Gitignore a .rs file — .log is not in READABLE_EXTENSIONS so it would
         // be skipped regardless of .gitignore.
@@ -495,11 +503,18 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir should be created");
 
         // Initialize a git repo so .gitignore is meaningful.
-        std::process::Command::new("git")
+        let git_init_output = std::process::Command::new("git")
             .args(["init"])
             .current_dir(dir.path())
             .output()
-            .expect("git init should succeed");
+            .expect("git init command should run");
+        assert!(
+            git_init_output.status.success(),
+            "git init failed: {:?} stdout={:?} stderr={:?}",
+            git_init_output.status,
+            String::from_utf8_lossy(&git_init_output.stdout),
+            String::from_utf8_lossy(&git_init_output.stderr),
+        );
 
         std::fs::write(dir.path().join(".gitignore"), "ignored.rs\n")
             .expect("write .gitignore should succeed");

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -145,6 +145,7 @@ pub async fn ensure_schema(connection: &Connection) -> Result<()> {
 }
 
 #[cfg(test)]
+// Acceptable in tests: .expect() produces immediate, clear failures.
 #[allow(clippy::expect_used)]
 mod tests {
     use super::*;
@@ -194,31 +195,37 @@ mod tests {
     async fn ensure_schema_idempotent() {
         let (_db, conn) = crate::test_helpers::test_db().await;
 
-        // test_db already called ensure_schema once; call it again.
+        // Record the table count after the first ensure_schema (called by test_db).
+        let count_query = "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table'";
+        let rows_before = crate::db::query_all(&conn, count_query, ())
+            .await
+            .expect("table count query before second call should succeed");
+        let count_before: i64 = rows_before[0]
+            .get(0)
+            .expect("COUNT(*) column 0 should be readable as i64");
+        let expected_table_count =
+            i64::try_from(EXPECTED_TABLES.len()).expect("table count fits in i64");
+        assert!(
+            count_before >= expected_table_count,
+            "at least {} core tables should exist before second call, got {count_before}",
+            EXPECTED_TABLES.len()
+        );
+
+        // Call ensure_schema a second time — must not add tables.
         ensure_schema(&conn)
             .await
             .expect("second ensure_schema call should succeed (idempotent)");
 
-        let rows = crate::db::query_all(
-            &conn,
-            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table'",
-            (),
-        )
-        .await
-        .expect("table count query should succeed");
-        let count: i64 = rows[0]
+        let rows_after = crate::db::query_all(&conn, count_query, ())
+            .await
+            .expect("table count query after second call should succeed");
+        let count_after: i64 = rows_after[0]
             .get(0)
             .expect("COUNT(*) column 0 should be readable as i64");
 
-        // Table count must be at least the 6 core tables and must not have changed.
-        assert!(
-            count >= 6,
-            "at least 6 core tables should exist, got {count}"
-        );
         assert_eq!(
-            usize::try_from(count).expect("table count should fit in usize"),
-            EXPECTED_TABLES.len(),
-            "table count should match expected after idempotent call"
+            count_before, count_after,
+            "ensure_schema must not add or remove tables on second call"
         );
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -143,3 +143,82 @@ pub async fn ensure_schema(connection: &Connection) -> Result<()> {
 
     Ok(())
 }
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    const EXPECTED_TABLES: &[&str] = &[
+        "compressed",
+        "drawer_words",
+        "drawers",
+        "entities",
+        "explicit_tunnels",
+        "triples",
+    ];
+
+    #[tokio::test]
+    async fn ensure_schema_creates_all_tables() {
+        let (_db, conn) = crate::test_helpers::test_db().await;
+
+        let rows = crate::db::query_all(
+            &conn,
+            "SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name",
+            (),
+        )
+        .await
+        .expect("sqlite_master query should succeed after ensure_schema");
+
+        let table_names: Vec<String> = rows
+            .iter()
+            .filter_map(|r| r.get::<String>(0).ok())
+            .collect();
+
+        // All 6 core tables must be present.
+        for &expected in EXPECTED_TABLES {
+            assert!(
+                table_names.contains(&expected.to_string()),
+                "table '{expected}' must exist after ensure_schema"
+            );
+        }
+        assert!(
+            table_names.len() >= EXPECTED_TABLES.len(),
+            "at least {} tables should exist, found {}",
+            EXPECTED_TABLES.len(),
+            table_names.len()
+        );
+    }
+
+    #[tokio::test]
+    async fn ensure_schema_idempotent() {
+        let (_db, conn) = crate::test_helpers::test_db().await;
+
+        // test_db already called ensure_schema once; call it again.
+        ensure_schema(&conn)
+            .await
+            .expect("second ensure_schema call should succeed (idempotent)");
+
+        let rows = crate::db::query_all(
+            &conn,
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table'",
+            (),
+        )
+        .await
+        .expect("table count query should succeed");
+        let count: i64 = rows[0]
+            .get(0)
+            .expect("COUNT(*) column 0 should be readable as i64");
+
+        // Table count must be at least the 6 core tables and must not have changed.
+        assert!(
+            count >= 6,
+            "at least 6 core tables should exist, got {count}"
+        );
+        assert_eq!(
+            usize::try_from(count).expect("table count should fit in usize"),
+            EXPECTED_TABLES.len(),
+            "table count should match expected after idempotent call"
+        );
+    }
+}

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -1,11 +1,37 @@
 // Test infrastructure — .expect() is acceptable with a descriptive message.
 #![allow(clippy::expect_used)]
 
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
 use turso::Connection;
+
+// Process-scoped config directory for tests. Kept as a `PathBuf` (not a
+// `TempDir`) because `test_helpers` is compiled as a library module, where
+// `tempfile` is not available (it is a dev-dependency only). The directory
+// lives under `std::env::temp_dir()` and is cleaned up by the OS.
+static TEST_CONFIG_DIR: OnceLock<PathBuf> = OnceLock::new();
+
+/// Redirect all config and WAL writes to a per-process temporary directory.
+///
+/// Uses `OnceLock` so the directory is created and registered exactly once,
+/// regardless of how many tests call `test_db` concurrently — safe for
+/// parallel test execution without any locking on the caller side.
+fn redirect_config_dir() {
+    TEST_CONFIG_DIR.get_or_init(|| {
+        // Use the process ID so parallel test processes don't share the same
+        // directory and overwrite each other's WAL files.
+        let path = std::env::temp_dir().join(format!("mempalace_test_{}", std::process::id()));
+        std::fs::create_dir_all(&path).expect("failed to create test config dir");
+        crate::config::set_config_dir_override(path.clone());
+        path
+    });
+}
 
 /// Create an in-memory turso database with the full schema applied.
 /// Returns (Database, Connection) tuple to keep the Database alive for the test lifetime.
 pub async fn test_db() -> (turso::Database, Connection) {
+    redirect_config_dir();
     let db = turso::Builder::new_local(":memory:")
         .experimental_triggers(true)
         .build()

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -1,37 +1,11 @@
 // Test infrastructure — .expect() is acceptable with a descriptive message.
 #![allow(clippy::expect_used)]
 
-use std::path::PathBuf;
-use std::sync::OnceLock;
-
 use turso::Connection;
-
-// Process-scoped config directory for tests. Kept as a `PathBuf` (not a
-// `TempDir`) because `test_helpers` is compiled as a library module, where
-// `tempfile` is not available (it is a dev-dependency only). The directory
-// lives under `std::env::temp_dir()` and is cleaned up by the OS.
-static TEST_CONFIG_DIR: OnceLock<PathBuf> = OnceLock::new();
-
-/// Redirect all config and WAL writes to a per-process temporary directory.
-///
-/// Uses `OnceLock` so the directory is created and registered exactly once,
-/// regardless of how many tests call `test_db` concurrently — safe for
-/// parallel test execution without any locking on the caller side.
-fn redirect_config_dir() {
-    TEST_CONFIG_DIR.get_or_init(|| {
-        // Use the process ID so parallel test processes don't share the same
-        // directory and overwrite each other's WAL files.
-        let path = std::env::temp_dir().join(format!("mempalace_test_{}", std::process::id()));
-        std::fs::create_dir_all(&path).expect("failed to create test config dir");
-        crate::config::set_config_dir_override(path.clone());
-        path
-    });
-}
 
 /// Create an in-memory turso database with the full schema applied.
 /// Returns (Database, Connection) tuple to keep the Database alive for the test lifetime.
 pub async fn test_db() -> (turso::Database, Connection) {
-    redirect_config_dir();
     let db = turso::Builder::new_local(":memory:")
         .experimental_triggers(true)
         .build()

--- a/tests/compress_pipeline.rs
+++ b/tests/compress_pipeline.rs
@@ -1,0 +1,59 @@
+// Integration test — .expect() is acceptable with a descriptive message.
+#![allow(clippy::expect_used)]
+
+use std::collections::HashMap;
+
+use mempalace::dialect::Dialect;
+
+/// Compress a verbose paragraph and verify the output is shorter than the input.
+/// The AAAK dialect extracts topics, entities, and key sentences — the output
+/// should always be substantially smaller than conversational prose.
+#[test]
+fn compress_reduces_content_size() {
+    let dialect = Dialect::empty();
+
+    let verbose = "We had a long meeting today where we discussed the architecture \
+        of the new microservices platform. The team decided to use GraphQL instead \
+        of REST because it provides better flexibility for the frontend developers. \
+        We also talked about switching from PostgreSQL to CockroachDB for better \
+        horizontal scaling. The deployment pipeline needs to be updated to support \
+        the new container orchestration system.";
+
+    let compressed = dialect.compress(verbose, None);
+
+    assert!(
+        compressed.len() < verbose.len(),
+        "compressed ({} chars) should be shorter than original ({} chars)",
+        compressed.len(),
+        verbose.len()
+    );
+    // The compressed output should contain the AAAK format marker.
+    assert!(
+        compressed.contains("0:"),
+        "compressed output should contain AAAK entity marker '0:'"
+    );
+}
+
+/// Create a Dialect with known entity mappings, compress text mentioning
+/// those entities, and verify the short codes appear in the output.
+#[test]
+fn dialect_with_entities_replaces_names() {
+    let mut entities = HashMap::new();
+    entities.insert("Alice".to_string(), "ALC".to_string());
+    entities.insert("Bob".to_string(), "BOB".to_string());
+    let dialect = Dialect::new(&entities, vec![]);
+
+    let text = "Alice and Bob discussed the new database migration strategy \
+        for the quarterly planning review session yesterday afternoon.";
+
+    let compressed = dialect.compress(text, None);
+
+    assert!(
+        compressed.contains("ALC"),
+        "compressed output should contain Alice's short code 'ALC'"
+    );
+    assert!(
+        compressed.contains("BOB"),
+        "compressed output should contain Bob's short code 'BOB'"
+    );
+}

--- a/tests/kg_workflow.rs
+++ b/tests/kg_workflow.rs
@@ -9,17 +9,17 @@ use mempalace::test_helpers::test_db;
 /// outgoing and incoming relationships are correctly stored and returned.
 #[tokio::test]
 async fn entity_triple_query_lifecycle() {
-    let (_db, conn) = test_db().await;
+    let (_db, connection) = test_db().await;
 
-    add_entity(&conn, "Alice", "person", None)
+    add_entity(&connection, "Alice", "person", None)
         .await
         .expect("add_entity Alice should succeed");
-    add_entity(&conn, "Bob", "person", None)
+    add_entity(&connection, "Bob", "person", None)
         .await
         .expect("add_entity Bob should succeed");
 
     add_triple(
-        &conn,
+        &connection,
         &TripleParams {
             subject: "Alice",
             predicate: "knows",
@@ -35,14 +35,14 @@ async fn entity_triple_query_lifecycle() {
     .expect("add_triple Alice->knows->Bob should succeed");
 
     // Alice's outgoing facts should include "knows".
-    let outgoing = query_entity(&conn, "Alice", None, "outgoing")
+    let outgoing = query_entity(&connection, "Alice", None, "outgoing")
         .await
         .expect("query_entity outgoing should succeed");
     assert_eq!(outgoing.len(), 1, "Alice should have 1 outgoing fact");
     assert_eq!(outgoing[0].predicate, "knows");
 
     // Bob's incoming facts should include "knows".
-    let incoming = query_entity(&conn, "Bob", None, "incoming")
+    let incoming = query_entity(&connection, "Bob", None, "incoming")
         .await
         .expect("query_entity incoming should succeed");
     assert_eq!(incoming.len(), 1, "Bob should have 1 incoming fact");
@@ -53,10 +53,10 @@ async fn entity_triple_query_lifecycle() {
 /// then verify the timeline shows a `valid_to` date.
 #[tokio::test]
 async fn invalidate_updates_timeline() {
-    let (_db, conn) = test_db().await;
+    let (_db, connection) = test_db().await;
 
     add_triple(
-        &conn,
+        &connection,
         &TripleParams {
             subject: "Carol",
             predicate: "works at",
@@ -72,7 +72,7 @@ async fn invalidate_updates_timeline() {
     .expect("add_triple Carol->works_at->OldCo should succeed");
 
     // Before invalidation: timeline should show the fact as current.
-    let before = timeline(&conn, Some("Carol"))
+    let before = timeline(&connection, Some("Carol"))
         .await
         .expect("timeline should succeed before invalidation");
     assert_eq!(before.len(), 1, "should have 1 timeline entry");
@@ -82,12 +82,18 @@ async fn invalidate_updates_timeline() {
     );
 
     // Invalidate with explicit end date.
-    invalidate(&conn, "Carol", "works at", "OldCo", Some("2024-06-01"))
-        .await
-        .expect("invalidate should succeed");
+    invalidate(
+        &connection,
+        "Carol",
+        "works at",
+        "OldCo",
+        Some("2024-06-01"),
+    )
+    .await
+    .expect("invalidate should succeed");
 
     // After invalidation: timeline should show valid_to.
-    let after = timeline(&conn, Some("Carol"))
+    let after = timeline(&connection, Some("Carol"))
         .await
         .expect("timeline should succeed after invalidation");
     assert_eq!(after.len(), 1, "should still have 1 timeline entry");
@@ -101,24 +107,24 @@ async fn invalidate_updates_timeline() {
 /// Verify stats counters track entities, triples, and expired facts accurately.
 #[tokio::test]
 async fn stats_reflect_operations() {
-    let (_db, conn) = test_db().await;
+    let (_db, connection) = test_db().await;
 
     // Empty DB.
-    let s0 = stats(&conn)
+    let stats_empty = stats(&connection)
         .await
         .expect("stats on empty DB should succeed");
-    assert_eq!(s0.entities, 0, "fresh DB should have 0 entities");
-    assert_eq!(s0.triples, 0, "fresh DB should have 0 triples");
+    assert_eq!(stats_empty.entities, 0, "fresh DB should have 0 entities");
+    assert_eq!(stats_empty.triples, 0, "fresh DB should have 0 triples");
 
     // Add entities and a triple.
-    add_entity(&conn, "Dave", "person", None)
+    add_entity(&connection, "Dave", "person", None)
         .await
         .expect("add_entity Dave should succeed");
-    add_entity(&conn, "Eve", "person", None)
+    add_entity(&connection, "Eve", "person", None)
         .await
         .expect("add_entity Eve should succeed");
     add_triple(
-        &conn,
+        &connection,
         &TripleParams {
             subject: "Dave",
             predicate: "likes",
@@ -133,41 +139,55 @@ async fn stats_reflect_operations() {
     .await
     .expect("add_triple Dave->likes->Eve should succeed");
 
-    let s1 = stats(&conn).await.expect("stats after adds should succeed");
-    assert_eq!(s1.entities, 2, "should have 2 entities");
-    assert_eq!(s1.triples, 1, "should have 1 triple");
-    assert_eq!(s1.current_facts, 1, "1 current fact before invalidation");
+    let stats_after_add = stats(&connection)
+        .await
+        .expect("stats after adds should succeed");
+    assert_eq!(stats_after_add.entities, 2, "should have 2 entities");
+    assert_eq!(stats_after_add.triples, 1, "should have 1 triple");
+    assert_eq!(
+        stats_after_add.current_facts, 1,
+        "1 current fact before invalidation"
+    );
 
     // Invalidate the triple.
-    invalidate(&conn, "Dave", "likes", "Eve", Some("2025-01-01"))
+    invalidate(&connection, "Dave", "likes", "Eve", Some("2025-01-01"))
         .await
         .expect("invalidate should succeed");
 
-    let s2 = stats(&conn)
+    let stats_after_invalidate = stats(&connection)
         .await
         .expect("stats after invalidate should succeed");
-    assert_eq!(s2.triples, 1, "total triples unchanged after invalidation");
-    assert_eq!(s2.current_facts, 0, "no current facts after invalidation");
-    assert_eq!(s2.expired_facts, 1, "1 expired fact after invalidation");
+    assert_eq!(
+        stats_after_invalidate.triples, 1,
+        "total triples unchanged after invalidation"
+    );
+    assert_eq!(
+        stats_after_invalidate.current_facts, 0,
+        "no current facts after invalidation"
+    );
+    assert_eq!(
+        stats_after_invalidate.expired_facts, 1,
+        "1 expired fact after invalidation"
+    );
 }
 
 /// Create multiple triples between the same pair of entities and verify
 /// all are returned by `query_entity`.
 #[tokio::test]
 async fn multiple_triples_same_entities() {
-    let (_db, conn) = test_db().await;
+    let (_db, connection) = test_db().await;
 
-    add_entity(&conn, "Frank", "person", None)
+    add_entity(&connection, "Frank", "person", None)
         .await
         .expect("add_entity Frank should succeed");
-    add_entity(&conn, "Grace", "person", None)
+    add_entity(&connection, "Grace", "person", None)
         .await
         .expect("add_entity Grace should succeed");
 
     // Add three distinct relationships between the same pair.
     for predicate in &["knows", "works with", "mentors"] {
         add_triple(
-            &conn,
+            &connection,
             &TripleParams {
                 subject: "Frank",
                 predicate,
@@ -183,7 +203,7 @@ async fn multiple_triples_same_entities() {
         .expect("add_triple should succeed for each predicate");
     }
 
-    let facts = query_entity(&conn, "Frank", None, "outgoing")
+    let facts = query_entity(&connection, "Frank", None, "outgoing")
         .await
         .expect("query_entity outgoing should succeed");
     assert_eq!(facts.len(), 3, "Frank should have 3 outgoing facts");

--- a/tests/kg_workflow.rs
+++ b/tests/kg_workflow.rs
@@ -1,0 +1,197 @@
+// Integration test — .expect() is acceptable with a descriptive message.
+#![allow(clippy::expect_used)]
+
+use mempalace::kg::query::{query_entity, stats, timeline};
+use mempalace::kg::{TripleParams, add_entity, add_triple, invalidate};
+use mempalace::test_helpers::test_db;
+
+/// Add entities, create a triple, then query from both sides to verify
+/// outgoing and incoming relationships are correctly stored and returned.
+#[tokio::test]
+async fn entity_triple_query_lifecycle() {
+    let (_db, conn) = test_db().await;
+
+    add_entity(&conn, "Alice", "person", None)
+        .await
+        .expect("add_entity Alice should succeed");
+    add_entity(&conn, "Bob", "person", None)
+        .await
+        .expect("add_entity Bob should succeed");
+
+    add_triple(
+        &conn,
+        &TripleParams {
+            subject: "Alice",
+            predicate: "knows",
+            object: "Bob",
+            valid_from: Some("2024-01-01"),
+            valid_to: None,
+            confidence: 1.0,
+            source_closet: None,
+            source_file: None,
+        },
+    )
+    .await
+    .expect("add_triple Alice->knows->Bob should succeed");
+
+    // Alice's outgoing facts should include "knows".
+    let outgoing = query_entity(&conn, "Alice", None, "outgoing")
+        .await
+        .expect("query_entity outgoing should succeed");
+    assert_eq!(outgoing.len(), 1, "Alice should have 1 outgoing fact");
+    assert_eq!(outgoing[0].predicate, "knows");
+
+    // Bob's incoming facts should include "knows".
+    let incoming = query_entity(&conn, "Bob", None, "incoming")
+        .await
+        .expect("query_entity incoming should succeed");
+    assert_eq!(incoming.len(), 1, "Bob should have 1 incoming fact");
+    assert_eq!(incoming[0].predicate, "knows");
+}
+
+/// Add a triple, verify it appears in the timeline as current, invalidate it,
+/// then verify the timeline shows a `valid_to` date.
+#[tokio::test]
+async fn invalidate_updates_timeline() {
+    let (_db, conn) = test_db().await;
+
+    add_triple(
+        &conn,
+        &TripleParams {
+            subject: "Carol",
+            predicate: "works at",
+            object: "OldCo",
+            valid_from: Some("2024-01-15"),
+            valid_to: None,
+            confidence: 0.9,
+            source_closet: None,
+            source_file: None,
+        },
+    )
+    .await
+    .expect("add_triple Carol->works_at->OldCo should succeed");
+
+    // Before invalidation: timeline should show the fact as current.
+    let before = timeline(&conn, Some("Carol"))
+        .await
+        .expect("timeline should succeed before invalidation");
+    assert_eq!(before.len(), 1, "should have 1 timeline entry");
+    assert!(
+        before[0].valid_to.is_none(),
+        "fact should be current (no valid_to)"
+    );
+
+    // Invalidate with explicit end date.
+    invalidate(&conn, "Carol", "works at", "OldCo", Some("2024-06-01"))
+        .await
+        .expect("invalidate should succeed");
+
+    // After invalidation: timeline should show valid_to.
+    let after = timeline(&conn, Some("Carol"))
+        .await
+        .expect("timeline should succeed after invalidation");
+    assert_eq!(after.len(), 1, "should still have 1 timeline entry");
+    assert_eq!(
+        after[0].valid_to.as_deref(),
+        Some("2024-06-01"),
+        "valid_to should match the invalidation date"
+    );
+}
+
+/// Verify stats counters track entities, triples, and expired facts accurately.
+#[tokio::test]
+async fn stats_reflect_operations() {
+    let (_db, conn) = test_db().await;
+
+    // Empty DB.
+    let s0 = stats(&conn)
+        .await
+        .expect("stats on empty DB should succeed");
+    assert_eq!(s0.entities, 0, "fresh DB should have 0 entities");
+    assert_eq!(s0.triples, 0, "fresh DB should have 0 triples");
+
+    // Add entities and a triple.
+    add_entity(&conn, "Dave", "person", None)
+        .await
+        .expect("add_entity Dave should succeed");
+    add_entity(&conn, "Eve", "person", None)
+        .await
+        .expect("add_entity Eve should succeed");
+    add_triple(
+        &conn,
+        &TripleParams {
+            subject: "Dave",
+            predicate: "likes",
+            object: "Eve",
+            valid_from: None,
+            valid_to: None,
+            confidence: 1.0,
+            source_closet: None,
+            source_file: None,
+        },
+    )
+    .await
+    .expect("add_triple Dave->likes->Eve should succeed");
+
+    let s1 = stats(&conn).await.expect("stats after adds should succeed");
+    assert_eq!(s1.entities, 2, "should have 2 entities");
+    assert_eq!(s1.triples, 1, "should have 1 triple");
+    assert_eq!(s1.current_facts, 1, "1 current fact before invalidation");
+
+    // Invalidate the triple.
+    invalidate(&conn, "Dave", "likes", "Eve", Some("2025-01-01"))
+        .await
+        .expect("invalidate should succeed");
+
+    let s2 = stats(&conn)
+        .await
+        .expect("stats after invalidate should succeed");
+    assert_eq!(s2.triples, 1, "total triples unchanged after invalidation");
+    assert_eq!(s2.current_facts, 0, "no current facts after invalidation");
+    assert_eq!(s2.expired_facts, 1, "1 expired fact after invalidation");
+}
+
+/// Create multiple triples between the same pair of entities and verify
+/// all are returned by `query_entity`.
+#[tokio::test]
+async fn multiple_triples_same_entities() {
+    let (_db, conn) = test_db().await;
+
+    add_entity(&conn, "Frank", "person", None)
+        .await
+        .expect("add_entity Frank should succeed");
+    add_entity(&conn, "Grace", "person", None)
+        .await
+        .expect("add_entity Grace should succeed");
+
+    // Add three distinct relationships between the same pair.
+    for predicate in &["knows", "works with", "mentors"] {
+        add_triple(
+            &conn,
+            &TripleParams {
+                subject: "Frank",
+                predicate,
+                object: "Grace",
+                valid_from: None,
+                valid_to: None,
+                confidence: 1.0,
+                source_closet: None,
+                source_file: None,
+            },
+        )
+        .await
+        .expect("add_triple should succeed for each predicate");
+    }
+
+    let facts = query_entity(&conn, "Frank", None, "outgoing")
+        .await
+        .expect("query_entity outgoing should succeed");
+    assert_eq!(facts.len(), 3, "Frank should have 3 outgoing facts");
+
+    let predicates: Vec<&str> = facts.iter().map(|f| f.predicate.as_str()).collect();
+    assert!(predicates.contains(&"knows"), "should contain 'knows'");
+    assert!(
+        predicates.contains(&"works_with"),
+        "should contain 'works_with'"
+    );
+}

--- a/tests/kg_workflow.rs
+++ b/tests/kg_workflow.rs
@@ -210,8 +210,9 @@ async fn multiple_triples_same_entities() {
 
     let predicates: Vec<&str> = facts.iter().map(|f| f.predicate.as_str()).collect();
     assert!(predicates.contains(&"knows"), "should contain 'knows'");
+    // Predicates are normalized on write: spaces become underscores.
     assert!(
-        predicates.contains(&"works with"),
-        "should contain 'works with'"
+        predicates.contains(&"works_with"),
+        "should contain 'works_with' (normalized from 'works with')"
     );
 }

--- a/tests/kg_workflow.rs
+++ b/tests/kg_workflow.rs
@@ -211,7 +211,7 @@ async fn multiple_triples_same_entities() {
     let predicates: Vec<&str> = facts.iter().map(|f| f.predicate.as_str()).collect();
     assert!(predicates.contains(&"knows"), "should contain 'knows'");
     assert!(
-        predicates.contains(&"works_with"),
-        "should contain 'works_with'"
+        predicates.contains(&"works with"),
+        "should contain 'works with'"
     );
 }

--- a/tests/kg_workflow.rs
+++ b/tests/kg_workflow.rs
@@ -215,4 +215,5 @@ async fn multiple_triples_same_entities() {
         predicates.contains(&"works_with"),
         "should contain 'works_with' (normalized from 'works with')"
     );
+    assert!(predicates.contains(&"mentors"), "should contain 'mentors'");
 }

--- a/tests/mcp_request_cycle.rs
+++ b/tests/mcp_request_cycle.rs
@@ -1,0 +1,253 @@
+// Integration test — .expect() is acceptable with a descriptive message.
+#![allow(clippy::expect_used)]
+
+use mempalace::mcp::tools::dispatch;
+use mempalace::test_helpers::test_db;
+use serde_json::json;
+
+/// Add a drawer via dispatch, search for it, delete it, then verify search
+/// returns nothing. Exercises the full CRUD path through the MCP tool layer.
+#[tokio::test]
+async fn full_lifecycle_add_search_delete() {
+    let (_db, conn) = test_db().await;
+
+    // Add a drawer with distinctive content.
+    let add_result = dispatch(
+        &conn,
+        "mempalace_add_drawer",
+        &json!({
+            "wing": "testproject",
+            "room": "backend",
+            "content": "rust programming language performance benchmarks"
+        }),
+    )
+    .await;
+    assert_eq!(add_result["success"], true, "add_drawer should succeed");
+    let drawer_id = add_result["drawer_id"]
+        .as_str()
+        .expect("drawer_id should be a string")
+        .to_string();
+    assert!(
+        drawer_id.starts_with("drawer_"),
+        "drawer_id should have drawer_ prefix"
+    );
+
+    // Search should find the drawer.
+    let search_result = dispatch(
+        &conn,
+        "mempalace_search",
+        &json!({"query": "rust programming benchmarks"}),
+    )
+    .await;
+    let count = search_result["count"]
+        .as_i64()
+        .expect("count should be i64");
+    assert!(count >= 1, "search should find the drawer we just added");
+
+    // Delete the drawer.
+    let del_result = dispatch(
+        &conn,
+        "mempalace_delete_drawer",
+        &json!({"drawer_id": drawer_id}),
+    )
+    .await;
+    assert_eq!(del_result["success"], true, "delete should succeed");
+
+    // Search again — should find nothing.
+    let search_after = dispatch(
+        &conn,
+        "mempalace_search",
+        &json!({"query": "rust programming benchmarks"}),
+    )
+    .await;
+    let after_count = search_after["count"].as_i64().expect("count should be i64");
+    assert_eq!(after_count, 0, "search should return 0 after deletion");
+}
+
+/// Dispatch status after adding drawers to verify counters track operations.
+#[tokio::test]
+async fn status_reflects_drawer_operations() {
+    let (_db, conn) = test_db().await;
+
+    // Empty palace should report 0 drawers.
+    let status0 = dispatch(&conn, "mempalace_status", &json!({})).await;
+    assert_eq!(
+        status0["total_drawers"], 0,
+        "fresh DB should have 0 drawers"
+    );
+
+    // Add first drawer.
+    let r1 = dispatch(
+        &conn,
+        "mempalace_add_drawer",
+        &json!({
+            "wing": "projA",
+            "room": "general",
+            "content": "first drawer content here with enough words"
+        }),
+    )
+    .await;
+    assert_eq!(r1["success"], true, "first add should succeed");
+
+    let status1 = dispatch(&conn, "mempalace_status", &json!({})).await;
+    assert_eq!(
+        status1["total_drawers"], 1,
+        "should have 1 drawer after first add"
+    );
+
+    // Add second drawer (different content so the deterministic ID differs).
+    let r2 = dispatch(
+        &conn,
+        "mempalace_add_drawer",
+        &json!({
+            "wing": "projA",
+            "room": "general",
+            "content": "second drawer with completely different content"
+        }),
+    )
+    .await;
+    assert_eq!(r2["success"], true, "second add should succeed");
+
+    let status2 = dispatch(&conn, "mempalace_status", &json!({})).await;
+    assert_eq!(
+        status2["total_drawers"], 2,
+        "should have 2 drawers after second add"
+    );
+}
+
+/// Add 5 drawers and page through them with limit/offset.
+#[tokio::test]
+async fn list_drawers_pagination_workflow() {
+    let (_db, conn) = test_db().await;
+
+    // Seed 5 drawers with distinct content.
+    for i in 0..5 {
+        let r = dispatch(
+            &conn,
+            "mempalace_add_drawer",
+            &json!({
+                "wing": "paginate",
+                "room": "general",
+                "content": format!("drawer number {i} with unique pagination content seed {}", i * 7)
+            }),
+        )
+        .await;
+        assert_eq!(r["success"], true, "add drawer {i} should succeed");
+    }
+
+    // Page 1: limit=2, offset=0
+    let page1 = dispatch(
+        &conn,
+        "mempalace_list_drawers",
+        &json!({"wing": "paginate", "limit": 2, "offset": 0}),
+    )
+    .await;
+    let p1_count = page1["count"].as_i64().expect("count should be i64");
+    assert_eq!(p1_count, 2, "page 1 should return 2 drawers");
+
+    // Page 2: limit=2, offset=2
+    let page2 = dispatch(
+        &conn,
+        "mempalace_list_drawers",
+        &json!({"wing": "paginate", "limit": 2, "offset": 2}),
+    )
+    .await;
+    let p2_count = page2["count"].as_i64().expect("count should be i64");
+    assert_eq!(p2_count, 2, "page 2 should return 2 drawers");
+
+    // Pages should contain different drawers.
+    let p1_ids: Vec<&str> = page1["drawers"]
+        .as_array()
+        .expect("drawers should be array")
+        .iter()
+        .filter_map(|d| d["drawer_id"].as_str())
+        .collect();
+    let p2_ids: Vec<&str> = page2["drawers"]
+        .as_array()
+        .expect("drawers should be array")
+        .iter()
+        .filter_map(|d| d["drawer_id"].as_str())
+        .collect();
+    assert!(
+        p1_ids.iter().all(|id| !p2_ids.contains(id)),
+        "page 1 and page 2 should have no overlapping drawer IDs"
+    );
+}
+
+/// Add a drawer, update its content, and verify the `drawer_id` changes
+/// because the ID is deterministic from wing+room+content.
+#[tokio::test]
+async fn update_drawer_changes_id() {
+    let (_db, conn) = test_db().await;
+
+    let add = dispatch(
+        &conn,
+        "mempalace_add_drawer",
+        &json!({
+            "wing": "upd",
+            "room": "general",
+            "content": "original content for update testing purposes"
+        }),
+    )
+    .await;
+    assert_eq!(add["success"], true, "add should succeed");
+    let old_id = add["drawer_id"]
+        .as_str()
+        .expect("drawer_id should exist")
+        .to_string();
+
+    // Fetch original content.
+    let get1 = dispatch(&conn, "mempalace_get_drawer", &json!({"drawer_id": old_id})).await;
+    assert_eq!(
+        get1["content"],
+        "original content for update testing purposes"
+    );
+
+    // Update content.
+    let upd = dispatch(
+        &conn,
+        "mempalace_update_drawer",
+        &json!({
+            "drawer_id": old_id,
+            "content": "updated content that is completely different now"
+        }),
+    )
+    .await;
+    assert_eq!(upd["success"], true, "update should succeed");
+    let new_id = upd["drawer_id"]
+        .as_str()
+        .expect("updated drawer_id should exist")
+        .to_string();
+
+    // Deterministic ID changes when content changes.
+    assert_ne!(
+        old_id, new_id,
+        "drawer_id should change after content update"
+    );
+
+    // Verify new content via get.
+    let get2 = dispatch(&conn, "mempalace_get_drawer", &json!({"drawer_id": new_id})).await;
+    assert_eq!(
+        get2["content"],
+        "updated content that is completely different now"
+    );
+}
+
+/// Dispatching a non-existent tool should return a structured error.
+#[tokio::test]
+async fn unknown_tool_returns_error() {
+    let (_db, conn) = test_db().await;
+
+    let result = dispatch(&conn, "mempalace_nonexistent_tool", &json!({})).await;
+    let error = result["error"]
+        .as_str()
+        .expect("error field should be a string");
+    assert!(
+        error.to_lowercase().contains("unknown"),
+        "error message should mention 'unknown': got {error}"
+    );
+    assert!(
+        error.contains("mempalace_nonexistent_tool"),
+        "error should include the tool name"
+    );
+}

--- a/tests/mcp_request_cycle.rs
+++ b/tests/mcp_request_cycle.rs
@@ -9,11 +9,11 @@ use serde_json::json;
 /// returns nothing. Exercises the full CRUD path through the MCP tool layer.
 #[tokio::test]
 async fn full_lifecycle_add_search_delete() {
-    let (_db, conn) = test_db().await;
+    let (_db, connection) = test_db().await;
 
     // Add a drawer with distinctive content.
     let add_result = dispatch(
-        &conn,
+        &connection,
         "mempalace_add_drawer",
         &json!({
             "wing": "testproject",
@@ -34,7 +34,7 @@ async fn full_lifecycle_add_search_delete() {
 
     // Search should find the drawer.
     let search_result = dispatch(
-        &conn,
+        &connection,
         "mempalace_search",
         &json!({"query": "rust programming benchmarks"}),
     )
@@ -45,17 +45,17 @@ async fn full_lifecycle_add_search_delete() {
     assert!(count >= 1, "search should find the drawer we just added");
 
     // Delete the drawer.
-    let del_result = dispatch(
-        &conn,
+    let delete_result = dispatch(
+        &connection,
         "mempalace_delete_drawer",
         &json!({"drawer_id": drawer_id}),
     )
     .await;
-    assert_eq!(del_result["success"], true, "delete should succeed");
+    assert_eq!(delete_result["success"], true, "delete should succeed");
 
     // Search again — should find nothing.
     let search_after = dispatch(
-        &conn,
+        &connection,
         "mempalace_search",
         &json!({"query": "rust programming benchmarks"}),
     )
@@ -67,18 +67,18 @@ async fn full_lifecycle_add_search_delete() {
 /// Dispatch status after adding drawers to verify counters track operations.
 #[tokio::test]
 async fn status_reflects_drawer_operations() {
-    let (_db, conn) = test_db().await;
+    let (_db, connection) = test_db().await;
 
     // Empty palace should report 0 drawers.
-    let status0 = dispatch(&conn, "mempalace_status", &json!({})).await;
+    let status0 = dispatch(&connection, "mempalace_status", &json!({})).await;
     assert_eq!(
         status0["total_drawers"], 0,
         "fresh DB should have 0 drawers"
     );
 
     // Add first drawer.
-    let r1 = dispatch(
-        &conn,
+    let add_result_first = dispatch(
+        &connection,
         "mempalace_add_drawer",
         &json!({
             "wing": "projA",
@@ -87,17 +87,20 @@ async fn status_reflects_drawer_operations() {
         }),
     )
     .await;
-    assert_eq!(r1["success"], true, "first add should succeed");
+    assert_eq!(
+        add_result_first["success"], true,
+        "first add should succeed"
+    );
 
-    let status1 = dispatch(&conn, "mempalace_status", &json!({})).await;
+    let status1 = dispatch(&connection, "mempalace_status", &json!({})).await;
     assert_eq!(
         status1["total_drawers"], 1,
         "should have 1 drawer after first add"
     );
 
     // Add second drawer (different content so the deterministic ID differs).
-    let r2 = dispatch(
-        &conn,
+    let add_result_second = dispatch(
+        &connection,
         "mempalace_add_drawer",
         &json!({
             "wing": "projA",
@@ -106,9 +109,12 @@ async fn status_reflects_drawer_operations() {
         }),
     )
     .await;
-    assert_eq!(r2["success"], true, "second add should succeed");
+    assert_eq!(
+        add_result_second["success"], true,
+        "second add should succeed"
+    );
 
-    let status2 = dispatch(&conn, "mempalace_status", &json!({})).await;
+    let status2 = dispatch(&connection, "mempalace_status", &json!({})).await;
     assert_eq!(
         status2["total_drawers"], 2,
         "should have 2 drawers after second add"
@@ -118,12 +124,12 @@ async fn status_reflects_drawer_operations() {
 /// Add 5 drawers and page through them with limit/offset.
 #[tokio::test]
 async fn list_drawers_pagination_workflow() {
-    let (_db, conn) = test_db().await;
+    let (_db, connection) = test_db().await;
 
     // Seed 5 drawers with distinct content.
     for i in 0..5 {
-        let r = dispatch(
-            &conn,
+        let add_result = dispatch(
+            &connection,
             "mempalace_add_drawer",
             &json!({
                 "wing": "paginate",
@@ -132,44 +138,44 @@ async fn list_drawers_pagination_workflow() {
             }),
         )
         .await;
-        assert_eq!(r["success"], true, "add drawer {i} should succeed");
+        assert_eq!(add_result["success"], true, "add drawer {i} should succeed");
     }
 
     // Page 1: limit=2, offset=0
     let page1 = dispatch(
-        &conn,
+        &connection,
         "mempalace_list_drawers",
         &json!({"wing": "paginate", "limit": 2, "offset": 0}),
     )
     .await;
-    let p1_count = page1["count"].as_i64().expect("count should be i64");
-    assert_eq!(p1_count, 2, "page 1 should return 2 drawers");
+    let page1_count = page1["count"].as_i64().expect("count should be i64");
+    assert_eq!(page1_count, 2, "page 1 should return 2 drawers");
 
     // Page 2: limit=2, offset=2
     let page2 = dispatch(
-        &conn,
+        &connection,
         "mempalace_list_drawers",
         &json!({"wing": "paginate", "limit": 2, "offset": 2}),
     )
     .await;
-    let p2_count = page2["count"].as_i64().expect("count should be i64");
-    assert_eq!(p2_count, 2, "page 2 should return 2 drawers");
+    let page2_count = page2["count"].as_i64().expect("count should be i64");
+    assert_eq!(page2_count, 2, "page 2 should return 2 drawers");
 
     // Pages should contain different drawers.
-    let p1_ids: Vec<&str> = page1["drawers"]
+    let page1_ids: Vec<&str> = page1["drawers"]
         .as_array()
         .expect("drawers should be array")
         .iter()
         .filter_map(|d| d["drawer_id"].as_str())
         .collect();
-    let p2_ids: Vec<&str> = page2["drawers"]
+    let page2_ids: Vec<&str> = page2["drawers"]
         .as_array()
         .expect("drawers should be array")
         .iter()
         .filter_map(|d| d["drawer_id"].as_str())
         .collect();
     assert!(
-        p1_ids.iter().all(|id| !p2_ids.contains(id)),
+        page1_ids.iter().all(|id| !page2_ids.contains(id)),
         "page 1 and page 2 should have no overlapping drawer IDs"
     );
 }
@@ -178,10 +184,10 @@ async fn list_drawers_pagination_workflow() {
 /// because the ID is deterministic from wing+room+content.
 #[tokio::test]
 async fn update_drawer_changes_id() {
-    let (_db, conn) = test_db().await;
+    let (_db, connection) = test_db().await;
 
-    let add = dispatch(
-        &conn,
+    let add_result = dispatch(
+        &connection,
         "mempalace_add_drawer",
         &json!({
             "wing": "upd",
@@ -190,22 +196,27 @@ async fn update_drawer_changes_id() {
         }),
     )
     .await;
-    assert_eq!(add["success"], true, "add should succeed");
-    let old_id = add["drawer_id"]
+    assert_eq!(add_result["success"], true, "add should succeed");
+    let old_id = add_result["drawer_id"]
         .as_str()
         .expect("drawer_id should exist")
         .to_string();
 
     // Fetch original content.
-    let get1 = dispatch(&conn, "mempalace_get_drawer", &json!({"drawer_id": old_id})).await;
+    let get_result_before = dispatch(
+        &connection,
+        "mempalace_get_drawer",
+        &json!({"drawer_id": old_id}),
+    )
+    .await;
     assert_eq!(
-        get1["content"],
+        get_result_before["content"],
         "original content for update testing purposes"
     );
 
     // Update content.
-    let upd = dispatch(
-        &conn,
+    let update_result = dispatch(
+        &connection,
         "mempalace_update_drawer",
         &json!({
             "drawer_id": old_id,
@@ -213,8 +224,8 @@ async fn update_drawer_changes_id() {
         }),
     )
     .await;
-    assert_eq!(upd["success"], true, "update should succeed");
-    let new_id = upd["drawer_id"]
+    assert_eq!(update_result["success"], true, "update should succeed");
+    let new_id = update_result["drawer_id"]
         .as_str()
         .expect("updated drawer_id should exist")
         .to_string();
@@ -226,9 +237,14 @@ async fn update_drawer_changes_id() {
     );
 
     // Verify new content via get.
-    let get2 = dispatch(&conn, "mempalace_get_drawer", &json!({"drawer_id": new_id})).await;
+    let get_result_after = dispatch(
+        &connection,
+        "mempalace_get_drawer",
+        &json!({"drawer_id": new_id}),
+    )
+    .await;
     assert_eq!(
-        get2["content"],
+        get_result_after["content"],
         "updated content that is completely different now"
     );
 }
@@ -236,9 +252,9 @@ async fn update_drawer_changes_id() {
 /// Dispatching a non-existent tool should return a structured error.
 #[tokio::test]
 async fn unknown_tool_returns_error() {
-    let (_db, conn) = test_db().await;
+    let (_db, connection) = test_db().await;
 
-    let result = dispatch(&conn, "mempalace_nonexistent_tool", &json!({})).await;
+    let result = dispatch(&connection, "mempalace_nonexistent_tool", &json!({})).await;
     let error = result["error"]
         .as_str()
         .expect("error field should be a string");

--- a/tests/mcp_request_cycle.rs
+++ b/tests/mcp_request_cycle.rs
@@ -9,273 +9,296 @@ use serde_json::json;
 /// returns nothing. Exercises the full CRUD path through the MCP tool layer.
 #[tokio::test]
 async fn full_lifecycle_add_search_delete() {
-    let (_db, connection) = test_db().await;
+    let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+    // Each test gets its own temp dir so WAL writes are isolated even when tests
+    // run in the same process. async_with_vars holds a mutex for the duration of
+    // the future, preventing env-var races between concurrent Tokio tasks.
+    temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+        let (_db, connection) = test_db().await;
 
-    // Add a drawer with distinctive content.
-    let add_result = dispatch(
-        &connection,
-        "mempalace_add_drawer",
-        &json!({
-            "wing": "testproject",
-            "room": "backend",
-            "content": "rust programming language performance benchmarks"
-        }),
-    )
-    .await;
-    assert_eq!(add_result["success"], true, "add_drawer should succeed");
-    let drawer_id = add_result["drawer_id"]
-        .as_str()
-        .expect("drawer_id should be a string")
-        .to_string();
-    assert!(
-        drawer_id.starts_with("drawer_"),
-        "drawer_id should have drawer_ prefix"
-    );
+        // Add a drawer with distinctive content.
+        let add_result = dispatch(
+            &connection,
+            "mempalace_add_drawer",
+            &json!({
+                "wing": "testproject",
+                "room": "backend",
+                "content": "rust programming language performance benchmarks"
+            }),
+        )
+        .await;
+        assert_eq!(add_result["success"], true, "add_drawer should succeed");
+        let drawer_id = add_result["drawer_id"]
+            .as_str()
+            .expect("drawer_id should be a string")
+            .to_string();
+        assert!(
+            drawer_id.starts_with("drawer_"),
+            "drawer_id should have drawer_ prefix"
+        );
 
-    // Search should find the drawer.
-    let search_result = dispatch(
-        &connection,
-        "mempalace_search",
-        &json!({"query": "rust programming benchmarks"}),
-    )
-    .await;
-    let count = search_result["count"]
-        .as_i64()
-        .expect("count should be i64");
-    assert!(count >= 1, "search should find the drawer we just added");
+        // Search should find the drawer.
+        let search_result = dispatch(
+            &connection,
+            "mempalace_search",
+            &json!({"query": "rust programming benchmarks"}),
+        )
+        .await;
+        let count = search_result["count"]
+            .as_i64()
+            .expect("count should be i64");
+        assert!(count >= 1, "search should find the drawer we just added");
 
-    // Delete the drawer.
-    let delete_result = dispatch(
-        &connection,
-        "mempalace_delete_drawer",
-        &json!({"drawer_id": drawer_id}),
-    )
-    .await;
-    assert_eq!(delete_result["success"], true, "delete should succeed");
+        // Delete the drawer.
+        let delete_result = dispatch(
+            &connection,
+            "mempalace_delete_drawer",
+            &json!({"drawer_id": drawer_id}),
+        )
+        .await;
+        assert_eq!(delete_result["success"], true, "delete should succeed");
 
-    // Search again — should find nothing.
-    let search_after = dispatch(
-        &connection,
-        "mempalace_search",
-        &json!({"query": "rust programming benchmarks"}),
-    )
+        // Search again — should find nothing.
+        let search_after = dispatch(
+            &connection,
+            "mempalace_search",
+            &json!({"query": "rust programming benchmarks"}),
+        )
+        .await;
+        let after_count = search_after["count"].as_i64().expect("count should be i64");
+        assert_eq!(after_count, 0, "search should return 0 after deletion");
+    })
     .await;
-    let after_count = search_after["count"].as_i64().expect("count should be i64");
-    assert_eq!(after_count, 0, "search should return 0 after deletion");
 }
 
 /// Dispatch status after adding drawers to verify counters track operations.
 #[tokio::test]
 async fn status_reflects_drawer_operations() {
-    let (_db, connection) = test_db().await;
+    let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+    temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+        let (_db, connection) = test_db().await;
 
-    // Empty palace should report 0 drawers.
-    let status0 = dispatch(&connection, "mempalace_status", &json!({})).await;
-    assert_eq!(
-        status0["total_drawers"], 0,
-        "fresh DB should have 0 drawers"
-    );
+        // Empty palace should report 0 drawers.
+        let status0 = dispatch(&connection, "mempalace_status", &json!({})).await;
+        assert_eq!(
+            status0["total_drawers"], 0,
+            "fresh DB should have 0 drawers"
+        );
 
-    // Add first drawer.
-    let add_result_first = dispatch(
-        &connection,
-        "mempalace_add_drawer",
-        &json!({
-            "wing": "projA",
-            "room": "general",
-            "content": "first drawer content here with enough words"
-        }),
-    )
+        // Add first drawer.
+        let add_result_first = dispatch(
+            &connection,
+            "mempalace_add_drawer",
+            &json!({
+                "wing": "projA",
+                "room": "general",
+                "content": "first drawer content here with enough words"
+            }),
+        )
+        .await;
+        assert_eq!(
+            add_result_first["success"], true,
+            "first add should succeed"
+        );
+
+        let status1 = dispatch(&connection, "mempalace_status", &json!({})).await;
+        assert_eq!(
+            status1["total_drawers"], 1,
+            "should have 1 drawer after first add"
+        );
+
+        // Add second drawer (different content so the deterministic ID differs).
+        let add_result_second = dispatch(
+            &connection,
+            "mempalace_add_drawer",
+            &json!({
+                "wing": "projA",
+                "room": "general",
+                "content": "second drawer with completely different content"
+            }),
+        )
+        .await;
+        assert_eq!(
+            add_result_second["success"], true,
+            "second add should succeed"
+        );
+
+        let status2 = dispatch(&connection, "mempalace_status", &json!({})).await;
+        assert_eq!(
+            status2["total_drawers"], 2,
+            "should have 2 drawers after second add"
+        );
+    })
     .await;
-    assert_eq!(
-        add_result_first["success"], true,
-        "first add should succeed"
-    );
-
-    let status1 = dispatch(&connection, "mempalace_status", &json!({})).await;
-    assert_eq!(
-        status1["total_drawers"], 1,
-        "should have 1 drawer after first add"
-    );
-
-    // Add second drawer (different content so the deterministic ID differs).
-    let add_result_second = dispatch(
-        &connection,
-        "mempalace_add_drawer",
-        &json!({
-            "wing": "projA",
-            "room": "general",
-            "content": "second drawer with completely different content"
-        }),
-    )
-    .await;
-    assert_eq!(
-        add_result_second["success"], true,
-        "second add should succeed"
-    );
-
-    let status2 = dispatch(&connection, "mempalace_status", &json!({})).await;
-    assert_eq!(
-        status2["total_drawers"], 2,
-        "should have 2 drawers after second add"
-    );
 }
 
 /// Add 5 drawers and page through them with limit/offset.
 #[tokio::test]
 async fn list_drawers_pagination_workflow() {
-    let (_db, connection) = test_db().await;
+    let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+    temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+        let (_db, connection) = test_db().await;
 
-    // Seed 5 drawers with distinct content.
-    for i in 0..5 {
-        let add_result = dispatch(
+        // Seed 5 drawers with distinct content.
+        for i in 0..5 {
+            let add_result = dispatch(
+                &connection,
+                "mempalace_add_drawer",
+                &json!({
+                    "wing": "paginate",
+                    "room": "general",
+                    "content": format!("drawer number {i} with unique pagination content seed {}", i * 7)
+                }),
+            )
+            .await;
+            assert_eq!(add_result["success"], true, "add drawer {i} should succeed");
+        }
+
+        // Page 1: limit=2, offset=0
+        let page1 = dispatch(
             &connection,
-            "mempalace_add_drawer",
-            &json!({
-                "wing": "paginate",
-                "room": "general",
-                "content": format!("drawer number {i} with unique pagination content seed {}", i * 7)
-            }),
+            "mempalace_list_drawers",
+            &json!({"wing": "paginate", "limit": 2, "offset": 0}),
         )
         .await;
-        assert_eq!(add_result["success"], true, "add drawer {i} should succeed");
-    }
+        let page1_count = page1["count"].as_i64().expect("count should be i64");
+        assert_eq!(page1_count, 2, "page 1 should return 2 drawers");
 
-    // Page 1: limit=2, offset=0
-    let page1 = dispatch(
-        &connection,
-        "mempalace_list_drawers",
-        &json!({"wing": "paginate", "limit": 2, "offset": 0}),
-    )
+        // Page 2: limit=2, offset=2
+        let page2 = dispatch(
+            &connection,
+            "mempalace_list_drawers",
+            &json!({"wing": "paginate", "limit": 2, "offset": 2}),
+        )
+        .await;
+        let page2_count = page2["count"].as_i64().expect("count should be i64");
+        assert_eq!(page2_count, 2, "page 2 should return 2 drawers");
+
+        // Pages should contain different drawers.
+        let page1_ids: Vec<&str> = page1["drawers"]
+            .as_array()
+            .expect("drawers should be array")
+            .iter()
+            .filter_map(|d| d["drawer_id"].as_str())
+            .collect();
+        let page2_ids: Vec<&str> = page2["drawers"]
+            .as_array()
+            .expect("drawers should be array")
+            .iter()
+            .filter_map(|d| d["drawer_id"].as_str())
+            .collect();
+        assert!(
+            page1_ids.iter().all(|id| !page2_ids.contains(id)),
+            "page 1 and page 2 should have no overlapping drawer IDs"
+        );
+    })
     .await;
-    let page1_count = page1["count"].as_i64().expect("count should be i64");
-    assert_eq!(page1_count, 2, "page 1 should return 2 drawers");
-
-    // Page 2: limit=2, offset=2
-    let page2 = dispatch(
-        &connection,
-        "mempalace_list_drawers",
-        &json!({"wing": "paginate", "limit": 2, "offset": 2}),
-    )
-    .await;
-    let page2_count = page2["count"].as_i64().expect("count should be i64");
-    assert_eq!(page2_count, 2, "page 2 should return 2 drawers");
-
-    // Pages should contain different drawers.
-    let page1_ids: Vec<&str> = page1["drawers"]
-        .as_array()
-        .expect("drawers should be array")
-        .iter()
-        .filter_map(|d| d["drawer_id"].as_str())
-        .collect();
-    let page2_ids: Vec<&str> = page2["drawers"]
-        .as_array()
-        .expect("drawers should be array")
-        .iter()
-        .filter_map(|d| d["drawer_id"].as_str())
-        .collect();
-    assert!(
-        page1_ids.iter().all(|id| !page2_ids.contains(id)),
-        "page 1 and page 2 should have no overlapping drawer IDs"
-    );
 }
 
 /// Add a drawer, update its content, and verify the `drawer_id` changes
 /// because the ID is deterministic from wing+room+content.
 #[tokio::test]
 async fn update_drawer_changes_id() {
-    let (_db, connection) = test_db().await;
+    let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+    temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+        let (_db, connection) = test_db().await;
 
-    let add_result = dispatch(
-        &connection,
-        "mempalace_add_drawer",
-        &json!({
-            "wing": "upd",
-            "room": "general",
-            "content": "original content for update testing purposes"
-        }),
-    )
+        let add_result = dispatch(
+            &connection,
+            "mempalace_add_drawer",
+            &json!({
+                "wing": "upd",
+                "room": "general",
+                "content": "original content for update testing purposes"
+            }),
+        )
+        .await;
+        assert_eq!(add_result["success"], true, "add should succeed");
+        let old_id = add_result["drawer_id"]
+            .as_str()
+            .expect("drawer_id should exist")
+            .to_string();
+
+        // Fetch original content.
+        let get_result_before = dispatch(
+            &connection,
+            "mempalace_get_drawer",
+            &json!({"drawer_id": old_id}),
+        )
+        .await;
+        assert_eq!(
+            get_result_before["content"],
+            "original content for update testing purposes"
+        );
+
+        // Update content.
+        let update_result = dispatch(
+            &connection,
+            "mempalace_update_drawer",
+            &json!({
+                "drawer_id": old_id,
+                "content": "updated content that is completely different now"
+            }),
+        )
+        .await;
+        assert_eq!(update_result["success"], true, "update should succeed");
+        let new_id = update_result["drawer_id"]
+            .as_str()
+            .expect("updated drawer_id should exist")
+            .to_string();
+
+        // Deterministic ID changes when content changes.
+        assert_ne!(
+            old_id, new_id,
+            "drawer_id should change after content update"
+        );
+
+        // Verify new content via get.
+        let get_result_after = dispatch(
+            &connection,
+            "mempalace_get_drawer",
+            &json!({"drawer_id": new_id}),
+        )
+        .await;
+        assert_eq!(
+            get_result_after["content"],
+            "updated content that is completely different now"
+        );
+
+        // Verify the old drawer was removed — update must not leave a ghost entry.
+        let get_old_after = dispatch(
+            &connection,
+            "mempalace_get_drawer",
+            &json!({"drawer_id": old_id}),
+        )
+        .await;
+        assert!(
+            get_old_after.get("error").is_some(),
+            "old drawer_id should no longer be found after update"
+        );
+    })
     .await;
-    assert_eq!(add_result["success"], true, "add should succeed");
-    let old_id = add_result["drawer_id"]
-        .as_str()
-        .expect("drawer_id should exist")
-        .to_string();
-
-    // Fetch original content.
-    let get_result_before = dispatch(
-        &connection,
-        "mempalace_get_drawer",
-        &json!({"drawer_id": old_id}),
-    )
-    .await;
-    assert_eq!(
-        get_result_before["content"],
-        "original content for update testing purposes"
-    );
-
-    // Update content.
-    let update_result = dispatch(
-        &connection,
-        "mempalace_update_drawer",
-        &json!({
-            "drawer_id": old_id,
-            "content": "updated content that is completely different now"
-        }),
-    )
-    .await;
-    assert_eq!(update_result["success"], true, "update should succeed");
-    let new_id = update_result["drawer_id"]
-        .as_str()
-        .expect("updated drawer_id should exist")
-        .to_string();
-
-    // Deterministic ID changes when content changes.
-    assert_ne!(
-        old_id, new_id,
-        "drawer_id should change after content update"
-    );
-
-    // Verify new content via get.
-    let get_result_after = dispatch(
-        &connection,
-        "mempalace_get_drawer",
-        &json!({"drawer_id": new_id}),
-    )
-    .await;
-    assert_eq!(
-        get_result_after["content"],
-        "updated content that is completely different now"
-    );
-
-    // Verify the old drawer was removed — update must not leave a ghost entry.
-    let get_old_after = dispatch(
-        &connection,
-        "mempalace_get_drawer",
-        &json!({"drawer_id": old_id}),
-    )
-    .await;
-    assert!(
-        get_old_after.get("error").is_some(),
-        "old drawer_id should no longer be found after update"
-    );
 }
 
 /// Dispatching a non-existent tool should return a structured error.
 #[tokio::test]
 async fn unknown_tool_returns_error() {
-    let (_db, connection) = test_db().await;
+    let wal_dir = tempfile::tempdir().expect("failed to create WAL temp dir");
+    temp_env::async_with_vars([("MEMPALACE_DIR", Some(wal_dir.path()))], async {
+        let (_db, connection) = test_db().await;
 
-    let result = dispatch(&connection, "mempalace_nonexistent_tool", &json!({})).await;
-    let error = result["error"]
-        .as_str()
-        .expect("error field should be a string");
-    assert!(
-        error.to_lowercase().contains("unknown"),
-        "error message should mention 'unknown': got {error}"
-    );
-    assert!(
-        error.contains("mempalace_nonexistent_tool"),
-        "error should include the tool name"
-    );
+        let result = dispatch(&connection, "mempalace_nonexistent_tool", &json!({})).await;
+        let error = result["error"]
+            .as_str()
+            .expect("error field should be a string");
+        assert!(
+            error.to_lowercase().contains("unknown"),
+            "error message should mention 'unknown': got {error}"
+        );
+        assert!(
+            error.contains("mempalace_nonexistent_tool"),
+            "error should include the tool name"
+        );
+    })
+    .await;
 }

--- a/tests/mcp_request_cycle.rs
+++ b/tests/mcp_request_cycle.rs
@@ -247,6 +247,18 @@ async fn update_drawer_changes_id() {
         get_result_after["content"],
         "updated content that is completely different now"
     );
+
+    // Verify the old drawer was removed — update must not leave a ghost entry.
+    let get_old_after = dispatch(
+        &connection,
+        "mempalace_get_drawer",
+        &json!({"drawer_id": old_id}),
+    )
+    .await;
+    assert!(
+        get_old_after.get("error").is_some(),
+        "old drawer_id should no longer be found after update"
+    );
 }
 
 /// Dispatching a non-existent tool should return a structured error.

--- a/tests/mining_pipeline.rs
+++ b/tests/mining_pipeline.rs
@@ -1,0 +1,150 @@
+// Integration test — .expect() is acceptable with a descriptive message.
+#![allow(clippy::expect_used)]
+
+use std::fs;
+
+use mempalace::palace::miner::{MineParams, scan_project};
+use mempalace::palace::search::search_memories;
+use mempalace::test_helpers::test_db;
+
+/// Create text files in a tempdir, scan to find them, mine into the palace,
+/// then search for their content to verify end-to-end data flow.
+#[tokio::test]
+async fn scan_and_mine_creates_searchable_drawers() {
+    let (_db, conn) = test_db().await;
+    let dir = tempfile::tempdir().expect("tempdir should be created");
+
+    // Write files with enough content to pass the 50-char minimum.
+    fs::write(
+        dir.path().join("notes.txt"),
+        "Rust programming offers memory safety without garbage collection overhead",
+    )
+    .expect("write notes.txt should succeed");
+    fs::write(
+        dir.path().join("design.md"),
+        "The architecture uses event sourcing with append-only storage design",
+    )
+    .expect("write design.md should succeed");
+
+    // Scan should find both files.
+    let files = scan_project(dir.path());
+    assert!(
+        files.len() >= 2,
+        "scan should find at least 2 readable files"
+    );
+
+    // Write a mempalace.yaml so mine() can read config.
+    fs::write(
+        dir.path().join("mempalace.yaml"),
+        "wing: test_mining\nrooms:\n  - name: general\n    description: default room\n    keywords: []\n",
+    )
+    .expect("write mempalace.yaml should succeed");
+
+    // Mine the directory.
+    let opts = MineParams {
+        wing: Some("test_mining".to_string()),
+        agent: "test".to_string(),
+        limit: 0,
+        dry_run: false,
+        respect_gitignore: false,
+    };
+    mempalace::palace::miner::mine(&conn, dir.path(), &opts)
+        .await
+        .expect("mine should succeed");
+
+    // Search for content from the mined files.
+    let results = search_memories(&conn, "rust programming memory safety", None, None, 10)
+        .await
+        .expect("search should succeed after mining");
+    assert!(!results.is_empty(), "search should find mined content");
+    assert_eq!(
+        results[0].wing, "test_mining",
+        "wing should match mine config"
+    );
+}
+
+/// Mining the same directory twice should not create duplicate drawers
+/// because `file_already_mined` checks the stored mtime.
+#[tokio::test]
+async fn mine_skips_already_mined_files() {
+    let (_db, conn) = test_db().await;
+    let dir = tempfile::tempdir().expect("tempdir should be created");
+
+    fs::write(
+        dir.path().join("stable.txt"),
+        "This content remains unchanged between mine runs for deduplication testing",
+    )
+    .expect("write stable.txt should succeed");
+    fs::write(
+        dir.path().join("mempalace.yaml"),
+        "wing: dedup_test\nrooms:\n  - name: general\n    description: default\n    keywords: []\n",
+    )
+    .expect("write mempalace.yaml should succeed");
+
+    let opts = MineParams {
+        wing: Some("dedup_test".to_string()),
+        agent: "test".to_string(),
+        limit: 0,
+        dry_run: false,
+        respect_gitignore: false,
+    };
+
+    // First mine.
+    mempalace::palace::miner::mine(&conn, dir.path(), &opts)
+        .await
+        .expect("first mine should succeed");
+    let first = search_memories(&conn, "unchanged deduplication testing", None, None, 50)
+        .await
+        .expect("search after first mine should succeed");
+
+    // Second mine — same files, same content.
+    mempalace::palace::miner::mine(&conn, dir.path(), &opts)
+        .await
+        .expect("second mine should succeed");
+    let second = search_memories(&conn, "unchanged deduplication testing", None, None, 50)
+        .await
+        .expect("search after second mine should succeed");
+
+    assert_eq!(
+        first.len(),
+        second.len(),
+        "second mine should not create duplicate drawers"
+    );
+    assert!(!first.is_empty(), "there should be at least one result");
+}
+
+/// `scan_project` respects `.gitignore` when a git repo is initialized.
+#[test]
+fn scan_respects_gitignore() {
+    let dir = tempfile::tempdir().expect("tempdir should be created");
+
+    // Initialize a git repo so the ignore crate picks up .gitignore.
+    std::process::Command::new("git")
+        .args(["init"])
+        .current_dir(dir.path())
+        .output()
+        .expect("git init should succeed");
+
+    // Gitignore a .rs file (must use a readable extension to be meaningful).
+    fs::write(dir.path().join(".gitignore"), "secret.rs\n")
+        .expect("write .gitignore should succeed");
+    fs::write(dir.path().join("visible.txt"), "this file should be found")
+        .expect("write visible.txt should succeed");
+    fs::write(dir.path().join("secret.rs"), "this file should be ignored")
+        .expect("write secret.rs should succeed");
+
+    let files = scan_project(dir.path());
+    let names: Vec<String> = files
+        .iter()
+        .filter_map(|p| p.file_name().map(|n| n.to_string_lossy().to_string()))
+        .collect();
+
+    assert!(
+        names.contains(&"visible.txt".to_string()),
+        "non-ignored file should be found"
+    );
+    assert!(
+        !names.contains(&"secret.rs".to_string()),
+        "gitignored file should be excluded"
+    );
+}

--- a/tests/mining_pipeline.rs
+++ b/tests/mining_pipeline.rs
@@ -11,23 +11,23 @@ use mempalace::test_helpers::test_db;
 /// then search for their content to verify end-to-end data flow.
 #[tokio::test]
 async fn scan_and_mine_creates_searchable_drawers() {
-    let (_db, conn) = test_db().await;
-    let dir = tempfile::tempdir().expect("tempdir should be created");
+    let (_db, connection) = test_db().await;
+    let directory = tempfile::tempdir().expect("tempdir should be created");
 
     // Write files with enough content to pass the 50-char minimum.
     fs::write(
-        dir.path().join("notes.txt"),
+        directory.path().join("notes.txt"),
         "Rust programming offers memory safety without garbage collection overhead",
     )
     .expect("write notes.txt should succeed");
     fs::write(
-        dir.path().join("design.md"),
+        directory.path().join("design.md"),
         "The architecture uses event sourcing with append-only storage design",
     )
     .expect("write design.md should succeed");
 
     // Scan should find both files.
-    let files = scan_project(dir.path());
+    let files = scan_project(directory.path());
     assert!(
         files.len() >= 2,
         "scan should find at least 2 readable files"
@@ -35,27 +35,33 @@ async fn scan_and_mine_creates_searchable_drawers() {
 
     // Write a mempalace.yaml so mine() can read config.
     fs::write(
-        dir.path().join("mempalace.yaml"),
+        directory.path().join("mempalace.yaml"),
         "wing: test_mining\nrooms:\n  - name: general\n    description: default room\n    keywords: []\n",
     )
     .expect("write mempalace.yaml should succeed");
 
     // Mine the directory.
-    let opts = MineParams {
+    let mine_params = MineParams {
         wing: Some("test_mining".to_string()),
         agent: "test".to_string(),
         limit: 0,
         dry_run: false,
         respect_gitignore: false,
     };
-    mempalace::palace::miner::mine(&conn, dir.path(), &opts)
+    mempalace::palace::miner::mine(&connection, directory.path(), &mine_params)
         .await
         .expect("mine should succeed");
 
     // Search for content from the mined files.
-    let results = search_memories(&conn, "rust programming memory safety", None, None, 10)
-        .await
-        .expect("search should succeed after mining");
+    let results = search_memories(
+        &connection,
+        "rust programming memory safety",
+        None,
+        None,
+        10,
+    )
+    .await
+    .expect("search should succeed after mining");
     assert!(!results.is_empty(), "search should find mined content");
     assert_eq!(
         results[0].wing, "test_mining",
@@ -67,21 +73,21 @@ async fn scan_and_mine_creates_searchable_drawers() {
 /// because `file_already_mined` checks the stored mtime.
 #[tokio::test]
 async fn mine_skips_already_mined_files() {
-    let (_db, conn) = test_db().await;
-    let dir = tempfile::tempdir().expect("tempdir should be created");
+    let (_db, connection) = test_db().await;
+    let directory = tempfile::tempdir().expect("tempdir should be created");
 
     fs::write(
-        dir.path().join("stable.txt"),
+        directory.path().join("stable.txt"),
         "This content remains unchanged between mine runs for deduplication testing",
     )
     .expect("write stable.txt should succeed");
     fs::write(
-        dir.path().join("mempalace.yaml"),
+        directory.path().join("mempalace.yaml"),
         "wing: dedup_test\nrooms:\n  - name: general\n    description: default\n    keywords: []\n",
     )
     .expect("write mempalace.yaml should succeed");
 
-    let opts = MineParams {
+    let mine_params = MineParams {
         wing: Some("dedup_test".to_string()),
         agent: "test".to_string(),
         limit: 0,
@@ -90,20 +96,32 @@ async fn mine_skips_already_mined_files() {
     };
 
     // First mine.
-    mempalace::palace::miner::mine(&conn, dir.path(), &opts)
+    mempalace::palace::miner::mine(&connection, directory.path(), &mine_params)
         .await
         .expect("first mine should succeed");
-    let first = search_memories(&conn, "unchanged deduplication testing", None, None, 50)
-        .await
-        .expect("search after first mine should succeed");
+    let first = search_memories(
+        &connection,
+        "unchanged deduplication testing",
+        None,
+        None,
+        50,
+    )
+    .await
+    .expect("search after first mine should succeed");
 
     // Second mine — same files, same content.
-    mempalace::palace::miner::mine(&conn, dir.path(), &opts)
+    mempalace::palace::miner::mine(&connection, directory.path(), &mine_params)
         .await
         .expect("second mine should succeed");
-    let second = search_memories(&conn, "unchanged deduplication testing", None, None, 50)
-        .await
-        .expect("search after second mine should succeed");
+    let second = search_memories(
+        &connection,
+        "unchanged deduplication testing",
+        None,
+        None,
+        50,
+    )
+    .await
+    .expect("search after second mine should succeed");
 
     assert_eq!(
         first.len(),
@@ -116,24 +134,30 @@ async fn mine_skips_already_mined_files() {
 /// `scan_project` respects `.gitignore` when a git repo is initialized.
 #[test]
 fn scan_respects_gitignore() {
-    let dir = tempfile::tempdir().expect("tempdir should be created");
+    let directory = tempfile::tempdir().expect("tempdir should be created");
 
     // Initialize a git repo so the ignore crate picks up .gitignore.
     std::process::Command::new("git")
         .args(["init"])
-        .current_dir(dir.path())
+        .current_dir(directory.path())
         .output()
         .expect("git init should succeed");
 
     // Gitignore a .rs file (must use a readable extension to be meaningful).
-    fs::write(dir.path().join(".gitignore"), "secret.rs\n")
+    fs::write(directory.path().join(".gitignore"), "secret.rs\n")
         .expect("write .gitignore should succeed");
-    fs::write(dir.path().join("visible.txt"), "this file should be found")
-        .expect("write visible.txt should succeed");
-    fs::write(dir.path().join("secret.rs"), "this file should be ignored")
-        .expect("write secret.rs should succeed");
+    fs::write(
+        directory.path().join("visible.txt"),
+        "this file should be found",
+    )
+    .expect("write visible.txt should succeed");
+    fs::write(
+        directory.path().join("secret.rs"),
+        "this file should be ignored",
+    )
+    .expect("write secret.rs should succeed");
 
-    let files = scan_project(dir.path());
+    let files = scan_project(directory.path());
     let names: Vec<String> = files
         .iter()
         .filter_map(|p| p.file_name().map(|n| n.to_string_lossy().to_string()))

--- a/tests/mining_pipeline.rs
+++ b/tests/mining_pipeline.rs
@@ -137,11 +137,18 @@ fn scan_respects_gitignore() {
     let directory = tempfile::tempdir().expect("tempdir should be created");
 
     // Initialize a git repo so the ignore crate picks up .gitignore.
-    std::process::Command::new("git")
+    let git_init_output = std::process::Command::new("git")
         .args(["init"])
         .current_dir(directory.path())
         .output()
-        .expect("git init should succeed");
+        .expect("git init command should run");
+    assert!(
+        git_init_output.status.success(),
+        "git init failed: {:?} stdout={:?} stderr={:?}",
+        git_init_output.status,
+        String::from_utf8_lossy(&git_init_output.stdout),
+        String::from_utf8_lossy(&git_init_output.stderr),
+    );
 
     // Gitignore a .rs file (must use a readable extension to be meaningful).
     fs::write(directory.path().join(".gitignore"), "secret.rs\n")

--- a/tests/normalize_pipeline.rs
+++ b/tests/normalize_pipeline.rs
@@ -1,0 +1,64 @@
+// Integration test — .expect() is acceptable with a descriptive message.
+#![allow(clippy::expect_used)]
+
+use std::fs;
+
+use mempalace::normalize::normalize;
+
+/// Write a valid Claude Code JSONL file, normalize it, and verify
+/// the output contains transcript markers ("> " for user messages).
+#[test]
+fn normalize_claude_code_jsonl() {
+    let dir = tempfile::tempdir().expect("tempdir should be created");
+    let path = dir.path().join("conversation.jsonl");
+
+    // Two messages minimum required for Claude Code parser to produce output.
+    let jsonl = r#"{"type":"human","message":{"content":"What is Rust?"}}
+{"type":"assistant","message":{"content":"Rust is a systems programming language focused on safety."}}"#;
+    fs::write(&path, jsonl).expect("write JSONL file should succeed");
+
+    let result = normalize(&path).expect("normalize should succeed for valid JSONL");
+    assert!(
+        result.contains("> What is Rust?"),
+        "user message should be prefixed with '> '"
+    );
+    assert!(
+        result.contains("Rust is a systems programming language"),
+        "assistant response should be present in transcript"
+    );
+}
+
+/// Plain text files should pass through normalization with content preserved.
+#[test]
+fn normalize_plain_text_passthrough() {
+    let dir = tempfile::tempdir().expect("tempdir should be created");
+    let path = dir.path().join("notes.txt");
+
+    let content = "These are plain text notes about project architecture and design decisions.";
+    fs::write(&path, content).expect("write plain text file should succeed");
+
+    let result = normalize(&path).expect("normalize should succeed for plain text");
+    assert!(
+        result.contains("plain text notes"),
+        "plain text content should be preserved"
+    );
+    assert!(
+        result.contains("architecture"),
+        "full content should be preserved in passthrough"
+    );
+}
+
+/// An empty file should normalize to an empty string without error.
+#[test]
+fn normalize_empty_file_returns_empty() {
+    let dir = tempfile::tempdir().expect("tempdir should be created");
+    let path = dir.path().join("empty.txt");
+
+    fs::write(&path, "").expect("write empty file should succeed");
+
+    let result = normalize(&path).expect("normalize should succeed for empty file");
+    assert!(
+        result.is_empty(),
+        "empty file should normalize to empty string"
+    );
+}

--- a/tests/normalize_pipeline.rs
+++ b/tests/normalize_pipeline.rs
@@ -9,8 +9,8 @@ use mempalace::normalize::normalize;
 /// the output contains transcript markers ("> " for user messages).
 #[test]
 fn normalize_claude_code_jsonl() {
-    let dir = tempfile::tempdir().expect("tempdir should be created");
-    let path = dir.path().join("conversation.jsonl");
+    let directory = tempfile::tempdir().expect("tempdir should be created");
+    let path = directory.path().join("conversation.jsonl");
 
     // Two messages minimum required for Claude Code parser to produce output.
     let jsonl = r#"{"type":"human","message":{"content":"What is Rust?"}}
@@ -31,8 +31,8 @@ fn normalize_claude_code_jsonl() {
 /// Plain text files should pass through normalization with content preserved.
 #[test]
 fn normalize_plain_text_passthrough() {
-    let dir = tempfile::tempdir().expect("tempdir should be created");
-    let path = dir.path().join("notes.txt");
+    let directory = tempfile::tempdir().expect("tempdir should be created");
+    let path = directory.path().join("notes.txt");
 
     let content = "These are plain text notes about project architecture and design decisions.";
     fs::write(&path, content).expect("write plain text file should succeed");
@@ -51,8 +51,8 @@ fn normalize_plain_text_passthrough() {
 /// An empty file should normalize to an empty string without error.
 #[test]
 fn normalize_empty_file_returns_empty() {
-    let dir = tempfile::tempdir().expect("tempdir should be created");
-    let path = dir.path().join("empty.txt");
+    let directory = tempfile::tempdir().expect("tempdir should be created");
+    let path = directory.path().join("empty.txt");
 
     fs::write(&path, "").expect("write empty file should succeed");
 


### PR DESCRIPTION
## Summary

- Removes `tokio-util` and `futures-util` dependencies, replacing their usage in `src/mcp/mod.rs` with a small bounded line-reader built directly on `tokio`'s `fill_buf`/`consume` primitives
- Sets `default-features = false` on all 12 dependencies in `Cargo.toml`, enabling only the features actually used — reduces compile surface and supply chain exposure
- Adds `src/lib.rs` as a library target so integration tests under `tests/` can import crate internals
- Grows the test suite from 145 to 534 tests (all passing, zero clippy warnings), covering unit tests in every module, integration tests for the MCP/KG/mining/normalization/compression pipelines, and end-to-end lifecycle tests through `dispatch`

---

Closes #16 

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Config directory can be overridden via MEMPALACE_DIR; defaults to ~/.mempalace.

* **Improvements**
  * Server input handling is more robust: oversized or invalid-encoding requests are detected and reported without disrupting service.
  * Large expansion of automated tests and end-to-end coverage across search, compress, mining, KG, MCP tools, and normalization flows.

* **Documentation**
  * Added contributor guidelines for agents and tooling.

* **Chores**
  * Updated ignore rules to exclude local Claude artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->