### PR TITLE
Migrate data directory to XDG Base Dir spec

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
-//! Configuration loading for global (`~/.mempalace/config.json`) and per-project (`mempalace.yaml`) settings.
+//! Configuration loading for global (`$XDG_DATA_HOME/mempalace/config.json`)
+//! and per-project (`mempalace.yaml`) settings.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -7,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::{Error, Result};
 
-/// Global mempalace configuration (`~/.mempalace/config.json`).
+/// Global mempalace configuration (`$XDG_DATA_HOME/mempalace/config.json`).
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MempalaceConfig {
     /// Path to the palace `SQLite` database file.
@@ -31,18 +32,45 @@ fn default_collection_name() -> String {
     "mempalace_drawers".to_string()
 }
 
-/// Returns the mempalace config directory.
+/// Returns the mempalace data directory.
 ///
 /// Resolution order:
 ///   1. `MEMPALACE_DIR` env var — explicit user, container, or test override.
-///   2. `~/.mempalace` — default.
+///   2. `$XDG_DATA_HOME/mempalace` — XDG standard location.
+///   3. `~/.local/share/mempalace` — XDG default fallback.
 pub fn config_dir() -> PathBuf {
     if let Ok(env_path) = std::env::var("MEMPALACE_DIR")
         && !env_path.is_empty()
     {
         return PathBuf::from(env_path);
     }
-    home_dir().join(".mempalace")
+    let data_directory = xdg_data_dir().join("mempalace");
+    assert!(!data_directory.as_os_str().is_empty());
+    assert!(data_directory.ends_with("mempalace"));
+    data_directory
+}
+
+/// Returns `$XDG_DATA_HOME` if set and non-empty, otherwise `$HOME/.local/share`.
+fn xdg_data_dir() -> PathBuf {
+    let base_directory = if let Ok(val) = std::env::var("XDG_DATA_HOME")
+        && !val.is_empty()
+    {
+        PathBuf::from(val)
+    } else {
+        home_dir().join(".local").join("share")
+    };
+    assert!(!base_directory.as_os_str().is_empty());
+    // Negative space: path must not contain null bytes.
+    assert!(!base_directory.to_string_lossy().contains('\0'));
+    base_directory
+}
+
+/// Returns the legacy `~/.mempalace` directory, used only for migration detection.
+pub fn legacy_dir() -> PathBuf {
+    let legacy_directory = home_dir().join(".mempalace");
+    assert!(!legacy_directory.as_os_str().is_empty());
+    assert!(legacy_directory.ends_with(".mempalace"));
+    legacy_directory
 }
 
 /// Returns the user's home directory, or `.` if `HOME` is unset.
@@ -56,8 +84,9 @@ pub fn config_path() -> PathBuf {
 }
 
 impl MempalaceConfig {
-    /// Load config from ~/.mempalace/config.json, or return defaults.
+    /// Load config from the XDG data dir, or return defaults.
     pub fn load() -> Result<Self> {
+        maybe_migrate()?;
         let path = config_path();
         if path.exists() {
             let data = std::fs::read_to_string(&path)?;
@@ -68,14 +97,17 @@ impl MempalaceConfig {
         }
     }
 
-    /// Ensure the config directory and default config exist.
+    /// Ensure the data directory and default config exist.
     pub fn init() -> Result<Self> {
+        maybe_migrate()?;
         let directory = config_dir();
         std::fs::create_dir_all(&directory)?;
 
         let path = config_path();
         if path.exists() {
-            Self::load()
+            let data = std::fs::read_to_string(&path)?;
+            let config: Self = serde_json::from_str(&data)?;
+            Ok(config)
         } else {
             let config = Self::default();
             let data = serde_json::to_string_pretty(&config)?;
@@ -107,6 +139,171 @@ impl Default for MempalaceConfig {
         }
     }
 }
+
+// --- Migration ---
+
+/// Migrate from `~/.mempalace` to `$XDG_DATA_HOME/mempalace` if needed.
+///
+/// Idempotent: returns immediately if already migrated, legacy dir absent,
+/// or `MEMPALACE_DIR` is set.
+fn maybe_migrate() -> Result<()> {
+    // MEMPALACE_DIR means the caller manages paths — skip migration entirely.
+    if let Ok(val) = std::env::var("MEMPALACE_DIR")
+        && !val.is_empty()
+    {
+        return Ok(());
+    }
+
+    let source = legacy_dir();
+    let destination = config_dir();
+
+    // No legacy directory — nothing to migrate.
+    if !source.exists() {
+        return Ok(());
+    }
+
+    // Already migrated — config.json exists in the XDG location.
+    if destination.join("config.json").exists() {
+        return Ok(());
+    }
+
+    assert!(source != destination);
+    assert!(source.exists());
+
+    maybe_migrate_inner(&source, &destination)
+}
+
+/// Perform the actual migration: move files from `source` to `destination`.
+fn maybe_migrate_inner(source: &Path, destination: &Path) -> Result<()> {
+    assert!(source.exists());
+    assert_ne!(source, destination);
+
+    std::fs::create_dir_all(destination)?;
+
+    let files = [
+        "config.json",
+        "identity.txt",
+        "palace.db",
+        "palace.db-wal",
+        "palace.db-shm",
+        "palace.db.bak",
+    ];
+    for name in &files {
+        let source_file = source.join(name);
+        if source_file.exists() {
+            maybe_migrate_move_file(&source_file, &destination.join(name))?;
+        }
+    }
+
+    let wal_source = source.join("wal");
+    if wal_source.exists() {
+        maybe_migrate_move_dir(&wal_source, &destination.join("wal"))?;
+    }
+
+    // Patch palace_path in config.json if it still points to the legacy location.
+    let destination_config = destination.join("config.json");
+    if destination_config.exists() {
+        let legacy_db = source.join("palace.db");
+        let new_db = destination.join("palace.db");
+        maybe_migrate_patch_config(&destination_config, &legacy_db, &new_db)?;
+    }
+
+    // Remove the legacy directory if it is now empty.
+    if std::fs::read_dir(source)
+        .map(|mut entries| entries.next().is_none())
+        .unwrap_or(false)
+    {
+        let _ = std::fs::remove_dir(source);
+    }
+
+    eprintln!(
+        "mempalace: migrated from {} to {}",
+        source.display(),
+        destination.display()
+    );
+
+    Ok(())
+}
+
+/// Move a directory's file contents from `source` to `destination`.
+fn maybe_migrate_move_dir(source: &Path, destination: &Path) -> Result<()> {
+    assert!(source.exists());
+    assert_ne!(source, destination);
+
+    std::fs::create_dir_all(destination)?;
+
+    // Collect entries before iterating so the directory is not modified mid-walk.
+    let entries: Vec<_> = std::fs::read_dir(source)?
+        .filter_map(std::result::Result::ok)
+        .collect();
+
+    assert!(source.is_dir());
+
+    for entry in &entries {
+        let source_entry = entry.path();
+        if source_entry.is_file() {
+            maybe_migrate_move_file(&source_entry, &destination.join(entry.file_name()))?;
+        }
+    }
+
+    // Remove source dir if now empty.
+    if std::fs::read_dir(source)
+        .map(|mut entries| entries.next().is_none())
+        .unwrap_or(false)
+    {
+        let _ = std::fs::remove_dir(source);
+    }
+
+    Ok(())
+}
+
+/// Move a single file, trying rename first, falling back to copy + delete.
+///
+/// Rename is fast and atomic on the same filesystem. Copy + delete handles
+/// cross-filesystem moves (e.g. `~/.mempalace` on one mount, `~/.local` on another).
+fn maybe_migrate_move_file(source: &Path, destination: &Path) -> Result<()> {
+    assert!(source.exists());
+    assert_ne!(source, destination);
+
+    if std::fs::rename(source, destination).is_err() {
+        std::fs::copy(source, destination)?;
+        std::fs::remove_file(source)?;
+    }
+
+    // Pair assertion: destination must exist after the move.
+    assert!(destination.exists());
+
+    Ok(())
+}
+
+/// Update `palace_path` in config.json if it still points to the legacy DB location.
+fn maybe_migrate_patch_config(config_path: &Path, legacy_db: &Path, new_db: &Path) -> Result<()> {
+    assert!(config_path.exists());
+    assert_ne!(legacy_db, new_db);
+
+    let data = std::fs::read_to_string(config_path)?;
+    let mut config: MempalaceConfig = match serde_json::from_str(&data) {
+        Ok(c) => c,
+        // Corrupted config — leave it alone; startup will surface the parse error.
+        Err(_) => return Ok(()),
+    };
+
+    if config.palace_path == legacy_db {
+        config.palace_path = new_db.to_path_buf();
+        let patched = serde_json::to_string_pretty(&config)?;
+        std::fs::write(config_path, &patched)?;
+        // Pair assertion: patched value must round-trip correctly.
+        debug_assert!(
+            serde_json::from_str::<MempalaceConfig>(&patched)
+                .map(|c| c.palace_path.as_path() == new_db)
+                .unwrap_or(false)
+        );
+    }
+
+    Ok(())
+}
+
+// --- Per-project config ---
 
 /// Per-project config (`mempalace.yaml`).
 #[derive(Debug, Serialize, Deserialize)]
@@ -156,31 +353,177 @@ mod tests {
 
     #[test]
     fn default_config_has_palace_path() {
-        // Test the default palace path formula directly: MempalaceConfig::default()
-        // calls config_dir() which may return MEMPALACE_DIR when set by the test runner.
-        let path = home_dir().join(".mempalace").join("palace.db");
+        // The default palace path is under the XDG data dir.
+        // Test the formula directly using home_dir() to avoid MEMPALACE_DIR interference.
+        let path = home_dir()
+            .join(".local")
+            .join("share")
+            .join("mempalace")
+            .join("palace.db");
         let path_str = path.to_string_lossy();
-        assert!(path_str.contains(".mempalace"));
+        assert!(path_str.contains("mempalace"));
         assert!(path_str.ends_with("palace.db"));
     }
 
     #[test]
     fn config_dir_ends_with_mempalace() {
-        // Test the default path formula directly: config_dir() returns MEMPALACE_DIR
-        // when set, so we test the fallback formula via home_dir().
-        let directory = home_dir().join(".mempalace");
-        assert!(directory.to_string_lossy().ends_with(".mempalace"));
+        // Test the default formula directly via xdg_data_dir() to avoid
+        // MEMPALACE_DIR interference from the test runner environment.
+        let directory = home_dir().join(".local").join("share").join("mempalace");
+        assert!(directory.ends_with("mempalace"));
     }
 
     #[test]
     fn config_dir_respects_mempalace_dir_env_var() {
-        // Verify that MEMPALACE_DIR overrides the default path. temp_env safely
+        // Verify that MEMPALACE_DIR overrides the XDG path. temp_env safely
         // sets the var for this test and restores the previous value afterwards,
         // preventing interference with concurrent tests.
-        let dir = tempfile::tempdir().expect("failed to create temp dir");
-        temp_env::with_var("MEMPALACE_DIR", Some(dir.path()), || {
-            assert_eq!(config_dir(), dir.path());
+        let tempdir = tempfile::tempdir().expect("failed to create temp dir");
+        temp_env::with_var("MEMPALACE_DIR", Some(tempdir.path()), || {
+            assert_eq!(config_dir(), tempdir.path());
         });
+    }
+
+    #[test]
+    fn config_dir_uses_xdg_data_home() {
+        // XDG_DATA_HOME should set the base for config_dir().
+        let xdg_tempdir = tempfile::tempdir().expect("failed to create temp dir");
+        temp_env::with_vars(
+            [
+                (
+                    "XDG_DATA_HOME",
+                    Some(xdg_tempdir.path().to_str().expect("valid path")),
+                ),
+                ("MEMPALACE_DIR", None),
+            ],
+            || {
+                let result = config_dir();
+                assert_eq!(result, xdg_tempdir.path().join("mempalace"));
+            },
+        );
+    }
+
+    #[test]
+    fn mempalace_dir_overrides_xdg_data_home() {
+        // MEMPALACE_DIR takes priority over XDG_DATA_HOME.
+        let mempalace_override = tempfile::tempdir().expect("failed to create temp dir");
+        let xdg_tempdir = tempfile::tempdir().expect("failed to create temp dir");
+        temp_env::with_vars(
+            [
+                (
+                    "MEMPALACE_DIR",
+                    Some(mempalace_override.path().to_str().expect("valid path")),
+                ),
+                (
+                    "XDG_DATA_HOME",
+                    Some(xdg_tempdir.path().to_str().expect("valid path")),
+                ),
+            ],
+            || {
+                assert_eq!(config_dir(), mempalace_override.path());
+            },
+        );
+    }
+
+    #[test]
+    fn default_palace_path_uses_xdg_data_dir() {
+        // The default palace.db path must be inside the XDG data dir, not ~/.mempalace.
+        let xdg_tempdir = tempfile::tempdir().expect("failed to create temp dir");
+        temp_env::with_vars(
+            [
+                (
+                    "XDG_DATA_HOME",
+                    Some(xdg_tempdir.path().to_str().expect("valid path")),
+                ),
+                ("MEMPALACE_DIR", None),
+            ],
+            || {
+                let path = default_palace_path();
+                assert_eq!(path, xdg_tempdir.path().join("mempalace").join("palace.db"));
+                assert!(!path.to_string_lossy().contains(".mempalace"));
+            },
+        );
+    }
+
+    #[test]
+    fn migrate_moves_files_from_legacy_dir() {
+        // Set HOME to a temp dir, create a fake legacy ~/.mempalace, run migration,
+        // verify files land in ~/.local/share/mempalace/.
+        let home = tempfile::tempdir().expect("failed to create temp dir");
+        let legacy = home.path().join(".mempalace");
+        std::fs::create_dir_all(&legacy).expect("create legacy dir");
+        std::fs::write(legacy.join("config.json"), r#"{"palace_path":"/old/palace.db","collection_name":"mempalace_drawers","people_map":{}}"#)
+            .expect("write config.json");
+        std::fs::write(legacy.join("identity.txt"), "I am a test palace.")
+            .expect("write identity.txt");
+
+        temp_env::with_vars(
+            [
+                ("HOME", Some(home.path().to_str().expect("valid path"))),
+                ("MEMPALACE_DIR", None),
+                ("XDG_DATA_HOME", None),
+            ],
+            || {
+                maybe_migrate().expect("migration should succeed");
+
+                let destination = home.path().join(".local").join("share").join("mempalace");
+                assert!(destination.join("config.json").exists());
+                assert!(destination.join("identity.txt").exists());
+                // Legacy directory should be removed (it is now empty).
+                assert!(!legacy.exists());
+            },
+        );
+    }
+
+    #[test]
+    fn migrate_skipped_when_mempalace_dir_set() {
+        // When MEMPALACE_DIR is set, migration must not run.
+        let home = tempfile::tempdir().expect("failed to create temp dir");
+        let legacy = home.path().join(".mempalace");
+        std::fs::create_dir_all(&legacy).expect("create legacy dir");
+        std::fs::write(legacy.join("config.json"), "{}").expect("write config.json");
+
+        let override_dir = tempfile::tempdir().expect("create override dir");
+        temp_env::with_vars(
+            [
+                ("HOME", Some(home.path().to_str().expect("valid path"))),
+                (
+                    "MEMPALACE_DIR",
+                    Some(override_dir.path().to_str().expect("valid path")),
+                ),
+                ("XDG_DATA_HOME", None),
+            ],
+            || {
+                maybe_migrate().expect("should return ok without migrating");
+                // Legacy dir must still exist — migration was skipped.
+                assert!(legacy.join("config.json").exists());
+            },
+        );
+    }
+
+    #[test]
+    fn migrate_idempotent() {
+        // Running migration twice must produce the same result with no errors.
+        let home = tempfile::tempdir().expect("failed to create temp dir");
+        let legacy = home.path().join(".mempalace");
+        std::fs::create_dir_all(&legacy).expect("create legacy dir");
+        std::fs::write(legacy.join("config.json"), r#"{"palace_path":"/old/palace.db","collection_name":"mempalace_drawers","people_map":{}}"#)
+            .expect("write config.json");
+
+        temp_env::with_vars(
+            [
+                ("HOME", Some(home.path().to_str().expect("valid path"))),
+                ("MEMPALACE_DIR", None),
+                ("XDG_DATA_HOME", None),
+            ],
+            || {
+                maybe_migrate().expect("first migration");
+                maybe_migrate().expect("second migration — must be idempotent");
+
+                let destination = home.path().join(".local").join("share").join("mempalace");
+                assert!(destination.join("config.json").exists());
+            },
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -76,9 +76,24 @@ pub fn legacy_dir() -> PathBuf {
     legacy_directory
 }
 
-/// Returns the user's home directory, or `.` if `HOME` is unset.
+/// Returns the user's home directory, or `.` if it cannot be determined.
+///
+/// Checks `HOME` (POSIX), then `USERPROFILE` (Windows), then
+/// `HOMEDRIVE`+`HOMEPATH` (legacy Windows), mirroring the fallback order
+/// used by `expand_tilde()` in `main.rs`.
 fn home_dir() -> PathBuf {
-    std::env::var("HOME").map_or_else(|_| PathBuf::from("."), PathBuf::from)
+    let home = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .or_else(|| {
+            let drive = std::env::var_os("HOMEDRIVE")?;
+            let path = std::env::var_os("HOMEPATH")?;
+            Some(PathBuf::from(drive).join(path).into_os_string())
+        })
+        .map_or_else(|| PathBuf::from("."), PathBuf::from);
+    assert!(!home.as_os_str().is_empty());
+    // Negative space: path must not contain null bytes.
+    assert!(!home.to_string_lossy().contains('\0'));
+    home
 }
 
 /// Path to the global config file.

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,10 +50,13 @@ pub fn config_dir() -> PathBuf {
     data_directory
 }
 
-/// Returns `$XDG_DATA_HOME` if set and non-empty, otherwise `$HOME/.local/share`.
+/// Returns `$XDG_DATA_HOME` if set to an absolute path, otherwise `$HOME/.local/share`.
+///
+/// A relative or empty `$XDG_DATA_HOME` is treated as unset, per XDG spec intent.
 fn xdg_data_dir() -> PathBuf {
     let base_directory = if let Ok(val) = std::env::var("XDG_DATA_HOME")
         && !val.is_empty()
+        && PathBuf::from(&val).is_absolute()
     {
         PathBuf::from(val)
     } else {
@@ -399,6 +402,28 @@ mod tests {
             || {
                 let result = config_dir();
                 assert_eq!(result, xdg_tempdir.path().join("mempalace"));
+            },
+        );
+    }
+
+    #[test]
+    fn xdg_data_home_relative_path_falls_back_to_default() {
+        // A relative XDG_DATA_HOME must be ignored — only absolute paths are valid
+        // per XDG spec intent. The fallback is $HOME/.local/share/mempalace.
+        let home = tempfile::tempdir().expect("failed to create temp dir");
+        temp_env::with_vars(
+            [
+                ("HOME", Some(home.path().to_str().expect("valid path"))),
+                ("XDG_DATA_HOME", Some("relative/path")),
+                ("MEMPALACE_DIR", None),
+            ],
+            || {
+                let result = config_dir();
+                assert_eq!(
+                    result,
+                    home.path().join(".local").join("share").join("mempalace")
+                );
+                assert!(!result.to_string_lossy().contains("relative/path"));
             },
         );
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -165,7 +165,10 @@ fn maybe_migrate() -> Result<()> {
         return Ok(());
     }
 
-    // Already migrated — config.json exists in the XDG location.
+    // Already migrated — config.json was moved last in maybe_migrate_inner(),
+    // so its presence at the destination confirms full completion. A partial
+    // migration (crash before config.json was moved) re-enters here and resumes
+    // because source still contains config.json.
     if destination.join("config.json").exists() {
         return Ok(());
     }
@@ -177,14 +180,20 @@ fn maybe_migrate() -> Result<()> {
 }
 
 /// Perform the actual migration: move files from `source` to `destination`.
+///
+/// `config.json` is moved last so that its presence at the destination acts as
+/// an atomic completion marker. If this function is interrupted mid-run, the
+/// next call re-enters and resumes: already-moved files are skipped because
+/// their source paths no longer exist.
 fn maybe_migrate_inner(source: &Path, destination: &Path) -> Result<()> {
     assert!(source.exists());
     assert_ne!(source, destination);
 
     std::fs::create_dir_all(destination)?;
 
+    // Move all artifacts except config.json first. config.json moves last —
+    // its arrival at the destination is the completion marker (see maybe_migrate).
     let files = [
-        "config.json",
         "identity.txt",
         "palace.db",
         "palace.db-wal",
@@ -203,12 +212,15 @@ fn maybe_migrate_inner(source: &Path, destination: &Path) -> Result<()> {
         maybe_migrate_move_dir(&wal_source, &destination.join("wal"))?;
     }
 
-    // Patch palace_path in config.json if it still points to the legacy location.
-    let destination_config = destination.join("config.json");
-    if destination_config.exists() {
+    // Patch palace_path in config.json while it is still at the source so that
+    // the moved copy already contains the correct path. Moving it after patching
+    // keeps the patch and the move atomic with respect to the completion marker.
+    let source_config = source.join("config.json");
+    if source_config.exists() {
         let legacy_db = source.join("palace.db");
         let new_db = destination.join("palace.db");
-        maybe_migrate_patch_config(&destination_config, &legacy_db, &new_db)?;
+        maybe_migrate_patch_config(&source_config, &legacy_db, &new_db)?;
+        maybe_migrate_move_file(&source_config, &destination.join("config.json"))?;
     }
 
     // Remove the legacy directory if it is now empty.
@@ -547,6 +559,47 @@ mod tests {
 
                 let destination = home.path().join(".local").join("share").join("mempalace");
                 assert!(destination.join("config.json").exists());
+            },
+        );
+    }
+
+    #[test]
+    fn migrate_resumes_after_partial_migration() {
+        // Simulate a crash mid-migration: palace.db was already moved to the
+        // destination but config.json is still in the legacy dir. The next run
+        // must detect that config.json is still in the source (completion marker
+        // absent at destination) and finish the migration rather than skipping it.
+        let home = tempfile::tempdir().expect("failed to create temp dir");
+        let legacy = home.path().join(".mempalace");
+        let destination = home.path().join(".local").join("share").join("mempalace");
+
+        std::fs::create_dir_all(&legacy).expect("create legacy dir");
+        std::fs::create_dir_all(&destination).expect("create destination dir");
+
+        // config.json is still in the legacy dir (not yet moved — migration incomplete).
+        std::fs::write(
+            legacy.join("config.json"),
+            r#"{"palace_path":"/old/palace.db","collection_name":"mempalace_drawers","people_map":{}}"#,
+        )
+        .expect("write config.json");
+        // palace.db was already moved to the destination in the previous partial run.
+        std::fs::write(destination.join("palace.db"), b"fake db content").expect("write palace.db");
+
+        temp_env::with_vars(
+            [
+                ("HOME", Some(home.path().to_str().expect("valid path"))),
+                ("MEMPALACE_DIR", None),
+                ("XDG_DATA_HOME", None),
+            ],
+            || {
+                maybe_migrate().expect("migration must resume successfully");
+
+                // Completion marker must now exist.
+                assert!(destination.join("config.json").exists());
+                // palace.db must still be present (was already there).
+                assert!(destination.join("palace.db").exists());
+                // Legacy dir must be gone (now empty).
+                assert!(!legacy.exists());
             },
         );
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -76,23 +76,30 @@ pub fn legacy_dir() -> PathBuf {
     legacy_directory
 }
 
-/// Returns the user's home directory, or `.` if it cannot be determined.
+/// Returns the user's home directory.
 ///
 /// Checks `HOME` (POSIX), then `USERPROFILE` (Windows), then
 /// `HOMEDRIVE`+`HOMEPATH` (legacy Windows), mirroring the fallback order
-/// used by `expand_tilde()` in `main.rs`.
+/// used by `expand_tilde()` in `main.rs`. Panics if none are set — a missing
+/// home directory is a fatal misconfiguration that yields unusable XDG paths.
 fn home_dir() -> PathBuf {
-    let home = std::env::var_os("HOME")
+    let os_home = std::env::var_os("HOME")
         .or_else(|| std::env::var_os("USERPROFILE"))
         .or_else(|| {
             let drive = std::env::var_os("HOMEDRIVE")?;
             let path = std::env::var_os("HOMEPATH")?;
             Some(PathBuf::from(drive).join(path).into_os_string())
-        })
-        .map_or_else(|| PathBuf::from("."), PathBuf::from);
+        });
+    // A missing home directory is a programmer/environment error, not a
+    // recoverable operating error — assert so both debug and release builds fail fast.
+    assert!(
+        os_home.is_some(),
+        "HOME, USERPROFILE, or HOMEDRIVE+HOMEPATH must be set"
+    );
+    // unwrap_or_default() is unreachable after the assert above; used in place
+    // of unwrap() because clippy::unwrap_used is denied in this project.
+    let home = PathBuf::from(os_home.unwrap_or_default());
     assert!(!home.as_os_str().is_empty());
-    // Negative space: path must not contain null bytes.
-    assert!(!home.to_string_lossy().contains('\0'));
     home
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -179,6 +179,15 @@ fn maybe_migrate() -> Result<()> {
         return Ok(());
     }
 
+    // Without a resolvable home directory there is no legacy ~/.mempalace to
+    // migrate from; skip silently rather than panicking inside legacy_dir().
+    let home_resolvable = std::env::var_os("HOME").is_some()
+        || std::env::var_os("USERPROFILE").is_some()
+        || (std::env::var_os("HOMEDRIVE").is_some() && std::env::var_os("HOMEPATH").is_some());
+    if !home_resolvable {
+        return Ok(());
+    }
+
     let source = legacy_dir();
     let destination = config_dir();
 
@@ -390,24 +399,29 @@ mod tests {
 
     #[test]
     fn default_config_has_palace_path() {
-        // The default palace path is under the XDG data dir.
-        // Test the formula directly using home_dir() to avoid MEMPALACE_DIR interference.
-        let path = home_dir()
-            .join(".local")
-            .join("share")
-            .join("mempalace")
-            .join("palace.db");
-        let path_str = path.to_string_lossy();
-        assert!(path_str.contains("mempalace"));
-        assert!(path_str.ends_with("palace.db"));
+        // default_palace_path() must return a path inside the XDG data directory.
+        // Clear overrides so the function resolves through HOME/.local/share.
+        temp_env::with_vars(
+            [("MEMPALACE_DIR", None::<&str>), ("XDG_DATA_HOME", None)],
+            || {
+                let path = default_palace_path();
+                let path_str = path.to_string_lossy();
+                assert!(path_str.contains("mempalace"));
+                assert!(path_str.ends_with("palace.db"));
+            },
+        );
     }
 
     #[test]
     fn config_dir_ends_with_mempalace() {
-        // Test the default formula directly via xdg_data_dir() to avoid
-        // MEMPALACE_DIR interference from the test runner environment.
-        let directory = home_dir().join(".local").join("share").join("mempalace");
-        assert!(directory.ends_with("mempalace"));
+        // config_dir() must end with "mempalace" when resolved via the XDG default.
+        // Clear overrides so the function uses HOME/.local/share/mempalace.
+        temp_env::with_vars(
+            [("MEMPALACE_DIR", None::<&str>), ("XDG_DATA_HOME", None)],
+            || {
+                assert!(config_dir().ends_with("mempalace"));
+            },
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -627,6 +627,51 @@ mod tests {
     }
 
     #[test]
+    fn migrate_patches_palace_path_when_pointing_to_legacy_default() {
+        // maybe_migrate_patch_config() only rewrites palace_path when it equals
+        // the legacy default (source.join("palace.db")). All other migration
+        // tests use "/old/palace.db" which never matches, leaving this code path
+        // untested. This test uses the real legacy default path to exercise it.
+        let home = tempfile::tempdir().expect("failed to create temp dir");
+        let legacy = home.path().join(".mempalace");
+        std::fs::create_dir_all(&legacy).expect("create legacy dir");
+
+        // Write config.json using serde to avoid hand-rolling JSON with a
+        // path that may contain characters requiring escaping.
+        let legacy_db = legacy.join("palace.db");
+        let config_content = serde_json::to_string(&MempalaceConfig {
+            palace_path: legacy_db,
+            collection_name: "mempalace_drawers".to_string(),
+            people_map: std::collections::HashMap::new(),
+        })
+        .expect("serialize config");
+        std::fs::write(legacy.join("config.json"), &config_content).expect("write config.json");
+
+        temp_env::with_vars(
+            [
+                ("HOME", Some(home.path().to_str().expect("valid path"))),
+                ("MEMPALACE_DIR", None),
+                ("XDG_DATA_HOME", None),
+            ],
+            || {
+                maybe_migrate().expect("migration should succeed");
+
+                let destination = home.path().join(".local").join("share").join("mempalace");
+                let new_db = destination.join("palace.db");
+
+                let data = std::fs::read_to_string(destination.join("config.json"))
+                    .expect("read migrated config.json");
+                let config: MempalaceConfig =
+                    serde_json::from_str(&data).expect("parse migrated config.json");
+
+                // palace_path must now point to the XDG location, not the legacy one.
+                assert_eq!(config.palace_path, new_db);
+                assert!(!config.palace_path.to_string_lossy().contains(".mempalace"));
+            },
+        );
+    }
+
+    #[test]
     fn project_config_yaml_round_trip() {
         let yaml = r"
 wing: my_project

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -238,7 +238,7 @@ fn sanitize_content(value: &str) -> Result<String, Value> {
     Ok(result)
 }
 
-/// Append a write-operation entry to `~/.mempalace/wal/write_log.jsonl`.
+/// Append a write-operation entry to `$XDG_DATA_HOME/mempalace/wal/write_log.jsonl`.
 ///
 /// Failures are non-fatal: logged to stderr so the server stays alive even if
 /// the WAL directory is unwritable.  I/O is offloaded to `spawn_blocking` so

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -238,11 +238,12 @@ fn sanitize_content(value: &str) -> Result<String, Value> {
     Ok(result)
 }
 
-/// Append a write-operation entry to `$XDG_DATA_HOME/mempalace/wal/write_log.jsonl`.
+/// Append a write-operation entry to `config_dir()/wal/write_log.jsonl`.
 ///
-/// Failures are non-fatal: logged to stderr so the server stays alive even if
-/// the WAL directory is unwritable.  I/O is offloaded to `spawn_blocking` so
-/// the async worker thread is not stalled by filesystem calls.
+/// The data directory is `$XDG_DATA_HOME/mempalace` by default, or the value
+/// of `MEMPALACE_DIR` when set. Failures are non-fatal: logged to stderr so
+/// the server stays alive even if the WAL directory is unwritable. I/O is
+/// offloaded to `spawn_blocking` so the async worker thread is not stalled.
 async fn wal_log(operation: &str, params: Value) {
     // wal_log is best-effort and must never crash. An empty operation string is a
     // programmer error caught in debug builds; in release builds we silently skip.

--- a/src/palace/layers.rs
+++ b/src/palace/layers.rs
@@ -16,25 +16,27 @@ const MAX_DRAWERS: usize = 15;
 // rule of thumb, leaving headroom for L0 and the user's own message.
 const MAX_CHARS: usize = 3200;
 
-/// Layer 0: Identity text from ~/.mempalace/identity.txt
+/// Layer 0: Identity text from `$XDG_DATA_HOME/mempalace/identity.txt`.
 pub fn layer0() -> String {
     let path = config::config_dir().join("identity.txt");
+    let missing = format!(
+        "## L0 — IDENTITY\nNo identity configured. Create {}",
+        path.display()
+    );
     if path.exists() {
         match std::fs::read_to_string(&path) {
             Ok(text) => {
                 let text = text.trim().to_string();
                 if text.is_empty() {
-                    "## L0 — IDENTITY\nNo identity configured. Create ~/.mempalace/identity.txt"
-                        .to_string()
+                    missing
                 } else {
                     format!("## L0 — IDENTITY\n{text}")
                 }
             }
-            Err(_) => "## L0 — IDENTITY\nNo identity configured. Create ~/.mempalace/identity.txt"
-                .to_string(),
+            Err(_) => missing,
         }
     } else {
-        "## L0 — IDENTITY\nNo identity configured. Create ~/.mempalace/identity.txt".to_string()
+        missing
     }
 }
 


### PR DESCRIPTION
## Summary

- Move the mempalace data directory from `~/.mempalace` to `$XDG_DATA_HOME/mempalace` (default: `~/.local/share/mempalace`), following the XDG Base Directory Specification
- On first run after upgrade, existing `~/.mempalace` contents are migrated automatically; `palace_path` in `config.json` is patched if it pointed to the legacy default; legacy directory is removed if empty
- `MEMPALACE_DIR` continues to bypass XDG resolution entirely, preserving test isolation and container deployments unchanged

Closes #10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App now uses XDG data directories for config/data (env override honored) and auto-migrates legacy data into the new location; migration is resumable, removes emptied legacy folders, patches default DB path in migrated config, and emits a console notice.

* **Bug Fixes**
  * More robust home-directory discovery and stricter path validation to avoid invalid or empty paths.

* **Documentation**
  * Updated messages/docs to show new data, WAL, and identity file locations under the XDG data dir.

* **Tests**
  * Expanded tests for path selection, override precedence, fallback behavior, default DB placement, and migration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->