### PR TITLE
Fix README quick start: remove split step for JSONL

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,7 @@ mempalace init ~/my-project
 # 2. Mine project files into the palace
 mempalace mine ~/my-project
 
-# 3. Mine conversation transcripts (split Claude Code mega-files first)
-mempalace split ~/.claude/projects/
+# 3. Mine conversation transcripts
 mempalace mine ~/.claude/projects/ --mode convos
 
 # 4. Search


### PR DESCRIPTION
## Summary

- Removes the misleading `mempalace split ~/.claude/projects/` step from the Quick Start snippet
- Claude Code's native JSONL format already stores each session as its own UUID-named file — there is nothing to split
- `mine --mode convos` can be run directly, matching the correction already made to USAGE.md in #35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified Quick Start CLI instructions by consolidating setup steps into a single unified command for conversation transcript mining.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->