### PR TITLE
Fix clean-pr-cache; simplify matrix job names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ permissions: {}
 
 jobs:
   run:
+    name: ${{ matrix.runs-on }}
     runs-on: ${{ matrix.runs-on }}
 
     permissions:

--- a/.github/workflows/clean-pr-cache.yml
+++ b/.github/workflows/clean-pr-cache.yml
@@ -1,4 +1,5 @@
 name: Clean PR Cache
+
 on:
   pull_request:
     types:
@@ -19,7 +20,7 @@ jobs:
       - name: Cleanup
         run: |-
           echo "Fetching list of cache key"
-          cacheKeysForPR=$(gh cache list --ref "$BRANCH" --limit 100 --json id --jq '.[].id')
+          mapfile -t cacheKeysForPR < <(gh cache list --ref "$BRANCH" --limit 100 --json id --jq '.[].id')
 
           ## Setting this to not fail the workflow while deleting cache keys.
           set +e

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,7 @@ permissions: {}
 
 jobs:
   run:
+    name: ${{ matrix.toolchain }}
     runs-on: ubuntu-24.04
     continue-on-error: ${{ matrix.toolchain != 'stable' }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ permissions: {}
 
 jobs:
   run:
+    name: ${{ matrix.runs-on }}
     runs-on: ${{ matrix.runs-on }}
 
     permissions:


### PR DESCRIPTION
## Summary

- Fix `clean-pr-cache.yml`: `cacheKeysForPR` was assigned with `$()`, producing a plain string; iterating with `"${cacheKeysForPR[@]}"` treated the entire newline-joined ID list as one element, so `gh cache delete` was called with an invalid key and silently failed (`set +e`) — switch to `mapfile -t` to read IDs into a real bash array
- Set `name: ${{ matrix.* }}` on matrix jobs in `lint.yml`, `test.yml`, and `build.yml`, shortening CI job labels from `Lint / run (stable)` to `Lint / stable`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved GitHub Actions workflow visibility with explicit job labeling for build, lint, and test pipelines, making it easier to track execution across different platforms.
  * Optimized cache cleanup logic for pull request workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->