### PR TITLE
Lint CI: stable/beta/nightly toolchain matrix

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,7 @@ jobs:
       contents: read
 
     strategy:
+      fail-fast: false
       matrix:
         toolchain: [stable, nightly]
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,7 @@ permissions: {}
 jobs:
   run:
     runs-on: ubuntu-24.04
+    continue-on-error: ${{ matrix.toolchain == 'nightly' }}
 
     permissions:
       contents: read
@@ -54,8 +55,5 @@ jobs:
             ${{ runner.os }}-cargo-lint-
 
       - run: cargo clippy --all-targets --all-features
-        continue-on-error: ${{ matrix.toolchain == 'nightly' }}
       - run: cargo fmt --check --all
-        continue-on-error: ${{ matrix.toolchain == 'nightly' }}
       - run: hk check --all --skip-step no_commit_protected_branch
-        continue-on-error: ${{ matrix.toolchain == 'nightly' }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,10 @@ jobs:
     permissions:
       contents: read
 
+    strategy:
+      matrix:
+        toolchain: [stable, nightly]
+
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -20,7 +24,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.toolchain }}
           components: clippy, rustfmt
 
       - name: Capture rustc fingerprint
@@ -49,5 +53,8 @@ jobs:
             ${{ runner.os }}-cargo-lint-
 
       - run: cargo clippy --all-targets --all-features
+        continue-on-error: ${{ matrix.toolchain == 'nightly' }}
       - run: cargo fmt --check --all
+        continue-on-error: ${{ matrix.toolchain == 'nightly' }}
       - run: hk check --all --skip-step no_commit_protected_branch
+        continue-on-error: ${{ matrix.toolchain == 'nightly' }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ permissions: {}
 jobs:
   run:
     runs-on: ubuntu-24.04
-    continue-on-error: ${{ matrix.toolchain == 'nightly' }}
+    continue-on-error: ${{ matrix.toolchain != 'stable' }}
 
     permissions:
       contents: read
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [stable, nightly]
+        toolchain: [stable, beta, nightly]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -44,6 +44,7 @@ jobs:
           install: true
 
       - name: Cache Cargo
+        if: matrix.toolchain == 'stable'
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: |

--- a/src/config.rs
+++ b/src/config.rs
@@ -255,10 +255,7 @@ fn maybe_migrate_inner(source: &Path, destination: &Path) -> Result<()> {
     }
 
     // Remove the legacy directory if it is now empty.
-    if std::fs::read_dir(source)
-        .map(|mut entries| entries.next().is_none())
-        .unwrap_or(false)
-    {
+    if std::fs::read_dir(source).is_ok_and(|mut entries| entries.next().is_none()) {
         let _ = std::fs::remove_dir(source);
     }
 
@@ -293,10 +290,7 @@ fn maybe_migrate_move_dir(source: &Path, destination: &Path) -> Result<()> {
     }
 
     // Remove source dir if now empty.
-    if std::fs::read_dir(source)
-        .map(|mut entries| entries.next().is_none())
-        .unwrap_or(false)
-    {
+    if std::fs::read_dir(source).is_ok_and(|mut entries| entries.next().is_none()) {
         let _ = std::fs::remove_dir(source);
     }
 
@@ -341,8 +335,7 @@ fn maybe_migrate_patch_config(config_path: &Path, legacy_db: &Path, new_db: &Pat
         // Pair assertion: patched value must round-trip correctly.
         debug_assert!(
             serde_json::from_str::<MempalaceConfig>(&patched)
-                .map(|c| c.palace_path.as_path() == new_db)
-                .unwrap_or(false)
+                .is_ok_and(|c| c.palace_path.as_path() == new_db)
         );
     }
 

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -135,7 +135,7 @@ fn extract_key_sentence(text: &str) -> String {
         })
         .collect();
 
-    scored.sort_by(|a, b| b.0.cmp(&a.0));
+    scored.sort_by_key(|b| std::cmp::Reverse(b.0));
     let best = scored[0].1;
 
     if best.len() > 55 {

--- a/src/dialect/topics.rs
+++ b/src/dialect/topics.rs
@@ -64,7 +64,7 @@ pub fn extract_topics(text: &str, max_topics: usize) -> Vec<String> {
     }
 
     let mut ranked: Vec<_> = freq.into_iter().collect();
-    ranked.sort_by(|a, b| b.1.cmp(&a.1));
+    ranked.sort_by_key(|b| std::cmp::Reverse(b.1));
     ranked
         .into_iter()
         .take(max_topics)

--- a/src/palace/entity_detect.rs
+++ b/src/palace/entity_detect.rs
@@ -86,7 +86,7 @@ pub fn detect_entities(file_paths: &[&Path], max_files: usize) -> DetectionResul
     let mut uncertain = Vec::new();
 
     let mut sorted_candidates: Vec<_> = candidates.into_iter().collect();
-    sorted_candidates.sort_by(|a, b| b.1.cmp(&a.1));
+    sorted_candidates.sort_by_key(|b| std::cmp::Reverse(b.1));
 
     for (name, frequency) in sorted_candidates {
         let scores = score_entity(&name, &all_text, &all_lines);
@@ -109,7 +109,7 @@ pub fn detect_entities(file_paths: &[&Path], max_files: usize) -> DetectionResul
             .partial_cmp(&a.confidence)
             .unwrap_or(std::cmp::Ordering::Equal)
     });
-    uncertain.sort_by(|a, b| b.frequency.cmp(&a.frequency));
+    uncertain.sort_by_key(|b| std::cmp::Reverse(b.frequency));
 
     people.truncate(15);
     projects.truncate(10);

--- a/src/palace/graph.rs
+++ b/src/palace/graph.rs
@@ -275,7 +275,7 @@ pub async fn graph_stats(connection: &Connection) -> Result<GraphStats> {
         .filter(|n| n.wings.len() >= 2)
         .cloned()
         .collect();
-    top_tunnels.sort_by(|a, b| b.wings.len().cmp(&a.wings.len()));
+    top_tunnels.sort_by_key(|b| std::cmp::Reverse(b.wings.len()));
     top_tunnels.truncate(10);
 
     Ok(GraphStats {

--- a/src/palace/graph.rs
+++ b/src/palace/graph.rs
@@ -247,7 +247,7 @@ pub async fn find_tunnels(
         .collect();
 
     // Surface the busiest shared rooms first — they are the most useful bridges.
-    tunnels.sort_by(|a, b| b.count.cmp(&a.count));
+    tunnels.sort_by_key(|b| std::cmp::Reverse(b.count));
     let truncated = tunnels.len() > GRAPH_RESULT_CAP;
     tunnels.truncate(GRAPH_RESULT_CAP);
 

--- a/src/palace/miner.rs
+++ b/src/palace/miner.rs
@@ -220,7 +220,7 @@ fn mine_print_summary(
     println!("\n  By room:");
 
     let mut sorted_rooms: Vec<_> = room_counts.iter().collect();
-    sorted_rooms.sort_by(|a, b| b.1.cmp(a.1));
+    sorted_rooms.sort_by_key(|b| std::cmp::Reverse(b.1));
     for (room, count) in sorted_rooms {
         println!("    {room:20} {count} files");
     }


### PR DESCRIPTION
## Summary

- Adds a `strategy.matrix` over `[stable, beta, nightly]` to the lint workflow
- `beta` and `nightly` use `continue-on-error: true` at the job level — failures surface without blocking merges
- `fail-fast: false` ensures a `stable` failure does not cancel in-progress `beta`/`nightly` jobs
- Cargo cache is skipped for non-stable toolchains to prevent orphaned entries from eroding the 10 GB repo cache limit and evicting the stable cache
- Fixes `map_unwrap_or` and `unnecessary_sort_by` clippy lints caught by the new nightly job