### PR TITLE
Add Codecov badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ No Python, no ChromaDB, no API keys.
 
 **Drop-in replacement for [MemPalace/mempalace](https://github.com/MemPalace/mempalace) with a ~13MB binary instead of a ~100MB Python environment.**
 
+[![codecov](https://codecov.io/gh/bunkerlab-net/mempalace/graph/badge.svg)](https://codecov.io/gh/bunkerlab-net/mempalace)
+
 ---
 
 ## Why


### PR DESCRIPTION
## Summary

- Adds a Codecov badge to the top of `README.md` linking to the bunkerlab-net/mempalace coverage report

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Codecov coverage status badge to the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->