### PR TITLE
Add `--no-gitignore` to `init` and `split`

### DIFF
--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -5,7 +5,7 @@ use crate::config::ProjectConfig;
 use crate::error::Result;
 use crate::palace::room_detect::detect_rooms_from_folders;
 
-pub fn run(directory: &Path, yes: bool) -> Result<()> {
+pub fn run(directory: &Path, yes: bool, no_gitignore: bool) -> Result<()> {
     let directory = directory.canonicalize().map_err(|e| {
         crate::error::Error::Other(format!("directory not found: {}: {e}", directory.display()))
     })?;
@@ -19,8 +19,8 @@ pub fn run(directory: &Path, yes: bool) -> Result<()> {
 
     let rooms = detect_rooms_from_folders(&directory);
 
-    // Count files for display
-    let file_count = crate::palace::miner::scan_project(&directory).len();
+    // Count files for display; honour the same gitignore flag used by `mine`.
+    let file_count = crate::palace::miner::scan_project_with_opts(&directory, !no_gitignore).len();
 
     println!("\n=======================================================");
     println!("  MemPalace Init");

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -33,6 +33,10 @@ pub enum Command {
         /// Auto-accept detected rooms without prompting (non-interactive / CI mode)
         #[arg(long, short = 'y')]
         yes: bool,
+
+        /// Disable .gitignore filtering (include all files regardless of gitignore rules)
+        #[arg(long)]
+        no_gitignore: bool,
     },
 
     /// Mine files into the palace
@@ -125,6 +129,10 @@ pub enum Command {
         /// Minimum sessions to trigger split
         #[arg(long, default_value = "2")]
         min_sessions: usize,
+
+        /// Disable .gitignore filtering (include all files regardless of gitignore rules)
+        #[arg(long)]
+        no_gitignore: bool,
     },
 
     /// Show palace overview and stats

--- a/src/cli/split.rs
+++ b/src/cli/split.rs
@@ -6,6 +6,49 @@ use regex::Regex;
 
 use crate::error::Result;
 
+/// Collect `.txt` file paths from the top level of `directory`.
+///
+/// When `respect_gitignore` is `true`, files excluded by `.gitignore` rules are
+/// omitted (same engine as `mine --no-gitignore`). Depth is fixed at 1 to match
+/// the original `fs::read_dir` behaviour — sub-directories are never traversed.
+fn split_collect_txt_files(directory: &Path, respect_gitignore: bool) -> Result<Vec<PathBuf>> {
+    assert!(
+        directory.is_dir(),
+        "split_collect_txt_files: directory must exist: {}",
+        directory.display()
+    );
+
+    let mut paths: Vec<PathBuf> = Vec::new();
+
+    if respect_gitignore {
+        let walker = ignore::WalkBuilder::new(directory)
+            .git_ignore(true)
+            .git_global(true)
+            .git_exclude(true)
+            .hidden(false)
+            .max_depth(Some(1))
+            .build();
+        for entry in walker.flatten() {
+            if !entry.file_type().is_some_and(|ft| ft.is_file()) {
+                continue;
+            }
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) == Some("txt") {
+                paths.push(path.to_path_buf());
+            }
+        }
+    } else {
+        for entry in fs::read_dir(directory)? {
+            let path = entry?.path();
+            if path.extension().and_then(|e| e.to_str()) == Some("txt") {
+                paths.push(path);
+            }
+        }
+    }
+
+    Ok(paths)
+}
+
 // Regex statics are compile-time literals; .expect() cannot fail at runtime.
 #[allow(clippy::expect_used)]
 // Matches the timestamp header line emitted by Claude Code session logs.
@@ -268,6 +311,7 @@ pub fn run(
     output_dir: Option<&Path>,
     dry_run: bool,
     min_sessions: usize,
+    respect_gitignore: bool,
 ) -> Result<()> {
     if !directory.is_dir() {
         return Err(crate::error::Error::Other(format!(
@@ -282,13 +326,7 @@ pub fn run(
     }
     let mut mega_files: Vec<(PathBuf, usize)> = Vec::new();
 
-    for entry in fs::read_dir(directory)? {
-        let entry = entry?;
-        let path = entry.path();
-        if path.extension().and_then(|e| e.to_str()) != Some("txt") {
-            continue;
-        }
-
+    for path in split_collect_txt_files(directory, respect_gitignore)? {
         if fs::metadata(&path).is_ok_and(|m| m.len() > MAX_SPLIT_FILE_SIZE) {
             println!("  SKIP: {} exceeds 500 MB limit", path.display());
             continue;

--- a/src/cli/split.rs
+++ b/src/cli/split.rs
@@ -12,11 +12,14 @@ use crate::error::Result;
 /// omitted (same engine as `mine --no-gitignore`). Depth is fixed at 1 to match
 /// the original `fs::read_dir` behaviour — sub-directories are never traversed.
 fn split_collect_txt_files(directory: &Path, respect_gitignore: bool) -> Result<Vec<PathBuf>> {
-    assert!(
-        directory.is_dir(),
-        "split_collect_txt_files: directory must exist: {}",
-        directory.display()
-    );
+    // Operating condition: filesystem state can change between the caller's
+    // is_dir() check and this call (TOCTOU) — return Err rather than panic.
+    if !directory.is_dir() {
+        return Err(crate::error::Error::Other(format!(
+            "split_collect_txt_files: '{}' is not an existing directory",
+            directory.display()
+        )));
+    }
 
     let mut paths: Vec<PathBuf> = Vec::new();
 
@@ -40,6 +43,11 @@ fn split_collect_txt_files(directory: &Path, respect_gitignore: bool) -> Result<
     } else {
         for entry in fs::read_dir(directory)? {
             let path = entry?.path();
+            // Guard matches the respect_gitignore branch: skip non-files so
+            // that a directory named "foo.txt" is never collected.
+            if !path.is_file() {
+                continue;
+            }
             if path.extension().and_then(|e| e.to_str()) == Some("txt") {
                 paths.push(path);
             }
@@ -527,13 +535,16 @@ mod tests {
     #[test]
     fn split_collect_txt_files_no_gitignore_returns_all_top_level() {
         // Verify that when respect_gitignore=false, all top-level .txt files are
-        // returned regardless of .gitignore, and nested .txt files are excluded.
+        // returned regardless of .gitignore, non-files with a .txt name are excluded,
+        // and nested .txt files are excluded.
         let directory = tempfile::tempdir().expect("create temp dir");
         fs::write(directory.path().join("a.txt"), "content a").expect("write a.txt");
         fs::write(directory.path().join("b.txt"), "content b").expect("write b.txt");
         fs::write(directory.path().join("notes.md"), "# notes").expect("write notes.md");
         // .gitignore excludes b.txt — must be ignored when respect_gitignore=false.
         fs::write(directory.path().join(".gitignore"), "b.txt\n").expect("write .gitignore");
+        // A directory with a .txt extension — is_file() guard must exclude it.
+        fs::create_dir(directory.path().join("fake.txt")).expect("create fake.txt dir");
         // Subdirectory with a .txt — depth=1 must exclude it in both modes.
         let subdirectory = directory.path().join("sub");
         fs::create_dir(&subdirectory).expect("create sub");
@@ -552,6 +563,10 @@ mod tests {
         assert!(
             names.contains(&"b.txt".to_owned()),
             "b.txt must be present when gitignore not respected"
+        );
+        assert!(
+            !names.contains(&"fake.txt".to_owned()),
+            "directory named fake.txt must be excluded by is_file() guard"
         );
         assert!(
             !names.contains(&"nested.txt".to_owned()),

--- a/src/cli/split.rs
+++ b/src/cli/split.rs
@@ -521,4 +521,90 @@ mod tests {
         );
         assert!(!result.is_empty(), "subject must not be empty");
     }
+
+    // --- split_collect_txt_files ---
+
+    #[test]
+    fn split_collect_txt_files_no_gitignore_returns_all_top_level() {
+        // Verify that when respect_gitignore=false, all top-level .txt files are
+        // returned regardless of .gitignore, and nested .txt files are excluded.
+        let directory = tempfile::tempdir().expect("create temp dir");
+        fs::write(directory.path().join("a.txt"), "content a").expect("write a.txt");
+        fs::write(directory.path().join("b.txt"), "content b").expect("write b.txt");
+        fs::write(directory.path().join("notes.md"), "# notes").expect("write notes.md");
+        // .gitignore excludes b.txt — must be ignored when respect_gitignore=false.
+        fs::write(directory.path().join(".gitignore"), "b.txt\n").expect("write .gitignore");
+        // Subdirectory with a .txt — depth=1 must exclude it in both modes.
+        let subdirectory = directory.path().join("sub");
+        fs::create_dir(&subdirectory).expect("create sub");
+        fs::write(subdirectory.join("nested.txt"), "nested").expect("write nested.txt");
+
+        let result =
+            split_collect_txt_files(directory.path(), false).expect("collect must succeed");
+        let mut names: Vec<String> = result
+            .iter()
+            .filter_map(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+            .collect();
+        names.sort();
+
+        assert_eq!(names.len(), 2, "both top-level .txt files must be returned");
+        assert!(names.contains(&"a.txt".to_owned()), "a.txt must be present");
+        assert!(
+            names.contains(&"b.txt".to_owned()),
+            "b.txt must be present when gitignore not respected"
+        );
+        assert!(
+            !names.contains(&"nested.txt".to_owned()),
+            "nested.txt in subdirectory must be excluded"
+        );
+    }
+
+    #[test]
+    fn split_collect_txt_files_respect_gitignore_filters_and_caps_depth() {
+        // Verify that when respect_gitignore=true, .gitignore-excluded files are
+        // omitted and nested files beyond depth=1 are excluded.
+        let directory = tempfile::tempdir().expect("create temp dir");
+        // The ignore crate only honours .gitignore when the directory is a git repo.
+        let git_init = std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(directory.path())
+            .output()
+            .expect("git init must run");
+        assert!(
+            git_init.status.success(),
+            "git init failed: {:?}",
+            String::from_utf8_lossy(&git_init.stderr)
+        );
+        fs::write(directory.path().join("a.txt"), "content a").expect("write a.txt");
+        fs::write(directory.path().join("b.txt"), "content b").expect("write b.txt");
+        // .gitignore excludes b.txt.
+        fs::write(directory.path().join(".gitignore"), "b.txt\n").expect("write .gitignore");
+        // Subdirectory with a .txt — depth limit must exclude it.
+        let subdirectory = directory.path().join("sub");
+        fs::create_dir(&subdirectory).expect("create sub");
+        fs::write(subdirectory.join("nested.txt"), "nested").expect("write nested.txt");
+
+        let result = split_collect_txt_files(directory.path(), true).expect("collect must succeed");
+        let mut names: Vec<String> = result
+            .iter()
+            .filter_map(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+            .collect();
+        names.sort();
+
+        // Only a.txt survives: b.txt excluded by .gitignore, nested.txt by depth.
+        assert_eq!(
+            names.len(),
+            1,
+            "only the non-ignored top-level .txt must be returned"
+        );
+        assert!(names.contains(&"a.txt".to_owned()), "a.txt must be present");
+        assert!(
+            !names.contains(&"b.txt".to_owned()),
+            "b.txt must be excluded by .gitignore"
+        );
+        assert!(
+            !names.contains(&"nested.txt".to_owned()),
+            "nested.txt in subdirectory must be excluded"
+        );
+    }
 }

--- a/src/cli/split.rs
+++ b/src/cli/split.rs
@@ -31,7 +31,10 @@ fn split_collect_txt_files(directory: &Path, respect_gitignore: bool) -> Result<
             .hidden(false)
             .max_depth(Some(1))
             .build();
-        for entry in walker.flatten() {
+        for entry in walker {
+            // Propagate IO/permission errors rather than silently dropping them,
+            // consistent with how the respect_gitignore=false branch uses `entry?`.
+            let entry = entry.map_err(|e| crate::error::Error::Other(e.to_string()))?;
             if !entry.file_type().is_some_and(|ft| ft.is_file()) {
                 continue;
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,8 +102,12 @@ async fn run(cli: Cli) -> error::Result<()> {
             run_status().await?;
         }
 
-        Command::Init { directory, yes } => {
-            cli::init::run(&directory, yes)?;
+        Command::Init {
+            directory,
+            yes,
+            no_gitignore,
+        } => {
+            cli::init::run(&directory, yes, no_gitignore)?;
         }
 
         Command::Mine {
@@ -164,11 +168,18 @@ async fn run(cli: Cli) -> error::Result<()> {
             output_dir,
             dry_run,
             min_sessions,
+            no_gitignore,
         } => {
             // Expand ~ so that `mempalace split ~/convos` works as expected.
             let directory = expand_tilde(&directory);
             let output_dir = output_dir.as_deref().map(expand_tilde);
-            cli::split::run(&directory, output_dir.as_deref(), dry_run, min_sessions)?;
+            cli::split::run(
+                &directory,
+                output_dir.as_deref(),
+                dry_run,
+                min_sessions,
+                !no_gitignore,
+            )?;
         }
 
         Command::Repair => {

--- a/src/palace/miner.rs
+++ b/src/palace/miner.rs
@@ -45,15 +45,6 @@ const SKIP_FILES: &[&str] = &[
 ];
 
 /// Scan a project directory for all readable files.
-///
-/// When `respect_gitignore` is `true`, `.gitignore` rules are applied via the
-/// `ignore` crate (same engine as ripgrep). `SKIP_DIRS` and `SKIP_FILES` are always
-/// applied regardless.
-pub fn scan_project(project_dir: &Path) -> Vec<PathBuf> {
-    scan_project_with_opts(project_dir, true)
-}
-
-/// Scan with explicit gitignore control.
 pub fn scan_project_with_opts(project_dir: &Path, respect_gitignore: bool) -> Vec<PathBuf> {
     assert!(
         project_dir.is_dir(),
@@ -429,7 +420,7 @@ mod tests {
         std::fs::write(dir.path().join("notes.txt"), "hello world")
             .expect("write .txt should succeed");
 
-        let files = scan_project(dir.path());
+        let files = scan_project_with_opts(dir.path(), true);
         let names: Vec<String> = files
             .iter()
             .map(|p| {
@@ -477,7 +468,7 @@ mod tests {
         std::fs::write(dir.path().join("ignored.rs"), "// ignored")
             .expect("write ignored.rs should succeed");
 
-        let files = scan_project(dir.path());
+        let files = scan_project_with_opts(dir.path(), true);
         let names: Vec<String> = files
             .iter()
             .map(|p| {
@@ -555,7 +546,7 @@ mod tests {
         std::fs::write(dir.path().join("index.js"), "console.log('main')")
             .expect("write index.js should succeed");
 
-        let files = scan_project(dir.path());
+        let files = scan_project_with_opts(dir.path(), true);
         let names: Vec<String> = files
             .iter()
             .map(|p| {
@@ -586,7 +577,7 @@ mod tests {
         std::fs::write(dir.path().join("code.rs"), "fn main() {}")
             .expect("write .rs should succeed");
 
-        let files = scan_project(dir.path());
+        let files = scan_project_with_opts(dir.path(), true);
         let names: Vec<String> = files
             .iter()
             .map(|p| {

--- a/tests/mining_pipeline.rs
+++ b/tests/mining_pipeline.rs
@@ -3,7 +3,7 @@
 
 use std::fs;
 
-use mempalace::palace::miner::{MineParams, scan_project};
+use mempalace::palace::miner::{MineParams, scan_project_with_opts};
 use mempalace::palace::search::search_memories;
 use mempalace::test_helpers::test_db;
 
@@ -27,7 +27,7 @@ async fn scan_and_mine_creates_searchable_drawers() {
     .expect("write design.md should succeed");
 
     // Scan should find both files.
-    let files = scan_project(directory.path());
+    let files = scan_project_with_opts(directory.path(), true);
     assert!(
         files.len() >= 2,
         "scan should find at least 2 readable files"
@@ -164,7 +164,7 @@ fn scan_respects_gitignore() {
     )
     .expect("write secret.rs should succeed");
 
-    let files = scan_project(directory.path());
+    let files = scan_project_with_opts(directory.path(), true);
     let names: Vec<String> = files
         .iter()
         .filter_map(|p| p.file_name().map(|n| n.to_string_lossy().to_string()))


### PR DESCRIPTION
## Summary

- `mine` already supported `--no-gitignore` via `scan_project_with_opts`, but `init` and `split` were missing the flag, creating a mismatch between the file count shown during `init` and what `mine`/`split` would actually process
- Wire `--no-gitignore` into `init` so its file-count preview is consistent with `mine`
- Extract `split_collect_txt_files` helper in `split.rs` to apply the same gitignore engine to `.txt` discovery
- Remove the `scan_project` wrapper alias; all callers now use `scan_project_with_opts` directly so gitignore behaviour is explicit at every call site

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --no-gitignore CLI flag to Init, Mine, and Split to optionally include files normally excluded by .gitignore.

* **Improvements**
  * Init now reports file counts using the same gitignore behavior as Mine.
  * Split now limits scanning to top-level .txt files and supports the no-gitignore option.
  * Project scanning was unified to use an explicit gitignore-respect option.

* **Tests**
  * Added tests for both gitignore-respecting and non-gitignore modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->