### PR TITLE
Resync with mempalace-py @ 6889c6f

### DIFF
--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -2611,6 +2611,82 @@ mod tests {
         .await;
     }
 
+    // --- sanitize_kg_value ---
+
+    #[test]
+    fn sanitize_kg_value_allows_natural_language_punctuation() {
+        // Commas, colons, and parentheses are common in KG entity values.
+        for input in &[
+            "Alice, Bob",
+            "type: Person",
+            "born in (1990)",
+            "co-founder",
+            "O'Brien",
+            "Dr. Smith",
+        ] {
+            let result = sanitize_kg_value(input, "entity");
+            assert!(result.is_ok(), "expected Ok for '{input}', got {result:?}");
+            assert_eq!(
+                result.expect("sanitize_kg_value must accept valid input"),
+                input.trim()
+            );
+        }
+    }
+
+    #[test]
+    fn sanitize_kg_value_trims_whitespace() {
+        let result = sanitize_kg_value("  Alice  ", "entity");
+        assert_eq!(result.expect("whitespace trimming must succeed"), "Alice");
+    }
+
+    #[test]
+    fn sanitize_kg_value_unicode_boundary() {
+        // Exactly 128 Unicode characters (each is 3 bytes) must be accepted;
+        // 129 must be rejected.
+        let char_128: String = "あ".repeat(128);
+        let char_129: String = "あ".repeat(129);
+        assert_eq!(char_128.chars().count(), 128);
+        assert_eq!(char_129.chars().count(), 129);
+        assert!(
+            sanitize_kg_value(&char_128, "entity").is_ok(),
+            "128-char Unicode must be accepted"
+        );
+        let err = sanitize_kg_value(&char_129, "entity");
+        assert!(err.is_err(), "129-char Unicode must be rejected");
+        assert!(
+            err.expect_err("129-char input must be rejected")["error"]
+                .as_str()
+                .expect("error must be string")
+                .contains("128"),
+            "error must mention limit"
+        );
+    }
+
+    #[test]
+    fn sanitize_kg_value_rejects_path_traversal_and_null() {
+        let disallowed = [
+            ("..", "dotdot"),
+            ("/", "slash"),
+            ("\\", "backslash"),
+            ("\0", "null"),
+        ];
+        for (input, label) in &disallowed {
+            let result = sanitize_kg_value(&format!("value{input}here"), "entity");
+            assert!(result.is_err(), "expected Err for {label}");
+            let error_json = result.expect_err("disallowed input must be rejected");
+            assert!(
+                error_json["public"].as_bool().unwrap_or(false),
+                "error must be public for {label}"
+            );
+        }
+    }
+
+    #[test]
+    fn sanitize_kg_value_rejects_empty_and_whitespace_only() {
+        assert!(sanitize_kg_value("", "entity").is_err());
+        assert!(sanitize_kg_value("   ", "entity").is_err());
+    }
+
     // --- get_aaak_spec (via dispatch) ---
 
     #[tokio::test]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1750,8 +1750,10 @@ mod tests {
 
     #[tokio::test]
     async fn search_results_include_created_at() {
-        // Each search result must include a non-empty created_at field sourced
-        // from the drawer's filed_at column.
+        // Each search result must include a created_at key that maps to a JSON
+        // string. The value may be empty for legacy rows where filed_at was not
+        // recorded (SearchResult.created_at uses unwrap_or_default), so only
+        // the type is asserted here, not non-emptiness.
         with_isolated_env(|connection| async move {
             seed_drawer(
                 &connection,
@@ -1766,10 +1768,58 @@ mod tests {
             let results = result["results"].as_array().expect("results must be array");
             assert!(!results.is_empty(), "must have at least one result");
             for r in results {
+                // Assert the key is present and is a JSON string (may be empty).
+                assert!(
+                    r["created_at"].is_string(),
+                    "created_at must be a string in each result"
+                );
+            }
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn search_results_created_at_empty_for_legacy_row() {
+        // A drawer with filed_at = NULL (legacy row — filed_at was added after
+        // initial schema) must still appear in search results. created_at must
+        // be an empty string (unwrap_or_default of None), not an error.
+        with_isolated_env(|connection| async move {
+            seed_drawer(
+                &connection,
+                "tech",
+                "rust",
+                "rust programming language memory safety",
+            )
+            .await;
+
+            // Null out filed_at to simulate a row from before the column existed.
+            connection
+                .execute("UPDATE drawers SET filed_at = NULL", ())
+                .await
+                .expect("UPDATE filed_at to NULL must succeed");
+
+            let result = tool_search(&connection, &json!({"query": "rust programming"})).await;
+            assert!(
+                result.get("error").is_none(),
+                "search must not error for legacy row"
+            );
+            let results = result["results"].as_array().expect("results must be array");
+            assert!(
+                !results.is_empty(),
+                "legacy row must appear in search results"
+            );
+            for r in results {
+                assert!(
+                    r["created_at"].is_string(),
+                    "created_at must be a string even when filed_at is NULL"
+                );
                 let created_at = r["created_at"]
                     .as_str()
-                    .expect("created_at must be a string");
-                assert!(!created_at.is_empty(), "created_at must not be empty");
+                    .expect("created_at must be a JSON string");
+                assert_eq!(
+                    created_at, "",
+                    "created_at must be empty string when filed_at is NULL"
+                );
             }
         })
         .await;

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -170,6 +170,54 @@ fn sanitize_name(value: &str, field_name: &str) -> Result<String, Value> {
     Ok(result)
 }
 
+/// Validate a knowledge-graph entity value (subject or object).
+///
+/// More permissive than `sanitize_name` — allows punctuation such as commas,
+/// colons, and parentheses that are common in natural-language KG values.
+/// Rejects null bytes, path-traversal sequences (`..`, `/`, `\`), and
+/// over-length strings.
+///
+/// Note: `/` is still rejected, so namespaced IRIs (e.g. `schema:Person`) are
+/// allowed but URI paths (e.g. `http://example.org/Person`) are not. If IRI
+/// support is ever needed, introduce a dedicated validator rather than relaxing
+/// this one.
+///
+/// Not used for wing/room names (filesystem constraints) or predicates
+/// (which should be simple relationship identifiers).
+fn sanitize_kg_value(value: &str, field_name: &str) -> Result<String, Value> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(
+            json!({"success": false, "error": format!("{field_name} must be a non-empty string"), "public": true}),
+        );
+    }
+    if trimmed.len() > 128 {
+        return Err(
+            json!({"success": false, "error": format!("{field_name} exceeds maximum length of 128 characters"), "public": true}),
+        );
+    }
+    if trimmed.contains("..")
+        || trimmed.contains('/')
+        || trimmed.contains('\\')
+        || trimmed.contains('\x00')
+    {
+        return Err(
+            json!({"success": false, "error": format!("{field_name} contains invalid characters"), "public": true}),
+        );
+    }
+    let result = trimmed.to_string();
+
+    // Postconditions: result is non-empty, trimmed, and has no path-traversal chars.
+    debug_assert!(!result.is_empty());
+    debug_assert!(result == result.trim());
+    debug_assert!(!result.contains(".."));
+    debug_assert!(!result.contains('/'));
+    debug_assert!(!result.contains('\\'));
+    debug_assert!(!result.contains('\0'));
+
+    Ok(result)
+}
+
 /// Validate an optional name filter.
 ///
 /// Returns `Ok(None)` if the value is empty/whitespace-only, `Ok(Some(trimmed))`
@@ -468,6 +516,7 @@ async fn tool_search(connection: &Connection, args: &Value) -> Value {
                         "room": r.room,
                         "content": r.text,
                         "source_file": r.source_file,
+                        "created_at": r.created_at,
                         "similarity": r.relevance,
                     })
                 })
@@ -949,7 +998,7 @@ async fn tool_update_drawer(connection: &Connection, args: &Value) -> Value {
 }
 
 async fn tool_kg_query(connection: &Connection, args: &Value) -> Value {
-    let entity = match sanitize_name(str_arg(args, "entity"), "entity") {
+    let entity = match sanitize_kg_value(str_arg(args, "entity"), "entity") {
         Ok(v) => v,
         Err(e) => return e,
     };
@@ -999,7 +1048,7 @@ async fn tool_kg_add(connection: &Connection, args: &Value) -> Value {
         }
     };
 
-    let subject = match sanitize_name(subject, "subject") {
+    let subject = match sanitize_kg_value(subject, "subject") {
         Ok(v) => v,
         Err(e) => return e,
     };
@@ -1007,10 +1056,7 @@ async fn tool_kg_add(connection: &Connection, args: &Value) -> Value {
         Ok(v) => v,
         Err(e) => return e,
     };
-    // `sanitize_name` intentionally restricts objects to [a-zA-Z0-9_ .'-].
-    // If KG identifiers ever need ':', '@', or '/' (e.g. for namespaced IRIs),
-    // introduce a dedicated `sanitize_kg_object` rather than relaxing this one.
-    let object = match sanitize_name(object, "object") {
+    let object = match sanitize_kg_value(object, "object") {
         Ok(v) => v,
         Err(e) => return e,
     };
@@ -1064,7 +1110,7 @@ async fn tool_kg_invalidate(connection: &Connection, args: &Value) -> Value {
         }
     };
 
-    let subject = match sanitize_name(subject, "subject") {
+    let subject = match sanitize_kg_value(subject, "subject") {
         Ok(v) => v,
         Err(e) => return e,
     };
@@ -1072,7 +1118,7 @@ async fn tool_kg_invalidate(connection: &Connection, args: &Value) -> Value {
         Ok(v) => v,
         Err(e) => return e,
     };
-    let object = match sanitize_name(object, "object") {
+    let object = match sanitize_kg_value(object, "object") {
         Ok(v) => v,
         Err(e) => return e,
     };
@@ -1098,9 +1144,16 @@ async fn tool_kg_invalidate(connection: &Connection, args: &Value) -> Value {
 }
 
 async fn tool_kg_timeline(connection: &Connection, args: &Value) -> Value {
-    let entity = match sanitize_opt_name(str_arg(args, "entity"), "entity") {
-        Ok(v) => v,
-        Err(e) => return e,
+    let entity = {
+        let raw_entity = str_arg(args, "entity");
+        if raw_entity.is_empty() {
+            None
+        } else {
+            match sanitize_kg_value(raw_entity, "entity") {
+                Ok(v) => Some(v),
+                Err(e) => return e,
+            }
+        }
     };
 
     match kg::query::timeline(connection, entity.as_deref()).await {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1749,6 +1749,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn search_results_include_created_at() {
+        // Each search result must include a non-empty created_at field sourced
+        // from the drawer's filed_at column.
+        with_isolated_env(|connection| async move {
+            seed_drawer(
+                &connection,
+                "tech",
+                "rust",
+                "rust programming language memory safety",
+            )
+            .await;
+
+            let result = tool_search(&connection, &json!({"query": "rust programming"})).await;
+            assert!(result.get("error").is_none(), "search must not error");
+            let results = result["results"].as_array().expect("results must be array");
+            assert!(!results.is_empty(), "must have at least one result");
+            for r in results {
+                let created_at = r["created_at"]
+                    .as_str()
+                    .expect("created_at must be a string");
+                assert!(!created_at.is_empty(), "created_at must not be empty");
+            }
+        })
+        .await;
+    }
+
+    #[tokio::test]
     async fn search_with_wing_filter() {
         with_isolated_env(|connection| async move {
             seed_drawer(

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -191,7 +191,7 @@ fn sanitize_kg_value(value: &str, field_name: &str) -> Result<String, Value> {
             json!({"success": false, "error": format!("{field_name} must be a non-empty string"), "public": true}),
         );
     }
-    if trimmed.len() > 128 {
+    if trimmed.chars().count() > 128 {
         return Err(
             json!({"success": false, "error": format!("{field_name} exceeds maximum length of 128 characters"), "public": true}),
         );
@@ -1145,7 +1145,7 @@ async fn tool_kg_invalidate(connection: &Connection, args: &Value) -> Value {
 
 async fn tool_kg_timeline(connection: &Connection, args: &Value) -> Value {
     let entity = {
-        let raw_entity = str_arg(args, "entity");
+        let raw_entity = str_arg(args, "entity").trim();
         if raw_entity.is_empty() {
             None
         } else {

--- a/src/normalize/slack.rs
+++ b/src/normalize/slack.rs
@@ -4,6 +4,29 @@ use std::collections::HashMap;
 
 use super::messages_to_transcript;
 
+/// Provenance footer appended to Slack transcript output so downstream consumers
+/// know the speaker roles are positionally assigned, not verified.
+const PROVENANCE_FOOTER: &str = "\n[source: slack-export | multi-party chat \u{2014} speaker roles are positional, not verified]";
+
+/// Sanitize a Slack speaker ID for safe embedding in transcript text.
+///
+/// Replaces bracket characters and control characters (U+0000..U+001F) with `_`
+/// to prevent chunk-boundary injection via crafted exports (issue #812).
+/// Trims surrounding whitespace after substitution.
+fn slack_sanitize_user_id(raw_user_id: &str) -> String {
+    let sanitized: String = raw_user_id
+        .chars()
+        .map(|c| {
+            if c == '[' || c == ']' || (c as u32) < 0x20 {
+                '_'
+            } else {
+                c
+            }
+        })
+        .collect();
+    sanitized.trim().to_string()
+}
+
 /// Try to parse a Slack JSON message export into transcript text.
 ///
 /// Valid messages are JSON objects with `type == "message"`, non-empty `text`,
@@ -11,7 +34,10 @@ use super::messages_to_transcript;
 /// empty text, and empty user fields are silently skipped.
 ///
 /// Assigns the first user as `"user"` and alternates role assignment for
-/// subsequent users. Returns `None` if fewer than 2 valid messages.
+/// subsequent users. Each message is prefixed with the speaker ID so the
+/// original author is preserved. A provenance footer is appended to mark
+/// the transcript as a Slack import. Returns `None` if fewer than 2 valid
+/// messages.
 pub fn try_parse(data: &serde_json::Value) -> Option<String> {
     let items = data.as_array()?;
     let mut messages: Vec<(String, String)> = Vec::new();
@@ -26,12 +52,13 @@ pub fn try_parse(data: &serde_json::Value) -> Option<String> {
             continue;
         }
 
-        let user_id = obj
+        let raw_user_id = obj
             .get("user")
             .or_else(|| obj.get("username"))
             .and_then(|u| u.as_str())
-            .unwrap_or("")
-            .to_string();
+            .unwrap_or("");
+        // Sanitize speaker ID before any use — prevents bracket/control-char injection.
+        let user_id = slack_sanitize_user_id(raw_user_id);
         let text = obj
             .get("text")
             .and_then(|t| t.as_str())
@@ -57,7 +84,8 @@ pub fn try_parse(data: &serde_json::Value) -> Option<String> {
             last_role = Some(new_role.clone());
             new_role
         };
-        messages.push((role, text));
+        // Prefix with speaker ID so the original author is preserved in the transcript.
+        messages.push((role, format!("[{user_id}] {text}")));
     }
 
     if messages.len() >= 2 {
@@ -65,7 +93,7 @@ pub fn try_parse(data: &serde_json::Value) -> Option<String> {
             .iter()
             .map(|(r, t)| (r.as_str(), t.as_str()))
             .collect();
-        Some(messages_to_transcript(&refs))
+        Some(messages_to_transcript(&refs) + PROVENANCE_FOOTER)
     } else {
         None
     }
@@ -87,8 +115,9 @@ mod tests {
         )
         .expect("valid json");
         let result = try_parse(&data).expect("should parse");
-        assert!(result.contains("> hello team"));
-        assert!(result.contains("hi there"));
+        assert!(result.contains("[U1] hello team"));
+        assert!(result.contains("[U2] hi there"));
+        assert!(result.contains("slack-export"));
     }
 
     #[test]
@@ -160,5 +189,36 @@ mod tests {
         let result = try_parse(&data).expect("should parse");
         assert!(result.contains("first valid"));
         assert!(result.contains("second valid"));
+    }
+
+    #[test]
+    fn sanitizes_injection_in_user_id() {
+        // Brackets and control chars in user ID must be replaced with '_' to prevent
+        // chunk-boundary injection via crafted exports (issue #812).
+        let data: serde_json::Value = serde_json::from_str(
+            r#"[
+                {"type":"message","user":"[U1\n]","text":"injected"},
+                {"type":"message","user":"U2","text":"clean"}
+            ]"#,
+        )
+        .expect("valid json");
+        let result = try_parse(&data).expect("should parse");
+        assert!(!result.contains("[U1\n]"), "raw injection must not appear");
+        assert!(result.contains("_U1__"), "brackets/newline replaced with _");
+        assert!(result.contains("slack-export"));
+    }
+
+    #[test]
+    fn appends_provenance_footer() {
+        let data: serde_json::Value = serde_json::from_str(
+            r#"[
+                {"type":"message","user":"A","text":"hello"},
+                {"type":"message","user":"B","text":"world"}
+            ]"#,
+        )
+        .expect("valid json");
+        let result = try_parse(&data).expect("should parse");
+        assert!(result.contains("slack-export"));
+        assert!(result.contains("speaker roles are positional, not verified"));
     }
 }

--- a/src/palace/miner.rs
+++ b/src/palace/miner.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use turso::Connection;
 
-use crate::config::ProjectConfig;
+use crate::config::{ProjectConfig, RoomConfig};
 use crate::error::Result;
 use crate::palace::chunker::chunk_text;
 use crate::palace::drawer;
@@ -351,6 +351,50 @@ async fn mine_process_files(
     ))
 }
 
+/// Load project config from `project_dir`, trying `mempalace.yaml` first, then the
+/// legacy `mempal.yaml` name. If neither exists, emits a warning to stderr and
+/// synthesises a default config using the directory basename as the wing name.
+///
+/// This mirrors the Python behaviour introduced in PR #604: directories without a
+/// config file can still be mined instead of aborting with an error.
+fn mine_load_config(project_dir: &Path) -> Result<ProjectConfig> {
+    let primary = project_dir.join("mempalace.yaml");
+    if primary.exists() {
+        return ProjectConfig::load(&primary);
+    }
+    let legacy = project_dir.join("mempal.yaml");
+    if legacy.exists() {
+        return ProjectConfig::load(&legacy);
+    }
+
+    // Neither config file found — warn and fall back to auto-detected defaults so
+    // mining can proceed without requiring an explicit `mempalace init` step.
+    let wing_name = project_dir
+        .file_name()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .into_owned();
+    assert!(
+        !wing_name.is_empty(),
+        "mine_load_config: project_dir must have a basename"
+    );
+    eprintln!(
+        "  No mempalace.yaml found in {} \
+         — using auto-detected defaults (wing='{wing_name}'). \
+         Directories with the same basename will share a wing; \
+         add mempalace.yaml to disambiguate.",
+        project_dir.display()
+    );
+    Ok(ProjectConfig {
+        wing: wing_name,
+        rooms: vec![RoomConfig {
+            name: "general".to_string(),
+            description: "All project files".to_string(),
+            keywords: vec![],
+        }],
+    })
+}
+
 /// Mine a project directory into the palace.
 pub async fn mine(connection: &Connection, project_dir: &Path, opts: &MineParams) -> Result<()> {
     if !project_dir.is_dir() {
@@ -367,8 +411,7 @@ pub async fn mine(connection: &Connection, project_dir: &Path, opts: &MineParams
         ))
     })?;
 
-    let config_path = project_dir.join("mempalace.yaml");
-    let config = ProjectConfig::load(&config_path)?;
+    let config = mine_load_config(&project_dir)?;
 
     let wing = opts.wing.as_deref().unwrap_or(&config.wing);
     let mut rooms = config.rooms;

--- a/src/palace/miner.rs
+++ b/src/palace/miner.rs
@@ -381,7 +381,13 @@ fn mine_load_config(project_dir: &Path, override_wing: Option<&str>) -> Result<P
     //
     // Wing resolution order: explicit --wing override, then directory basename.
     let wing_name = if let Some(wing) = override_wing {
-        wing.to_string()
+        let trimmed = wing.trim().to_string();
+        if trimmed.is_empty() {
+            return Err(crate::error::Error::Other(
+                "--wing override must not be empty or whitespace-only".to_string(),
+            ));
+        }
+        trimmed
     } else {
         let inferred = project_dir
             .file_name()
@@ -715,6 +721,35 @@ mod tests {
             .expect("override_wing must prevent error on root path");
         assert_eq!(config.wing, "myproject");
         assert_eq!(config.rooms[0].name, "general");
+    }
+
+    #[test]
+    fn mine_load_config_override_wing_trims_whitespace() {
+        // Leading/trailing whitespace in --wing must be stripped so that
+        // `mempalace mine . --wing " myproject "` yields wing="myproject".
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+        let config = mine_load_config(dir.path(), Some("  myproject  "))
+            .expect("trimmed override must succeed");
+        assert_eq!(config.wing, "myproject");
+    }
+
+    #[test]
+    fn mine_load_config_override_wing_rejects_empty() {
+        // An empty --wing override must be an error, not a blank wing name.
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+        let result = mine_load_config(dir.path(), Some(""));
+        assert!(result.is_err(), "empty override must produce an error");
+    }
+
+    #[test]
+    fn mine_load_config_override_wing_rejects_whitespace_only() {
+        // A whitespace-only --wing override must be an error, not a blank wing name.
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+        let result = mine_load_config(dir.path(), Some("   "));
+        assert!(
+            result.is_err(),
+            "whitespace-only override must produce an error"
+        );
     }
 
     #[test]

--- a/src/palace/miner.rs
+++ b/src/palace/miner.rs
@@ -34,15 +34,22 @@ const READABLE_EXTENSIONS: &[&str] = &[
     "lua", "r", "php", "pl", "zig", "nim", "ex", "exs", "erl", "hs", "ml",
 ];
 
-const SKIP_FILES: &[&str] = &[
+/// Config filenames recognised by the miner, in load-precedence order.
+/// Single source of truth: referenced by both `mine_load_config` and `is_skip_file`.
+pub const PROJECT_CONFIG_FILES: &[&str] = &[
     "mempalace.yaml",
     "mempalace.yml",
     "mempal.yaml",
     "mempal.yml",
-    ".gitignore",
-    "package-lock.json",
-    "Cargo.lock",
 ];
+
+/// Non-config files that are always excluded from mining.
+const SKIP_FILES_EXTRA: &[&str] = &[".gitignore", "package-lock.json", "Cargo.lock"];
+
+/// Return `true` if a filename should be excluded from mining.
+fn is_skip_file(name: &str) -> bool {
+    PROJECT_CONFIG_FILES.contains(&name) || SKIP_FILES_EXTRA.contains(&name)
+}
 
 /// Scan a project directory for all readable files.
 pub fn scan_project_with_opts(project_dir: &Path, respect_gitignore: bool) -> Vec<PathBuf> {
@@ -102,7 +109,7 @@ fn walk_dir_gitignore(project_dir: &Path) -> Vec<PathBuf> {
             .unwrap_or_default()
             .to_string_lossy()
             .to_string();
-        if SKIP_FILES.contains(&name.as_str()) {
+        if is_skip_file(name.as_str()) {
             continue;
         }
 
@@ -153,7 +160,7 @@ fn walk_dir(directory: &Path, files: &mut Vec<PathBuf>) {
             } else if let Some(extension) = path.extension() {
                 let extension_lower = extension.to_string_lossy().to_lowercase();
                 if READABLE_EXTENSIONS.contains(&extension_lower.as_str())
-                    && !SKIP_FILES.contains(&name.as_str())
+                    && !is_skip_file(name.as_str())
                 {
                     if std::fs::metadata(&path).is_ok_and(|m| m.len() > MAX_FILE_SIZE) {
                         continue;
@@ -359,12 +366,7 @@ async fn mine_process_files(
 /// This mirrors the Python behaviour introduced in PR #604: directories without a
 /// config file can still be mined instead of aborting with an error.
 fn mine_load_config(project_dir: &Path) -> Result<ProjectConfig> {
-    for name in &[
-        "mempalace.yaml",
-        "mempalace.yml",
-        "mempal.yaml",
-        "mempal.yml",
-    ] {
+    for name in PROJECT_CONFIG_FILES {
         let path = project_dir.join(name);
         if path.exists() {
             return ProjectConfig::load(&path);
@@ -614,6 +616,84 @@ mod tests {
         assert!(
             !names.iter().any(|n| n == "foo.js"),
             "Files inside node_modules should be skipped"
+        );
+    }
+
+    // --- mine_load_config ---
+
+    #[test]
+    fn mine_load_config_loads_primary_yaml() {
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+        std::fs::write(
+            dir.path().join("mempalace.yaml"),
+            "wing: primary\nrooms:\n  - name: main\n    description: ''\n",
+        )
+        .expect("write mempalace.yaml should succeed");
+        let config = mine_load_config(dir.path()).expect("should load primary yaml");
+        assert_eq!(config.wing, "primary");
+        assert_eq!(config.rooms.len(), 1);
+        assert_eq!(config.rooms[0].name, "main");
+    }
+
+    #[test]
+    fn mine_load_config_precedence_yaml_over_yml() {
+        // mempalace.yaml must take precedence over mempalace.yml.
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+        std::fs::write(
+            dir.path().join("mempalace.yaml"),
+            "wing: from-yaml\nrooms:\n  - name: r\n    description: ''\n",
+        )
+        .expect("write .yaml should succeed");
+        std::fs::write(
+            dir.path().join("mempalace.yml"),
+            "wing: from-yml\nrooms:\n  - name: r\n    description: ''\n",
+        )
+        .expect("write .yml should succeed");
+        let config = mine_load_config(dir.path()).expect("should load yaml over yml");
+        assert_eq!(config.wing, "from-yaml");
+    }
+
+    #[test]
+    fn mine_load_config_falls_back_to_yml() {
+        // mempalace.yml is used when the .yaml variant is absent.
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+        std::fs::write(
+            dir.path().join("mempalace.yml"),
+            "wing: yml-wing\nrooms:\n  - name: r\n    description: ''\n",
+        )
+        .expect("write mempalace.yml should succeed");
+        let config = mine_load_config(dir.path()).expect("should load .yml");
+        assert_eq!(config.wing, "yml-wing");
+    }
+
+    #[test]
+    fn mine_load_config_synthesises_defaults_when_no_config() {
+        // No config files present — defaults use the directory basename as wing.
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+        let config = mine_load_config(dir.path()).expect("should synthesise defaults");
+        let expected_wing = dir
+            .path()
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string();
+        assert_eq!(config.wing, expected_wing);
+        assert_eq!(config.rooms.len(), 1);
+        assert_eq!(config.rooms[0].name, "general");
+    }
+
+    #[test]
+    fn mine_load_config_errors_on_empty_basename() {
+        // Mining a root-like path (no basename) must return Err, not panic.
+        // Use a path whose file_name() is None (e.g. "/").
+        let result = mine_load_config(std::path::Path::new("/"));
+        assert!(result.is_err(), "root path must produce an error");
+        let error_message = result
+            .expect_err("root path must produce an error")
+            .to_string();
+        assert!(
+            error_message.contains("basename"),
+            "error must mention basename: {error_message}"
         );
     }
 

--- a/src/palace/miner.rs
+++ b/src/palace/miner.rs
@@ -436,9 +436,18 @@ pub async fn mine(connection: &Connection, project_dir: &Path, opts: &MineParams
         ))
     })?;
 
-    let config = mine_load_config(&project_dir, opts.wing.as_deref())?;
+    // Normalize the wing override: trim whitespace and treat empty/whitespace-only
+    // values as no override, falling back to config or directory basename.
+    let normalized_wing: Option<String> = opts
+        .wing
+        .as_deref()
+        .map(str::trim)
+        .filter(|w| !w.is_empty())
+        .map(str::to_string);
 
-    let wing = opts.wing.as_deref().unwrap_or(&config.wing);
+    let config = mine_load_config(&project_dir, normalized_wing.as_deref())?;
+
+    let wing = normalized_wing.as_deref().unwrap_or(&config.wing);
     let mut rooms = config.rooms;
     if rooms.is_empty() {
         // Empty rooms list in mempalace.yaml would violate detect_room's precondition;
@@ -780,6 +789,104 @@ mod tests {
         assert!(
             !names.contains(&"image.png".to_string()),
             "Non-readable extension should be excluded"
+        );
+    }
+
+    // --- mine() wing normalization ---
+
+    const CONFIG_YAML: &str = "wing: config-wing\nrooms:\n  - name: general\n    description: ''\n";
+
+    fn mine_opts(wing: Option<&str>) -> MineParams {
+        MineParams {
+            wing: wing.map(str::to_string),
+            agent: "test".to_string(),
+            limit: 0,
+            dry_run: false,
+            respect_gitignore: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn mine_wing_override_is_trimmed() {
+        // A padded --wing value must be trimmed before drawers are stored, so
+        // `mine . --wing " padded "` yields wing="padded" in the palace.
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+        std::fs::write(dir.path().join("mempalace.yaml"), CONFIG_YAML)
+            .expect("write config should succeed");
+        std::fs::write(
+            dir.path().join("notes.txt"),
+            "rust programming language provides memory safety without a garbage collector",
+        )
+        .expect("write notes.txt should succeed");
+
+        let (_db, connection) = crate::test_helpers::test_db().await;
+        mine(&connection, dir.path(), &mine_opts(Some("  padded  ")))
+            .await
+            .expect("mine must succeed with padded wing");
+
+        let rows = crate::db::query_all(&connection, "SELECT DISTINCT wing FROM drawers", ())
+            .await
+            .expect("query must succeed");
+        assert_eq!(rows.len(), 1, "must have exactly one distinct wing");
+        let stored_wing: String = rows[0].get(0).expect("wing column must be readable");
+        assert_eq!(stored_wing, "padded", "wing must be trimmed");
+    }
+
+    #[tokio::test]
+    async fn mine_wing_whitespace_only_falls_back_to_config() {
+        // A whitespace-only --wing must be treated as no override, so the
+        // config file's wing ("config-wing") is used instead.
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+        std::fs::write(dir.path().join("mempalace.yaml"), CONFIG_YAML)
+            .expect("write config should succeed");
+        std::fs::write(
+            dir.path().join("notes.txt"),
+            "rust programming language provides memory safety without a garbage collector",
+        )
+        .expect("write notes.txt should succeed");
+
+        let (_db, connection) = crate::test_helpers::test_db().await;
+        mine(&connection, dir.path(), &mine_opts(Some("   ")))
+            .await
+            .expect("mine must succeed when whitespace wing falls back to config");
+
+        let rows = crate::db::query_all(&connection, "SELECT DISTINCT wing FROM drawers", ())
+            .await
+            .expect("query must succeed");
+        assert_eq!(rows.len(), 1, "must have exactly one distinct wing");
+        let stored_wing: String = rows[0].get(0).expect("wing column must be readable");
+        assert_eq!(
+            stored_wing, "config-wing",
+            "whitespace-only wing must fall back to config"
+        );
+    }
+
+    #[tokio::test]
+    async fn mine_wing_empty_falls_back_to_config() {
+        // An empty --wing must be treated as no override, so the config file's
+        // wing ("config-wing") is used instead.
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+        std::fs::write(dir.path().join("mempalace.yaml"), CONFIG_YAML)
+            .expect("write config should succeed");
+        std::fs::write(
+            dir.path().join("notes.txt"),
+            "rust programming language provides memory safety without a garbage collector",
+        )
+        .expect("write notes.txt should succeed");
+
+        let (_db, connection) = crate::test_helpers::test_db().await;
+        mine(&connection, dir.path(), &mine_opts(Some("")))
+            .await
+            .expect("mine must succeed when empty wing falls back to config");
+
+        let rows = crate::db::query_all(&connection, "SELECT DISTINCT wing FROM drawers", ())
+            .await
+            .expect("query must succeed");
+        assert_eq!(rows.len(), 1, "must have exactly one distinct wing");
+        let stored_wing: String = rows[0].get(0).expect("wing column must be readable");
+        assert_eq!(
+            stored_wing, "config-wing",
+            "empty wing must fall back to config"
         );
     }
 }

--- a/src/palace/miner.rs
+++ b/src/palace/miner.rs
@@ -351,20 +351,24 @@ async fn mine_process_files(
     ))
 }
 
-/// Load project config from `project_dir`, trying `mempalace.yaml` first, then the
-/// legacy `mempal.yaml` name. If neither exists, emits a warning to stderr and
-/// synthesises a default config using the directory basename as the wing name.
+/// Load project config from `project_dir`, trying config file names in precedence
+/// order: `mempalace.yaml`, `mempalace.yml`, `mempal.yaml`, `mempal.yml`. If none
+/// exist, emits a warning to stderr and synthesises a default config using the
+/// directory basename as the wing name.
 ///
 /// This mirrors the Python behaviour introduced in PR #604: directories without a
 /// config file can still be mined instead of aborting with an error.
 fn mine_load_config(project_dir: &Path) -> Result<ProjectConfig> {
-    let primary = project_dir.join("mempalace.yaml");
-    if primary.exists() {
-        return ProjectConfig::load(&primary);
-    }
-    let legacy = project_dir.join("mempal.yaml");
-    if legacy.exists() {
-        return ProjectConfig::load(&legacy);
+    for name in &[
+        "mempalace.yaml",
+        "mempalace.yml",
+        "mempal.yaml",
+        "mempal.yml",
+    ] {
+        let path = project_dir.join(name);
+        if path.exists() {
+            return ProjectConfig::load(&path);
+        }
     }
 
     // Neither config file found — warn and fall back to auto-detected defaults so
@@ -374,12 +378,15 @@ fn mine_load_config(project_dir: &Path) -> Result<ProjectConfig> {
         .unwrap_or_default()
         .to_string_lossy()
         .into_owned();
-    assert!(
-        !wing_name.is_empty(),
-        "mine_load_config: project_dir must have a basename"
-    );
+    if wing_name.is_empty() {
+        return Err(crate::error::Error::Other(format!(
+            "cannot infer wing name: {} has no basename; \
+             add mempalace.yaml with an explicit wing name",
+            project_dir.display()
+        )));
+    }
     eprintln!(
-        "  No mempalace.yaml found in {} \
+        "  No mempalace.yaml/.yml found in {} \
          — using auto-detected defaults (wing='{wing_name}'). \
          Directories with the same basename will share a wing; \
          add mempalace.yaml to disambiguate.",

--- a/src/palace/miner.rs
+++ b/src/palace/miner.rs
@@ -360,12 +360,15 @@ async fn mine_process_files(
 
 /// Load project config from `project_dir`, trying config file names in precedence
 /// order: `mempalace.yaml`, `mempalace.yml`, `mempal.yaml`, `mempal.yml`. If none
-/// exist, emits a warning to stderr and synthesises a default config using the
-/// directory basename as the wing name.
+/// exist, emits a warning to stderr and synthesises a default config.
+///
+/// `override_wing` is the wing name from `--wing` on the command line. When no
+/// config file is found and the directory has no basename (e.g. `/`), the override
+/// is used instead of failing — so `mempalace mine / --wing myproject` succeeds.
 ///
 /// This mirrors the Python behaviour introduced in PR #604: directories without a
 /// config file can still be mined instead of aborting with an error.
-fn mine_load_config(project_dir: &Path) -> Result<ProjectConfig> {
+fn mine_load_config(project_dir: &Path, override_wing: Option<&str>) -> Result<ProjectConfig> {
     for name in PROJECT_CONFIG_FILES {
         let path = project_dir.join(name);
         if path.exists() {
@@ -375,18 +378,25 @@ fn mine_load_config(project_dir: &Path) -> Result<ProjectConfig> {
 
     // Neither config file found — warn and fall back to auto-detected defaults so
     // mining can proceed without requiring an explicit `mempalace init` step.
-    let wing_name = project_dir
-        .file_name()
-        .unwrap_or_default()
-        .to_string_lossy()
-        .into_owned();
-    if wing_name.is_empty() {
-        return Err(crate::error::Error::Other(format!(
-            "cannot infer wing name: {} has no basename; \
-             add mempalace.yaml with an explicit wing name",
-            project_dir.display()
-        )));
-    }
+    //
+    // Wing resolution order: explicit --wing override, then directory basename.
+    let wing_name = if let Some(wing) = override_wing {
+        wing.to_string()
+    } else {
+        let inferred = project_dir
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .into_owned();
+        if inferred.is_empty() {
+            return Err(crate::error::Error::Other(format!(
+                "cannot infer wing name: {} has no basename; \
+                 add mempalace.yaml with an explicit wing name",
+                project_dir.display()
+            )));
+        }
+        inferred
+    };
     eprintln!(
         "  No mempalace.yaml/.yml found in {} \
          — using auto-detected defaults (wing='{wing_name}'). \
@@ -420,7 +430,7 @@ pub async fn mine(connection: &Connection, project_dir: &Path, opts: &MineParams
         ))
     })?;
 
-    let config = mine_load_config(&project_dir)?;
+    let config = mine_load_config(&project_dir, opts.wing.as_deref())?;
 
     let wing = opts.wing.as_deref().unwrap_or(&config.wing);
     let mut rooms = config.rooms;
@@ -629,7 +639,7 @@ mod tests {
             "wing: primary\nrooms:\n  - name: main\n    description: ''\n",
         )
         .expect("write mempalace.yaml should succeed");
-        let config = mine_load_config(dir.path()).expect("should load primary yaml");
+        let config = mine_load_config(dir.path(), None).expect("should load primary yaml");
         assert_eq!(config.wing, "primary");
         assert_eq!(config.rooms.len(), 1);
         assert_eq!(config.rooms[0].name, "main");
@@ -649,7 +659,7 @@ mod tests {
             "wing: from-yml\nrooms:\n  - name: r\n    description: ''\n",
         )
         .expect("write .yml should succeed");
-        let config = mine_load_config(dir.path()).expect("should load yaml over yml");
+        let config = mine_load_config(dir.path(), None).expect("should load yaml over yml");
         assert_eq!(config.wing, "from-yaml");
     }
 
@@ -662,7 +672,7 @@ mod tests {
             "wing: yml-wing\nrooms:\n  - name: r\n    description: ''\n",
         )
         .expect("write mempalace.yml should succeed");
-        let config = mine_load_config(dir.path()).expect("should load .yml");
+        let config = mine_load_config(dir.path(), None).expect("should load .yml");
         assert_eq!(config.wing, "yml-wing");
     }
 
@@ -670,7 +680,7 @@ mod tests {
     fn mine_load_config_synthesises_defaults_when_no_config() {
         // No config files present — defaults use the directory basename as wing.
         let dir = tempfile::tempdir().expect("tempdir should be created");
-        let config = mine_load_config(dir.path()).expect("should synthesise defaults");
+        let config = mine_load_config(dir.path(), None).expect("should synthesise defaults");
         let expected_wing = dir
             .path()
             .file_name()
@@ -686,7 +696,7 @@ mod tests {
     fn mine_load_config_errors_on_empty_basename() {
         // Mining a root-like path (no basename) must return Err, not panic.
         // Use a path whose file_name() is None (e.g. "/").
-        let result = mine_load_config(std::path::Path::new("/"));
+        let result = mine_load_config(std::path::Path::new("/"), None);
         assert!(result.is_err(), "root path must produce an error");
         let error_message = result
             .expect_err("root path must produce an error")
@@ -695,6 +705,16 @@ mod tests {
             error_message.contains("basename"),
             "error must mention basename: {error_message}"
         );
+    }
+
+    #[test]
+    fn mine_load_config_override_wing_succeeds_on_empty_basename() {
+        // --wing override must be used instead of the basename when the directory
+        // has no basename (e.g. "/"), so `mempalace mine / --wing myproject` succeeds.
+        let config = mine_load_config(std::path::Path::new("/"), Some("myproject"))
+            .expect("override_wing must prevent error on root path");
+        assert_eq!(config.wing, "myproject");
+        assert_eq!(config.rooms[0].name, "general");
     }
 
     #[test]

--- a/src/palace/search.rs
+++ b/src/palace/search.rs
@@ -18,6 +18,8 @@ pub struct SearchResult {
     pub source_file: String,
     /// Relevance score — sum of matched word counts.
     pub relevance: f64,
+    /// ISO-8601 timestamp when this drawer was filed; empty string if not recorded.
+    pub created_at: String,
 }
 
 /// Search the palace using the inverted index (keyword matching with relevance scoring).
@@ -55,7 +57,7 @@ pub async fn search_memories(
     }
 
     let sql = format!(
-        "SELECT d.id, d.content, d.wing, d.room, d.source_file, SUM(dw.count) as relevance \
+        "SELECT d.id, d.content, d.wing, d.room, d.source_file, SUM(dw.count) as relevance, d.filed_at \
          FROM drawers d \
          JOIN drawer_words dw ON d.id = dw.drawer_id \
          WHERE dw.word IN ({in_clause}){filters} \
@@ -90,7 +92,7 @@ pub async fn search_memories(
     Ok(results)
 }
 
-/// Map query result rows (columns: id, content, wing, room, `source_file`, relevance)
+/// Map query result rows (columns: id, content, wing, room, `source_file`, relevance, `filed_at`)
 /// into `SearchResult` values.
 fn search_memories_parse_rows(rows: &[turso::Row]) -> Vec<SearchResult> {
     let mut results = Vec::new();
@@ -121,6 +123,11 @@ fn search_memories_parse_rows(rows: &[turso::Row]) -> Vec<SearchResult> {
             .and_then(|v| v.as_integer().copied())
             .unwrap_or(0);
         let relevance = f64::from(i32::try_from(raw_relevance).unwrap_or(i32::MAX));
+        let created_at = row
+            .get_value(6)
+            .ok()
+            .and_then(|v| v.as_text().cloned())
+            .unwrap_or_default();
 
         let source_name = Path::new(&source)
             .file_name()
@@ -134,6 +141,7 @@ fn search_memories_parse_rows(rows: &[turso::Row]) -> Vec<SearchResult> {
             room,
             source_file: source_name,
             relevance,
+            created_at,
         });
     }
     results


### PR DESCRIPTION
## Summary

- **`sanitize_kg_value`**: permissive validator for KG subject/object fields; allows natural-language punctuation (commas, colons, parens) while rejecting path-traversal chars and null bytes. Predicates keep the stricter `sanitize_name`. Documents that `/` remains rejected so URI-path IRIs would need a dedicated validator.
- **Slack normalization**: sanitize speaker IDs (replace brackets and control chars with `_` to block chunk-boundary injection, issue #812); prefix each message with `[speaker_id]` to preserve authorship; append provenance footer marking the transcript as a Slack import.
- **Miner missing-yaml fallback**: warn to stderr and synthesise defaults (wing = directory basename, single general room) instead of aborting when `mempalace.yaml` is absent; also tries the legacy `mempal.yaml` name before falling back.
- **Search `created_at`**: include `filed_at` timestamp in search results returned by the MCP `mempalace_search` tool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search results now include creation timestamps.

* **Improvements**
  * Slack transcripts now prefix messages with sanitized speaker IDs and include a provenance footer.
  * Stricter validation for Knowledge Graph inputs to reject empty, unsafe, or overly long values.
  * Project loading recognizes additional legacy config filenames, falls back to sensible defaults, and applies consistent file-scan skipping.

* **Tests**
  * Added tests for input validation, Slack sanitization, transcript footer, and config fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->