### PR TITLE
Increase test coverage from 86% to 95%

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -318,9 +318,9 @@ mod tests {
                 let path = std::path::Path::new("~/no/home");
                 let result = expand_tilde(path);
                 // With no home env vars the expansion falls back to returning path as-is.
-                assert!(
-                    !result.to_string_lossy().is_empty(),
-                    "result must not be empty"
+                assert_eq!(
+                    result, path,
+                    "expand_tilde must return the original path unchanged when HOME is unresolvable"
                 );
                 assert!(
                     !result.is_absolute(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -382,10 +382,10 @@ mod tests {
                     result.is_ok(),
                     "run_status must return Ok when palace.db does not exist"
                 );
-                // Pair assertion: no error variant must be returned.
+                // Pair assertion: the temp directory must not have gained a palace.db.
                 assert!(
-                    result.err().is_none(),
-                    "run_status must not produce any error for a missing palace"
+                    !temp_directory.path().join("palace.db").exists(),
+                    "run_status must not create a palace.db when reporting absence"
                 );
             },
         )

--- a/src/app.rs
+++ b/src/app.rs
@@ -234,3 +234,161 @@ async fn run_mine(
     }
     Ok(())
 }
+
+#[cfg(test)]
+// Test code — .expect() is acceptable with a descriptive message.
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    // -- expand_tilde ---------------------------------------------------------
+
+    #[test]
+    fn expand_tilde_no_leading_tilde_returns_path_unchanged() {
+        // A path with no leading ~ must be returned as-is.
+        let path = std::path::Path::new("/absolute/path/to/file");
+        let result = expand_tilde(path);
+        assert_eq!(result, path, "absolute path must be returned unchanged");
+        assert!(
+            !result.to_string_lossy().starts_with("~/"),
+            "result must not start with ~/"
+        );
+    }
+
+    #[test]
+    fn expand_tilde_relative_path_returned_unchanged() {
+        // A relative path that does not start with ~ must be returned as-is.
+        let path = std::path::Path::new("relative/path");
+        let result = expand_tilde(path);
+        assert_eq!(
+            result, path,
+            "relative path without ~ must be returned unchanged"
+        );
+        assert_eq!(result.to_string_lossy(), "relative/path");
+    }
+
+    #[test]
+    fn expand_tilde_tilde_only_expands_to_home() {
+        // A path of just "~" must expand to the HOME directory.
+        temp_env::with_var("HOME", Some("/test/home"), || {
+            let path = std::path::Path::new("~");
+            let result = expand_tilde(path);
+            assert_eq!(
+                result,
+                std::path::Path::new("/test/home"),
+                "bare ~ must expand to HOME"
+            );
+            assert!(
+                !result.to_string_lossy().contains('~'),
+                "result must not contain ~"
+            );
+        });
+    }
+
+    #[test]
+    fn expand_tilde_tilde_slash_path_appends_suffix() {
+        // "~/foo/bar" must expand to "<HOME>/foo/bar".
+        temp_env::with_var("HOME", Some("/test/home"), || {
+            let path = std::path::Path::new("~/foo/bar");
+            let result = expand_tilde(path);
+            assert_eq!(
+                result,
+                std::path::Path::new("/test/home/foo/bar"),
+                "~/foo/bar must expand to HOME/foo/bar"
+            );
+            assert!(
+                result.starts_with("/test/home"),
+                "result must start with HOME"
+            );
+        });
+    }
+
+    #[test]
+    fn expand_tilde_no_home_set_returns_path_unchanged() {
+        // When HOME is unset expand_tilde must return the path unchanged rather than panicking.
+        // This covers the None branch of the home directory resolution chain.
+        temp_env::with_vars(
+            [
+                ("HOME", None::<&str>),
+                ("USERPROFILE", None::<&str>),
+                ("HOMEDRIVE", None::<&str>),
+                ("HOMEPATH", None::<&str>),
+            ],
+            || {
+                let path = std::path::Path::new("~/no/home");
+                let result = expand_tilde(path);
+                // With no home env vars the expansion falls back to returning path as-is.
+                assert!(
+                    !result.to_string_lossy().is_empty(),
+                    "result must not be empty"
+                );
+                assert!(
+                    !result.is_absolute(),
+                    "result must remain a relative path when home is unresolvable"
+                );
+            },
+        );
+    }
+
+    // -- run_mine error path --------------------------------------------------
+
+    #[tokio::test]
+    async fn run_mine_unknown_mode_returns_error() {
+        // An unrecognised mode must return Err without calling open_palace.
+        // This avoids requiring a real palace DB for the error path.
+        let temp_directory =
+            tempfile::tempdir().expect("failed to create temporary directory for run_mine test");
+        let result = run_mine(
+            temp_directory.path().to_path_buf(),
+            "invalid_mode".to_string(),
+            "full".to_string(),
+            None,
+            "test_agent".to_string(),
+            0,
+            false,
+            false,
+        )
+        .await;
+        assert!(result.is_err(), "unknown mine mode must return Err");
+        assert!(
+            result
+                .err()
+                .is_some_and(|error| error.to_string().contains("invalid_mode")),
+            "error message must contain the unknown mode name"
+        );
+    }
+
+    // -- run_status without a palace ------------------------------------------
+
+    #[tokio::test]
+    async fn run_status_with_no_palace_db_returns_ok() {
+        // When the palace.db does not exist run_status must print a friendly message
+        // and return Ok without panicking.
+        let temp_directory =
+            tempfile::tempdir().expect("failed to create temporary directory for run_status test");
+        let temp_directory_path_string = temp_directory
+            .path()
+            .to_str()
+            .expect("temporary directory path must be valid UTF-8")
+            .to_string();
+        temp_env::async_with_vars(
+            [
+                ("MEMPALACE_DIR", Some(temp_directory_path_string.as_str())),
+                ("MEMPALACE_PALACE_PATH", None),
+            ],
+            async {
+                let result = run_status().await;
+                assert!(
+                    result.is_ok(),
+                    "run_status must return Ok when palace.db does not exist"
+                );
+                // Pair assertion: no error variant must be returned.
+                assert!(
+                    result.err().is_none(),
+                    "run_status must not produce any error for a missing palace"
+                );
+            },
+        )
+        .await;
+    }
+}

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -63,3 +63,65 @@ pub fn run(directory: &Path, yes: bool, no_gitignore: bool) -> Result<()> {
 
     Ok(())
 }
+
+#[cfg(test)]
+// Test code — .expect() is acceptable with a descriptive message.
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn init_run_creates_mempalace_yaml_in_directory() {
+        // init::run with yes=true must write a mempalace.yaml to the target directory.
+        let temp_directory =
+            tempfile::tempdir().expect("failed to create temporary directory for init test");
+        run(temp_directory.path(), true, false)
+            .expect("init::run should succeed for a valid directory with yes=true");
+
+        let config_path = temp_directory.path().join("mempalace.yaml");
+        assert!(config_path.exists(), "mempalace.yaml must be created");
+        // Pair assertion: the file must contain valid YAML with a wing key.
+        let contents = std::fs::read_to_string(&config_path)
+            .expect("mempalace.yaml must be readable after init");
+        assert!(
+            contents.contains("wing:"),
+            "config must contain a wing field"
+        );
+        assert!(!contents.is_empty(), "config file must not be empty");
+    }
+
+    #[test]
+    fn init_run_nonexistent_directory_returns_error() {
+        // Passing a path that does not exist must return Err.
+        let path = std::path::Path::new("/nonexistent/path/that/does/not/exist");
+        let result = run(path, true, false);
+        assert!(result.is_err(), "nonexistent directory must return Err");
+        assert!(
+            result
+                .err()
+                .is_some_and(|error| !error.to_string().is_empty()),
+            "error message must not be empty"
+        );
+    }
+
+    #[test]
+    fn init_run_no_gitignore_flag_counts_files() {
+        // no_gitignore=true must still produce a valid config (just without .gitignore filtering).
+        let temp_directory = tempfile::tempdir()
+            .expect("failed to create temporary directory for no-gitignore init test");
+        std::fs::write(temp_directory.path().join("test.rs"), "fn main() {}")
+            .expect("failed to write test source file");
+
+        run(temp_directory.path(), true, true)
+            .expect("init::run should succeed with no_gitignore=true");
+
+        let config_path = temp_directory.path().join("mempalace.yaml");
+        assert!(
+            config_path.exists(),
+            "mempalace.yaml must be created with no_gitignore=true"
+        );
+        let contents = std::fs::read_to_string(&config_path)
+            .expect("mempalace.yaml must be readable after init with no_gitignore");
+        assert!(contents.contains("wing:"), "config must contain wing field");
+    }
+}

--- a/src/cli/repair.rs
+++ b/src/cli/repair.rs
@@ -86,3 +86,96 @@ pub async fn run(connection: &Connection, palace_path: &Path) -> Result<()> {
 
     Ok(())
 }
+
+#[cfg(test)]
+// Test code — .expect() is acceptable with a descriptive message.
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    /// Open a file-backed turso database at `path`, apply the schema, and return
+    /// `(Database, Connection)`.  `repair::run` requires a real filesystem path because
+    /// it calls `std::fs::copy`; an in-memory database cannot be used here.
+    async fn open_file_db(path: &std::path::Path) -> (turso::Database, turso::Connection) {
+        let database = turso::Builder::new_local(
+            path.to_str()
+                .expect("file-backed database path must be valid UTF-8"),
+        )
+        .experimental_triggers(true)
+        .build()
+        .await
+        .expect("failed to create file-backed turso database");
+        let connection = database
+            .connect()
+            .expect("failed to connect to file-backed database");
+        crate::schema::ensure_schema(&connection)
+            .await
+            .expect("failed to apply schema to file-backed database");
+        (database, connection)
+    }
+
+    #[tokio::test]
+    async fn repair_creates_backup_and_rebuilds_index() {
+        // repair::run must create a .db.bak backup and re-index all drawers.
+        let temp_directory = tempfile::tempdir()
+            .expect("failed to create temporary directory for repair backup test");
+        let database_path = temp_directory.path().join("palace.db");
+        let (_database, connection) = open_file_db(&database_path).await;
+
+        // Add a drawer so there is at least one entry to re-index.
+        crate::palace::drawer::add_drawer(
+            &connection,
+            &crate::palace::drawer::DrawerParams {
+                id: "drawer_repair_test_001",
+                wing: "test_wing",
+                room: "general",
+                content: "content to index during repair test",
+                source_file: "test.txt",
+                chunk_index: 0,
+                added_by: "test_agent",
+                ingest_mode: "repair_test",
+                source_mtime: None,
+            },
+        )
+        .await
+        .expect("failed to add drawer for repair test setup");
+
+        run(&connection, &database_path)
+            .await
+            .expect("repair::run should succeed after adding a test drawer");
+
+        // Backup file must exist after repair.
+        let backup_path = database_path.with_extension("db.bak");
+        assert!(
+            backup_path.exists(),
+            "repair must create a .db.bak backup file"
+        );
+        assert!(
+            database_path.exists(),
+            "original palace.db must still exist after repair"
+        );
+    }
+
+    #[tokio::test]
+    async fn repair_with_no_drawers_succeeds() {
+        // repair::run must succeed even when the palace has no drawers to re-index.
+        let temp_directory = tempfile::tempdir()
+            .expect("failed to create temporary directory for empty-palace repair test");
+        let database_path = temp_directory.path().join("empty_palace.db");
+        let (_database, connection) = open_file_db(&database_path).await;
+
+        run(&connection, &database_path)
+            .await
+            .expect("repair::run should succeed on a palace with zero drawers");
+
+        let backup_path = database_path.with_extension("db.bak");
+        assert!(
+            backup_path.exists(),
+            "backup must be created even for empty palace"
+        );
+        assert!(
+            database_path.exists(),
+            "original database file must remain after repair"
+        );
+    }
+}

--- a/src/cli/split.rs
+++ b/src/cli/split.rs
@@ -577,6 +577,242 @@ mod tests {
         );
     }
 
+    // --- split_file ---
+
+    /// Build a test file containing `n_sessions` Claude Code session blocks, each with
+    /// at least 12 content lines so the 10-line minimum is satisfied.
+    fn make_mega_file(n_sessions: usize) -> String {
+        let mut lines = Vec::new();
+        for i in 0..n_sessions {
+            lines.push(format!("╭──── Claude Code v1.{i}.0"));
+            // Twelve body lines — safely above the 10-line minimum in split_file.
+            for j in 0..12 {
+                lines.push(format!("Content line {j} for session {i} here."));
+            }
+            lines.push(format!("> User prompt for session {i} to create subject."));
+            lines.push(format!("Assistant answer for session {i} is here now."));
+        }
+        lines.join("\n")
+    }
+
+    #[test]
+    fn split_file_dry_run_returns_session_count() {
+        // split_file in dry-run mode must count sessions without writing any output files.
+        // The dry-run path is the same split logic but skips fs::write and fs::rename.
+        let temp_directory =
+            tempfile::tempdir().expect("failed to create temporary directory for dry-run test");
+        let mega_file_path = temp_directory.path().join("mega.txt");
+        fs::write(&mega_file_path, make_mega_file(3))
+            .expect("failed to write three-session mega file");
+        let output_directory =
+            tempfile::tempdir().expect("failed to create temporary output directory");
+
+        let written = split_file(&mega_file_path, output_directory.path(), true)
+            .expect("split_file dry run should succeed for a valid file");
+
+        assert_eq!(written, 3, "dry run must report three sessions written");
+        // Nothing must be written — output directory stays empty.
+        let output_count = fs::read_dir(output_directory.path())
+            .expect("failed to read output directory after dry run")
+            .count();
+        assert_eq!(
+            output_count, 0,
+            "dry run must not write any session files to disk"
+        );
+    }
+
+    #[test]
+    fn split_file_writes_sessions_and_renames_original() {
+        // split_file must write per-session files and rename the original to .mega_backup.
+        let temp_directory =
+            tempfile::tempdir().expect("failed to create temporary directory for write test");
+        let mega_file_path = temp_directory.path().join("mega.txt");
+        fs::write(&mega_file_path, make_mega_file(2))
+            .expect("failed to write two-session mega file");
+        let output_directory =
+            tempfile::tempdir().expect("failed to create temporary output directory");
+
+        let written = split_file(&mega_file_path, output_directory.path(), false)
+            .expect("split_file should succeed for a valid two-session file");
+
+        assert_eq!(written, 2, "must report two sessions written");
+        // Original must be renamed to .mega_backup — a rename signals successful completion.
+        assert!(
+            !mega_file_path.exists(),
+            "original file must be renamed away after split"
+        );
+        assert!(
+            mega_file_path.with_extension("mega_backup").exists(),
+            "backup file must exist at original path with .mega_backup extension"
+        );
+        // Two session files must be in the output directory.
+        let output_count = fs::read_dir(output_directory.path())
+            .expect("failed to read output directory after split")
+            .count();
+        assert_eq!(
+            output_count, 2,
+            "two session files must be written to the output directory"
+        );
+    }
+
+    #[test]
+    fn split_file_fewer_than_two_sessions_returns_zero() {
+        // A file with only one session boundary must return 0 — nothing to split.
+        let temp_directory = tempfile::tempdir()
+            .expect("failed to create temporary directory for single-session test");
+        let single_session_path = temp_directory.path().join("single.txt");
+        fs::write(&single_session_path, make_mega_file(1))
+            .expect("failed to write single-session test file");
+        let output_directory =
+            tempfile::tempdir().expect("failed to create temporary output directory");
+
+        let written = split_file(&single_session_path, output_directory.path(), false)
+            .expect("split_file should return Ok even when there is only one session");
+
+        assert_eq!(
+            written, 0,
+            "single session must return 0 — nothing to split"
+        );
+        // Original must not be renamed when no split occurred.
+        assert!(
+            single_session_path.exists(),
+            "original file must remain untouched when split produces zero sessions"
+        );
+    }
+
+    #[test]
+    fn split_file_not_a_file_returns_error() {
+        // Passing a directory path as the file argument must return Err.
+        let temp_directory =
+            tempfile::tempdir().expect("failed to create temporary directory for error test");
+        let output_directory =
+            tempfile::tempdir().expect("failed to create temporary output directory");
+        let result = split_file(temp_directory.path(), output_directory.path(), false);
+        assert!(
+            result.is_err(),
+            "directory path as file argument must return Err"
+        );
+        assert!(
+            result
+                .err()
+                .is_some_and(|error| error.to_string().contains("not an existing file")),
+            "error must mention 'not an existing file'"
+        );
+    }
+
+    // --- run ---
+
+    #[test]
+    fn run_min_sessions_below_two_returns_error() {
+        // min_sessions=1 must be rejected immediately — callers must require at least two.
+        let temp_directory = tempfile::tempdir()
+            .expect("failed to create temporary directory for min_sessions test");
+        let result = run(temp_directory.path(), None, false, 1, false);
+        assert!(result.is_err(), "min_sessions < 2 must return Err");
+        assert!(
+            result
+                .err()
+                .is_some_and(|error| error.to_string().contains("min_sessions")),
+            "error message must mention min_sessions"
+        );
+    }
+
+    #[test]
+    fn run_nonexistent_directory_returns_error() {
+        // A path that does not point to an existing directory must return Err.
+        let result = run(
+            std::path::Path::new("/nonexistent/path/that/does/not/exist"),
+            None,
+            false,
+            2,
+            false,
+        );
+        assert!(result.is_err(), "nonexistent directory must return Err");
+        assert!(
+            result
+                .err()
+                .is_some_and(|error| !error.to_string().is_empty()),
+            "error message must not be empty"
+        );
+    }
+
+    #[test]
+    fn run_no_mega_files_returns_ok() {
+        // A directory with no .txt files meeting min_sessions must return Ok with no output.
+        let temp_directory = tempfile::tempdir()
+            .expect("failed to create temporary directory for no-mega-files test");
+        // One .txt file but only one session — does not meet min_sessions=2.
+        fs::write(temp_directory.path().join("single.txt"), make_mega_file(1))
+            .expect("failed to write single-session test file");
+
+        let result = run(temp_directory.path(), None, false, 2, false);
+        assert!(
+            result.is_ok(),
+            "directory with no qualifying mega-files must return Ok"
+        );
+    }
+
+    #[test]
+    fn run_dry_run_with_mega_file_does_not_write() {
+        // run in dry-run mode must not write any output files or rename the original.
+        let temp_directory =
+            tempfile::tempdir().expect("failed to create temporary directory for run dry-run test");
+        let mega_file_path = temp_directory.path().join("mega.txt");
+        fs::write(&mega_file_path, make_mega_file(3))
+            .expect("failed to write three-session mega file");
+        let output_directory =
+            tempfile::tempdir().expect("failed to create temporary output directory for dry run");
+
+        run(
+            temp_directory.path(),
+            Some(output_directory.path()),
+            true,
+            2,
+            false,
+        )
+        .expect("run dry run should succeed without writing files");
+
+        // Original must still exist; output directory must be empty.
+        assert!(
+            mega_file_path.exists(),
+            "dry run must not rename original mega file"
+        );
+        let output_count = fs::read_dir(output_directory.path())
+            .expect("failed to read output directory after dry run")
+            .count();
+        assert_eq!(
+            output_count, 0,
+            "dry run must not write any session files to the output directory"
+        );
+    }
+
+    #[test]
+    fn run_invalid_output_dir_returns_error() {
+        // An explicit output directory path that does not exist must return Err.
+        let temp_directory = tempfile::tempdir()
+            .expect("failed to create temporary directory for invalid output test");
+        fs::write(temp_directory.path().join("mega.txt"), make_mega_file(3))
+            .expect("failed to write three-session mega file");
+
+        let result = run(
+            temp_directory.path(),
+            Some(std::path::Path::new("/nonexistent/output/directory")),
+            false,
+            2,
+            false,
+        );
+        assert!(
+            result.is_err(),
+            "nonexistent output directory must return Err"
+        );
+        assert!(
+            result
+                .err()
+                .is_some_and(|error| error.to_string().contains("output directory")),
+            "error message must mention 'output directory'"
+        );
+    }
+
     #[test]
     fn split_collect_txt_files_respect_gitignore_filters_and_caps_depth() {
         // Verify that when respect_gitignore=true, .gitignore-excluded files are

--- a/src/config.rs
+++ b/src/config.rs
@@ -679,6 +679,310 @@ mod tests {
     }
 
     #[test]
+    fn load_returns_default_when_no_config_file() {
+        // MempalaceConfig::load() must return defaults when no config.json exists.
+        let temp_directory = tempfile::tempdir()
+            .expect("failed to create temporary directory for load-default test");
+        temp_env::with_vars(
+            [
+                (
+                    "MEMPALACE_DIR",
+                    Some(
+                        temp_directory
+                            .path()
+                            .to_str()
+                            .expect("temporary directory path must be valid UTF-8"),
+                    ),
+                ),
+                (
+                    "HOME",
+                    Some(
+                        temp_directory
+                            .path()
+                            .to_str()
+                            .expect("temporary directory path must be valid UTF-8"),
+                    ),
+                ),
+            ],
+            || {
+                let config = MempalaceConfig::load().expect(
+                    "MempalaceConfig::load should return defaults when config.json is absent",
+                );
+                assert!(
+                    !config.palace_path.as_os_str().is_empty(),
+                    "palace_path must not be empty"
+                );
+                assert_eq!(config.collection_name, "mempalace_drawers");
+            },
+        );
+    }
+
+    #[test]
+    fn load_reads_existing_config_file() {
+        // MempalaceConfig::load() must parse an existing config.json.
+        let temp_directory = tempfile::tempdir()
+            .expect("failed to create temporary directory for load-existing test");
+        let config_json =
+            r#"{"palace_path":"/custom/palace.db","collection_name":"custom","people_map":{}}"#;
+        std::fs::write(temp_directory.path().join("config.json"), config_json)
+            .expect("failed to write test config.json");
+
+        temp_env::with_vars(
+            [
+                (
+                    "MEMPALACE_DIR",
+                    Some(
+                        temp_directory
+                            .path()
+                            .to_str()
+                            .expect("temporary directory path must be valid UTF-8"),
+                    ),
+                ),
+                (
+                    "HOME",
+                    Some(
+                        temp_directory
+                            .path()
+                            .to_str()
+                            .expect("temporary directory path must be valid UTF-8"),
+                    ),
+                ),
+            ],
+            || {
+                let config = MempalaceConfig::load()
+                    .expect("MempalaceConfig::load should succeed when config.json exists");
+                assert_eq!(config.collection_name, "custom");
+                assert_eq!(
+                    config.palace_path,
+                    std::path::PathBuf::from("/custom/palace.db")
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn init_creates_config_file_when_none_exists() {
+        // MempalaceConfig::init() must create config.json when the directory is fresh.
+        let temp_directory = tempfile::tempdir()
+            .expect("failed to create temporary directory for init-creates test");
+        temp_env::with_vars(
+            [
+                (
+                    "MEMPALACE_DIR",
+                    Some(
+                        temp_directory
+                            .path()
+                            .to_str()
+                            .expect("temporary directory path must be valid UTF-8"),
+                    ),
+                ),
+                (
+                    "HOME",
+                    Some(
+                        temp_directory
+                            .path()
+                            .to_str()
+                            .expect("temporary directory path must be valid UTF-8"),
+                    ),
+                ),
+            ],
+            || {
+                let config = MempalaceConfig::init()
+                    .expect("MempalaceConfig::init should succeed on a fresh directory");
+                // config.json must have been written.
+                assert!(
+                    temp_directory.path().join("config.json").exists(),
+                    "init must create config.json"
+                );
+                assert!(
+                    !config.palace_path.as_os_str().is_empty(),
+                    "palace_path must not be empty after init"
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn init_reads_existing_config_when_present() {
+        // MempalaceConfig::init() must read an existing config.json rather than overwriting it.
+        let temp_directory = tempfile::tempdir()
+            .expect("failed to create temporary directory for init-reads-existing test");
+        let config_json =
+            r#"{"palace_path":"/existing/palace.db","collection_name":"existing","people_map":{}}"#;
+        std::fs::write(temp_directory.path().join("config.json"), config_json)
+            .expect("failed to write existing config.json for init test");
+
+        temp_env::with_vars(
+            [
+                (
+                    "MEMPALACE_DIR",
+                    Some(
+                        temp_directory
+                            .path()
+                            .to_str()
+                            .expect("temporary directory path must be valid UTF-8"),
+                    ),
+                ),
+                (
+                    "HOME",
+                    Some(
+                        temp_directory
+                            .path()
+                            .to_str()
+                            .expect("temporary directory path must be valid UTF-8"),
+                    ),
+                ),
+            ],
+            || {
+                let config = MempalaceConfig::init()
+                    .expect("MempalaceConfig::init should read existing config.json without error");
+                assert_eq!(
+                    config.collection_name, "existing",
+                    "init must return existing config values"
+                );
+                assert_eq!(
+                    config.palace_path,
+                    std::path::PathBuf::from("/existing/palace.db")
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn palace_db_path_env_var_overrides_config() {
+        // MEMPALACE_PALACE_PATH must take priority over the config value.
+        let config = MempalaceConfig {
+            palace_path: std::path::PathBuf::from("/config/palace.db"),
+            collection_name: "mempalace_drawers".to_string(),
+            people_map: std::collections::HashMap::new(),
+        };
+        temp_env::with_var("MEMPALACE_PALACE_PATH", Some("/env/override.db"), || {
+            let path = config.palace_db_path();
+            assert_eq!(
+                path,
+                std::path::PathBuf::from("/env/override.db"),
+                "env var must override config palace_path"
+            );
+            assert!(
+                !path.to_string_lossy().contains("config"),
+                "result must not contain the config path"
+            );
+        });
+    }
+
+    #[test]
+    fn project_config_load_wrong_extension_returns_error() {
+        // ProjectConfig::load() must reject files that are not .yaml or .yml.
+        let temp_directory = tempfile::tempdir()
+            .expect("failed to create temporary directory for wrong-extension test");
+        let json_path = temp_directory.path().join("config.json");
+        std::fs::write(&json_path, "wing: test\nrooms: []")
+            .expect("failed to write test file with wrong extension");
+        let result = ProjectConfig::load(&json_path);
+        assert!(result.is_err(), "non-yaml extension must return Err");
+        assert!(
+            result.err().is_some_and(
+                |error| error.to_string().contains("yaml") || error.to_string().contains("yml")
+            ),
+            "error must mention the expected extension"
+        );
+    }
+
+    #[test]
+    fn project_config_load_nonexistent_file_returns_error() {
+        // ProjectConfig::load() must return Err when the file does not exist.
+        let path = std::path::Path::new("/nonexistent/path/mempalace.yaml");
+        let result = ProjectConfig::load(path);
+        assert!(result.is_err(), "nonexistent file must return Err");
+        assert!(
+            result.err().is_some(),
+            "error must be present for nonexistent file"
+        );
+    }
+
+    #[test]
+    fn maybe_migrate_moves_wal_directory() {
+        // maybe_migrate_inner must move a "wal" subdirectory to the destination.
+        let home_directory = tempfile::tempdir()
+            .expect("failed to create temporary home directory for WAL migration test");
+        let legacy_directory = home_directory.path().join(".mempalace");
+        let wal_source_directory = legacy_directory.join("wal");
+        std::fs::create_dir_all(&wal_source_directory)
+            .expect("failed to create legacy wal directory");
+        std::fs::write(wal_source_directory.join("frame.bin"), b"wal data")
+            .expect("failed to write wal frame file");
+        // config.json acts as the completion marker — move it last.
+        std::fs::write(
+            legacy_directory.join("config.json"),
+            r#"{"palace_path":"/old/palace.db","collection_name":"mempalace_drawers","people_map":{}}"#,
+        )
+        .expect("failed to write config.json for WAL migration test");
+
+        temp_env::with_vars(
+            [
+                (
+                    "HOME",
+                    Some(
+                        home_directory
+                            .path()
+                            .to_str()
+                            .expect("home directory path must be valid UTF-8"),
+                    ),
+                ),
+                ("MEMPALACE_DIR", None),
+                ("XDG_DATA_HOME", None),
+            ],
+            || {
+                maybe_migrate()
+                    .expect("migration should succeed for legacy directory with wal subdirectory");
+                let destination = home_directory
+                    .path()
+                    .join(".local")
+                    .join("share")
+                    .join("mempalace");
+                // wal directory must have been moved to the destination.
+                assert!(
+                    destination.join("wal").exists(),
+                    "wal directory must exist at destination after migration"
+                );
+                assert!(
+                    destination.join("wal").join("frame.bin").exists(),
+                    "wal frame must be present in migrated wal directory"
+                );
+                assert!(
+                    destination.join("config.json").exists(),
+                    "config.json must exist as completion marker"
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn maybe_migrate_patch_config_corrupted_json_is_noop() {
+        // maybe_migrate_patch_config must silently ignore a corrupted config.json.
+        let temp_directory = tempfile::tempdir()
+            .expect("failed to create temporary directory for corrupted-config test");
+        let config_path = temp_directory.path().join("config.json");
+        std::fs::write(&config_path, "not valid json {{{{")
+            .expect("failed to write corrupted config.json for test");
+        let legacy_db = std::path::Path::new("/old/palace.db");
+        let new_db = std::path::Path::new("/new/palace.db");
+
+        let result = maybe_migrate_patch_config(&config_path, legacy_db, new_db);
+
+        // Corrupted JSON must be left unchanged (Ok returned, not Err).
+        assert!(
+            result.is_ok(),
+            "corrupted config.json must not cause migration error"
+        );
+        let content = std::fs::read_to_string(&config_path).expect("config must still be readable");
+        assert_eq!(
+            content, "not valid json {{{{",
+            "corrupted config.json must be left unchanged"
+        );
+    }
+
+    #[test]
     fn project_config_yaml_round_trip() {
         let yaml = r"
 wing: my_project

--- a/src/dialect/emotions.rs
+++ b/src/dialect/emotions.rs
@@ -116,3 +116,61 @@ pub fn flag_signals() -> &'static [(&'static str, &'static str)] {
         ("config", "TECHNICAL"),
     ]
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn emotion_codes_is_non_empty_and_has_known_entries() {
+        // emotion_codes() must return a non-empty map with expected long-form keys.
+        let codes = emotion_codes();
+        assert!(!codes.is_empty(), "emotion_codes must not be empty");
+        // Positive space: specific well-known entries must be present.
+        assert_eq!(codes.get("joy"), Some(&"joy"), "joy must map to 'joy'");
+        assert_eq!(
+            codes.get("vulnerability"),
+            Some(&"vul"),
+            "vulnerability must map to 'vul'"
+        );
+        assert_eq!(codes.get("rage"), Some(&"rage"), "rage must map to 'rage'");
+        // Negative space: the short codes themselves are not keys.
+        assert!(
+            !codes.contains_key("vul"),
+            "short code 'vul' must not be a key"
+        );
+    }
+
+    #[test]
+    fn emotion_signals_is_non_empty_with_expected_mappings() {
+        // emotion_signals() must return a non-empty slice with key signal pairs.
+        let signals = emotion_signals();
+        assert!(!signals.is_empty(), "emotion_signals must not be empty");
+        // At least one well-known keyword must be present.
+        assert!(
+            signals.iter().any(|(kw, _)| *kw == "love"),
+            "emotion_signals must include 'love' keyword"
+        );
+        assert!(
+            signals.iter().any(|(_, code)| *code == "joy"),
+            "emotion_signals must include a signal mapping to 'joy'"
+        );
+    }
+
+    #[test]
+    fn flag_signals_is_non_empty_and_has_decision_entries() {
+        // flag_signals() must return a non-empty slice including DECISION flags.
+        let flags = flag_signals();
+        assert!(!flags.is_empty(), "flag_signals must not be empty");
+        // Positive space: DECISION and TECHNICAL categories must be present.
+        let has_decision = flags.iter().any(|(_, flag)| *flag == "DECISION");
+        let has_technical = flags.iter().any(|(_, flag)| *flag == "TECHNICAL");
+        assert!(has_decision, "flag_signals must include DECISION flags");
+        assert!(has_technical, "flag_signals must include TECHNICAL flags");
+        // Negative space: no empty keywords.
+        assert!(
+            flags.iter().all(|(kw, _)| !kw.is_empty()),
+            "all flag signal keywords must be non-empty"
+        );
+    }
+}

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -378,7 +378,6 @@ mod tests {
             result.is_empty(),
             "text with only short fragments must produce empty key sentence"
         );
-        assert_eq!(result.len(), 0, "empty key sentence must have zero length");
     }
 
     #[test]

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -334,4 +334,59 @@ mod tests {
         assert!(found.contains(&"ALC".to_string()));
         assert!(found.contains(&"BOB".to_string()));
     }
+
+    #[test]
+    fn detect_emotions_caps_at_three() {
+        // detect_emotions must break after collecting 3 distinct emotion codes.
+        // This exercises the `detected.len() >= 3` early-exit branch.
+        let text = "I love this, I'm excited, but worried and frustrated about the deadline";
+        let emotions = detect_emotions(text);
+        assert!(emotions.len() <= 3, "emotion count must be capped at 3");
+        assert!(
+            !emotions.is_empty(),
+            "text with emotion keywords must produce at least one"
+        );
+    }
+
+    #[test]
+    fn detect_flags_caps_at_three() {
+        // detect_flags must break after collecting 3 distinct flag codes.
+        // This exercises the `detected.len() >= 3` early-exit branch.
+        let text =
+            "We decided to switch the api because the server architecture was launched wrong";
+        let flags = detect_flags(text);
+        assert!(flags.len() <= 3, "flag count must be capped at 3");
+        assert!(
+            !flags.is_empty(),
+            "text with flag keywords must produce at least one"
+        );
+    }
+
+    #[test]
+    fn extract_key_sentence_empty_on_short_text() {
+        // Text with no sentences longer than 10 chars must return an empty string.
+        // This exercises the `sentences.is_empty()` early return.
+        let result = extract_key_sentence("hi. ok.");
+        assert!(
+            result.is_empty(),
+            "text with only short fragments must produce empty key sentence"
+        );
+        assert_eq!(result.len(), 0, "empty key sentence must have zero length");
+    }
+
+    #[test]
+    fn extract_key_sentence_truncates_long_sentence() {
+        // A key sentence longer than 55 characters must be truncated with "...".
+        // This exercises the `best.len() > 55` truncation branch.
+        let long_text = "We decided to completely restructure the entire backend architecture because the legacy system was causing too many production failures and nobody understood the codebase anymore";
+        let result = extract_key_sentence(long_text);
+        assert!(
+            result.ends_with("..."),
+            "long key sentence must be truncated with ellipsis"
+        );
+        assert!(
+            result.len() <= 60,
+            "truncated key sentence must not exceed ~55 chars plus ellipsis"
+        );
+    }
 }

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -339,9 +339,15 @@ mod tests {
     fn detect_emotions_caps_at_three() {
         // detect_emotions must break after collecting 3 distinct emotion codes.
         // This exercises the `detected.len() >= 3` early-exit branch.
+        // Input has 4+ distinct emotion keywords: love→love, excited→excite,
+        // worried→anx, frustrated→frust — only the first 3 unique codes kept.
         let text = "I love this, I'm excited, but worried and frustrated about the deadline";
         let emotions = detect_emotions(text);
-        assert!(emotions.len() <= 3, "emotion count must be capped at 3");
+        assert_eq!(
+            emotions.len(),
+            3,
+            "emotion count must saturate at exactly 3"
+        );
         assert!(
             !emotions.is_empty(),
             "text with emotion keywords must produce at least one"
@@ -352,10 +358,11 @@ mod tests {
     fn detect_flags_caps_at_three() {
         // detect_flags must break after collecting 3 distinct flag codes.
         // This exercises the `detected.len() >= 3` early-exit branch.
-        let text =
-            "We decided to switch the api because the server architecture was launched wrong";
+        // Input has 4+ distinct flag codes: decided→DECISION, first time→ORIGIN,
+        // core→CORE, api→TECHNICAL — only the first 3 unique codes kept.
+        let text = "We decided for the first time that the core api needs a rewrite";
         let flags = detect_flags(text);
-        assert!(flags.len() <= 3, "flag count must be capped at 3");
+        assert_eq!(flags.len(), 3, "flag count must saturate at exactly 3");
         assert!(
             !flags.is_empty(),
             "text with flag keywords must produce at least one"

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -448,4 +448,216 @@ mod tests {
         assert!(!memories.is_empty());
         assert_eq!(memories[0].kind, "emotional");
     }
+
+    #[test]
+    fn test_extract_preference() {
+        // Preference markers like "I prefer" and "always use" must classify as preference.
+        let text = "I prefer snake_case for all variable names. I always use functional style over imperative when possible.";
+        let memories = extract_memories(text, 0.1);
+        assert!(
+            !memories.is_empty(),
+            "preference text must produce at least one memory"
+        );
+        assert_eq!(
+            memories[0].kind, "preference",
+            "text with preference markers must classify as preference"
+        );
+    }
+
+    #[test]
+    fn test_extract_unresolved_problem() {
+        // A problem description without resolution words must stay classified as "problem".
+        let text = "The bug is causing the database connection to crash repeatedly. The system keeps failing under load and we need to investigate further.";
+        let memories = extract_memories(text, 0.1);
+        assert!(
+            !memories.is_empty(),
+            "problem text must produce at least one memory"
+        );
+        assert_eq!(
+            memories[0].kind, "problem",
+            "unresolved problem text must classify as problem, not milestone"
+        );
+    }
+
+    #[test]
+    fn test_short_segments_are_skipped() {
+        // Segments shorter than 20 characters must be skipped entirely.
+        let text = "Too short.";
+        let memories = extract_memories(text, 0.0);
+        assert!(
+            memories.is_empty(),
+            "segments under 20 characters must be skipped"
+        );
+        // Verify the threshold boundary: exactly 20 chars or just under.
+        let text_19 = "1234567890123456789";
+        assert_eq!(text_19.trim().len(), 19);
+        let memories_19 = extract_memories(text_19, 0.0);
+        assert!(
+            memories_19.is_empty(),
+            "19-character segment must be skipped"
+        );
+    }
+
+    #[test]
+    fn test_extract_prose_all_code_falls_back_to_full_text() {
+        // When all lines are code (matching code patterns), extract_prose falls
+        // back to returning the original text so scoring can still proceed.
+        let code_only = "```\nlet x = 1;\nlet y = 2;\n```";
+        let result = extract_prose(code_only);
+        // All lines are either code fences or inside a code block, so prose is
+        // empty and the function falls back to the original text.
+        assert!(
+            !result.is_empty(),
+            "extract_prose must return original text when no prose lines found"
+        );
+        assert!(
+            result.contains("let x = 1"),
+            "fallback must contain original code content"
+        );
+    }
+
+    #[test]
+    fn test_large_single_block_is_chunked() {
+        // A single paragraph (no blank lines) exceeding 20 lines must be split
+        // into chunks of 25 lines by the line-group fallback in split_into_segments.
+        let lines: Vec<String> = (0..30)
+            .map(|i| format!("Line number {i} with some padding text to make it longer"))
+            .collect();
+        let text = lines.join("\n");
+        let segments = split_into_segments(&text);
+        // 30 lines with no blank line separators and no turn markers: should chunk.
+        assert!(
+            segments.len() >= 2,
+            "30-line single block must be split into at least 2 chunks"
+        );
+        // Each chunk must be non-empty.
+        assert!(
+            segments.iter().all(|segment| !segment.trim().is_empty()),
+            "all chunks must be non-empty"
+        );
+    }
+
+    #[test]
+    fn test_disambiguate_problem_positive_milestone() {
+        // A problem with positive sentiment and milestone score must be reclassified
+        // as milestone (not emotional). This exercises the positive-sentiment branch
+        // in disambiguate where milestone score is present.
+        let text = "The bug was terrible but it finally works now and I'm so proud we built this breakthrough achievement.";
+        let memories = extract_memories(text, 0.1);
+        assert!(
+            !memories.is_empty(),
+            "text must produce at least one memory"
+        );
+        // The text has problem markers ("bug"), positive sentiment ("proud",
+        // "breakthrough"), and milestone markers ("finally", "works", "built",
+        // "breakthrough"). Resolution word "works" triggers has_resolution,
+        // and positive + emotional → "emotional" or resolution → "milestone".
+        let kind = &memories[0].kind;
+        assert!(
+            kind == "milestone" || kind == "emotional",
+            "resolved problem with positive sentiment must be milestone or emotional, got: {kind}"
+        );
+    }
+
+    #[test]
+    fn test_high_confidence_threshold_filters_low_scores() {
+        // A very high min_confidence (1.0) should filter out memories that don't
+        // have extremely high marker scores relative to the 5.0 divisor.
+        let text =
+            "We decided to use a new approach for the architecture because of the trade-off.";
+        let memories_low = extract_memories(text, 0.1);
+        let memories_high = extract_memories(text, 1.0);
+        // With low threshold, the decision markers should produce a memory.
+        assert!(
+            !memories_low.is_empty(),
+            "low threshold must produce memories from decision text"
+        );
+        // With maximum threshold (1.0), most text is filtered out since
+        // confidence = (score / 5.0).min(1.0) requires score >= 5.0.
+        assert!(
+            memories_high.len() <= memories_low.len(),
+            "high threshold must produce fewer or equal memories than low threshold"
+        );
+    }
+
+    #[test]
+    fn test_chunk_index_sequential() {
+        // Extracted memories must have sequential chunk_index values starting at 0.
+        let text = "> What do you prefer?\nI prefer tabs over spaces always.\n\n> Any milestones?\nWe finally shipped version 2.0 and deployed it successfully.";
+        let memories = extract_memories(text, 0.1);
+        // Verify sequential indexing for however many memories are extracted.
+        for (index, memory) in memories.iter().enumerate() {
+            assert_eq!(
+                memory.chunk_index, index,
+                "chunk_index must be sequential; expected {index}, got {}",
+                memory.chunk_index
+            );
+        }
+        // Postcondition: all memories have non-empty content and kind.
+        assert!(
+            memories.iter().all(|memory| !memory.content.is_empty()),
+            "all memories must have non-empty content"
+        );
+        assert!(
+            memories.iter().all(|memory| !memory.kind.is_empty()),
+            "all memories must have non-empty kind"
+        );
+    }
+
+    #[test]
+    fn test_score_markers_returns_zero_for_no_matches() {
+        // Text with no matching markers must produce a score of 0.0.
+        let text = "the quick brown fox jumps over the lazy dog";
+        let score = score_markers(text, DECISION_REGEXES.as_slice());
+        assert!(
+            (score - 0.0).abs() < f64::EPSILON,
+            "non-matching text must score 0.0"
+        );
+        // Also verify against emotion markers for cross-type coverage.
+        let emotion_score = score_markers(text, EMOTION_REGEXES.as_slice());
+        assert!(
+            (emotion_score - 0.0).abs() < f64::EPSILON,
+            "non-matching text must score 0.0 for emotion markers"
+        );
+    }
+
+    #[test]
+    fn test_disambiguate_non_problem_passes_through() {
+        // Non-problem types must pass through disambiguate unchanged regardless
+        // of sentiment or resolution words.
+        let scores: std::collections::HashMap<&str, f64> =
+            [("decision", 3.0), ("milestone", 1.0)].into();
+        let result = disambiguate("decision", "we fixed the breakthrough", &scores);
+        assert_eq!(
+            result, "decision",
+            "non-problem type must not be reclassified"
+        );
+        // Also verify emotional passes through unchanged.
+        let result_emotional = disambiguate("emotional", "we fixed it", &scores);
+        assert_eq!(
+            result_emotional, "emotional",
+            "emotional type must not be reclassified by disambiguate"
+        );
+    }
+
+    #[test]
+    fn test_has_resolution_patterns() {
+        // Additional resolution patterns must be detected correctly.
+        assert!(
+            has_resolution("I patched the config file"),
+            "'patched' must be detected as resolution"
+        );
+        assert!(
+            has_resolution("We got it working after three tries"),
+            "'got it working' must be detected as resolution"
+        );
+        assert!(
+            has_resolution("She nailed it on the first attempt"),
+            "'nailed it' must be detected as resolution"
+        );
+        assert!(
+            has_resolution("The answer was to restart the service"),
+            "'the answer' must be detected as resolution"
+        );
+    }
 }

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -496,6 +496,19 @@ mod tests {
             memories_19.is_empty(),
             "19-character segment must be skipped"
         );
+        // Boundary case: exactly 20 characters must NOT be skipped by the length
+        // filter. Uses "let's use" which matches the decision regex pattern.
+        let text_20 = "Let's use this tool.";
+        assert_eq!(
+            text_20.trim().len(),
+            20,
+            "test string must be exactly 20 chars"
+        );
+        let memories_20 = extract_memories(text_20, 0.0);
+        assert!(
+            !memories_20.is_empty(),
+            "20-character segment with keywords must not be skipped by the length filter"
+        );
     }
 
     #[test]
@@ -539,23 +552,22 @@ mod tests {
 
     #[test]
     fn test_disambiguate_problem_positive_milestone() {
-        // A problem with positive sentiment and milestone score must be reclassified
-        // as milestone (not emotional). This exercises the positive-sentiment branch
-        // in disambiguate where milestone score is present.
-        let text = "The bug was terrible but it finally works now and I'm so proud we built this breakthrough achievement.";
+        // A problem with resolution markers but no emotional markers must be
+        // reclassified as "milestone". The `disambiguate` function checks
+        // `has_resolution` first; when emotional score is 0 it returns "milestone".
+        // Avoid emotional keywords (proud, love, joy) to stay off the emotional branch.
+        let text = "The bug was terrible but the issue was finally fixed and it works after the long struggle.";
         let memories = extract_memories(text, 0.1);
         assert!(
             !memories.is_empty(),
             "text must produce at least one memory"
         );
-        // The text has problem markers ("bug"), positive sentiment ("proud",
-        // "breakthrough"), and milestone markers ("finally", "works", "built",
-        // "breakthrough"). Resolution word "works" triggers has_resolution,
-        // and positive + emotional → "emotional" or resolution → "milestone".
+        // "works" and "fixed" trigger has_resolution; no emotional keywords means
+        // the emotional score is 0, so disambiguate returns "milestone".
         let kind = &memories[0].kind;
-        assert!(
-            kind == "milestone" || kind == "emotional",
-            "resolved problem with positive sentiment must be milestone or emotional, got: {kind}"
+        assert_eq!(
+            kind, "milestone",
+            "resolved problem without emotional cues must be reclassified as milestone, got: {kind}"
         );
     }
 

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -597,6 +597,11 @@ mod tests {
         // Extracted memories must have sequential chunk_index values starting at 0.
         let text = "> What do you prefer?\nI prefer tabs over spaces always.\n\n> Any milestones?\nWe finally shipped version 2.0 and deployed it successfully.";
         let memories = extract_memories(text, 0.1);
+        // Guard: at least one memory must be produced for the loop to be meaningful.
+        assert!(
+            !memories.is_empty(),
+            "text with preference and milestone markers must produce at least one memory"
+        );
         // Verify sequential indexing for however many memories are extracted.
         for (index, memory) in memories.iter().enumerate() {
             assert_eq!(

--- a/src/kg/mod.rs
+++ b/src/kg/mod.rs
@@ -94,6 +94,29 @@ mod tests {
     }
 
     #[test]
+    fn add_triple_validate_params_rejects_confidence_greater_than_one() {
+        // Confidence above 1.0 is outside the valid [0.0, 1.0] range.
+        let params = TripleParams {
+            subject: "Alice",
+            predicate: "knows",
+            object: "Bob",
+            valid_from: None,
+            valid_to: None,
+            confidence: 1.1,
+            source_closet: None,
+            source_file: None,
+        };
+        let result = add_triple_validate_params(&params);
+        assert!(result.is_err(), "confidence > 1.0 must be rejected");
+        assert!(
+            result
+                .err()
+                .is_some_and(|error| error.to_string().contains("confidence")),
+            "error message must mention confidence"
+        );
+    }
+
+    #[test]
     fn add_triple_validate_params_rejects_invalid_date_format() {
         // A non-ISO date in valid_from must be rejected with a clear error.
         let params = TripleParams {

--- a/src/kg/mod.rs
+++ b/src/kg/mod.rs
@@ -46,6 +46,124 @@ mod tests {
     fn entity_id_empty_string() {
         assert_eq!(entity_id(""), "");
     }
+
+    #[test]
+    fn add_triple_validate_params_rejects_nan_confidence() {
+        // NaN confidence must be rejected — it would corrupt sort comparisons downstream.
+        let params = TripleParams {
+            subject: "Alice",
+            predicate: "knows",
+            object: "Bob",
+            valid_from: None,
+            valid_to: None,
+            confidence: f64::NAN,
+            source_closet: None,
+            source_file: None,
+        };
+        let result = add_triple_validate_params(&params);
+        assert!(result.is_err(), "NaN confidence must be rejected");
+        assert!(
+            result
+                .err()
+                .is_some_and(|error| error.to_string().contains("confidence")),
+            "error message must mention confidence"
+        );
+    }
+
+    #[test]
+    fn add_triple_validate_params_rejects_negative_confidence() {
+        // Negative confidence is outside the valid [0.0, 1.0] range.
+        let params = TripleParams {
+            subject: "Alice",
+            predicate: "knows",
+            object: "Bob",
+            valid_from: None,
+            valid_to: None,
+            confidence: -0.1,
+            source_closet: None,
+            source_file: None,
+        };
+        let result = add_triple_validate_params(&params);
+        assert!(result.is_err(), "negative confidence must be rejected");
+        assert!(
+            result
+                .err()
+                .is_some_and(|error| error.to_string().contains("confidence")),
+            "error message must mention confidence"
+        );
+    }
+
+    #[test]
+    fn add_triple_validate_params_rejects_invalid_date_format() {
+        // A non-ISO date in valid_from must be rejected with a clear error.
+        let params = TripleParams {
+            subject: "Alice",
+            predicate: "knows",
+            object: "Bob",
+            valid_from: Some("not-a-date"),
+            valid_to: None,
+            confidence: 0.5,
+            source_closet: None,
+            source_file: None,
+        };
+        let result = add_triple_validate_params(&params);
+        assert!(result.is_err(), "invalid date format must be rejected");
+        assert!(
+            result
+                .err()
+                .is_some_and(|error| error.to_string().contains("valid_from")),
+            "error message must mention valid_from"
+        );
+    }
+
+    #[test]
+    fn add_triple_validate_params_rejects_from_after_to() {
+        // valid_from after valid_to is logically impossible and must be rejected.
+        let params = TripleParams {
+            subject: "Alice",
+            predicate: "knows",
+            object: "Bob",
+            valid_from: Some("2025-06-01"),
+            valid_to: Some("2025-01-01"),
+            confidence: 0.8,
+            source_closet: None,
+            source_file: None,
+        };
+        let result = add_triple_validate_params(&params);
+        assert!(
+            result.is_err(),
+            "valid_from after valid_to must be rejected"
+        );
+        assert!(
+            result
+                .err()
+                .is_some_and(|error| error.to_string().contains("must not be after")),
+            "error message must explain the temporal ordering constraint"
+        );
+    }
+
+    #[test]
+    fn add_triple_validate_params_rejects_invalid_valid_to_date() {
+        // A non-ISO date in valid_to must also be rejected.
+        let params = TripleParams {
+            subject: "Alice",
+            predicate: "knows",
+            object: "Bob",
+            valid_from: None,
+            valid_to: Some("garbage"),
+            confidence: 0.5,
+            source_closet: None,
+            source_file: None,
+        };
+        let result = add_triple_validate_params(&params);
+        assert!(result.is_err(), "invalid valid_to date must be rejected");
+        assert!(
+            result
+                .err()
+                .is_some_and(|error| error.to_string().contains("valid_to")),
+            "error message must mention valid_to"
+        );
+    }
 }
 
 #[cfg(test)]
@@ -53,6 +171,24 @@ mod tests {
 #[allow(clippy::expect_used)]
 mod async_tests {
     use super::*;
+
+    #[tokio::test]
+    async fn add_entity_rejects_all_apostrophe_name() {
+        // A name consisting entirely of apostrophes normalizes to an empty entity id.
+        // add_entity must reject this with an Err rather than inserting a blank key.
+        let (_db, connection) = crate::test_helpers::test_db().await;
+        let result = add_entity(&connection, "'''", "person", None).await;
+        assert!(
+            result.is_err(),
+            "all-apostrophe name must produce an empty entity id and be rejected"
+        );
+        assert!(
+            result
+                .err()
+                .is_some_and(|error| error.to_string().contains("empty")),
+            "error message must mention empty entity id"
+        );
+    }
 
     #[tokio::test]
     async fn add_entity_inserts_and_returns_id() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@
     clippy::must_use_candidate
 )]
 
+pub mod app;
+pub mod cli;
 pub mod config;
 pub mod db;
 pub mod dialect;

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -690,4 +690,123 @@ mod tests {
         // Buffer should have 'hello' without the \r.
         assert_eq!(buf.len(), 5, "buffer should be 5 bytes after \\r strip");
     }
+
+    #[tokio::test]
+    async fn read_line_eof_with_partial_line_no_newline() {
+        // A stream that ends without a trailing newline must return the accumulated bytes as a line.
+        let cursor = Cursor::new(b"no newline at end".to_vec());
+        let mut reader = BufReader::new(cursor);
+        let mut buf = Vec::new();
+        let result = run_read_line_impl(&mut reader, &mut buf, 1024)
+            .await
+            .expect("read should succeed");
+        let LineRead::Line(line) = result else {
+            panic!("expected LineRead::Line for partial line at EOF");
+        };
+        assert_eq!(
+            line, "no newline at end",
+            "partial line at EOF must be returned"
+        );
+        assert_eq!(buf.len(), 17, "buffer must contain all bytes");
+    }
+
+    #[tokio::test]
+    async fn read_line_overflow_no_newline_drains_to_eof() {
+        // An oversized line with no trailing newline must drain to EOF and still report Overflow.
+        let limit = 5;
+        let input = "a".repeat(limit + 10); // No newline — entire input is one oversized line.
+        let cursor = Cursor::new(input.into_bytes());
+        let mut reader = BufReader::new(cursor);
+        let mut buf = Vec::new();
+        let result = run_read_line_impl(&mut reader, &mut buf, limit)
+            .await
+            .expect("read should succeed");
+        assert!(
+            matches!(result, LineRead::Overflow),
+            "oversized line without newline must report Overflow"
+        );
+        // After drain the stream is at EOF; next read must return Eof.
+        buf.clear();
+        let next = run_read_line_impl(&mut reader, &mut buf, limit)
+            .await
+            .expect("second read should succeed");
+        assert!(
+            matches!(next, LineRead::Eof),
+            "after overflow drain to EOF the next read must return Eof"
+        );
+    }
+
+    // -- handle_request_tools_call edge cases --------------------------------
+
+    #[tokio::test]
+    async fn handle_request_tools_call_non_object_params_returns_error() {
+        // When 'params' is not a JSON object (e.g. a string), tools/call must
+        // return Invalid Params (-32602) rather than panicking.
+        let (_db, connection) = crate::test_helpers::test_db().await;
+        let request = json!({
+            "method": "tools/call",
+            "params": "not_an_object",
+            "id": 8
+        });
+        let response = handle_request(&connection, &request)
+            .await
+            .expect("handle_request should return Some for tools/call with non-object params");
+        assert_eq!(response["error"]["code"], -32602);
+        assert!(
+            response["error"]["message"]
+                .as_str()
+                .expect("error message must be a string")
+                .contains("params"),
+            "error must mention invalid params"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_request_tools_call_null_arguments_succeeds() {
+        // null arguments must be treated as an empty object — the call must succeed.
+        let (_db, connection) = crate::test_helpers::test_db().await;
+        let request = json!({
+            "method": "tools/call",
+            "params": {"name": "mempalace_status", "arguments": null},
+            "id": 9
+        });
+        let response = handle_request(&connection, &request)
+            .await
+            .expect("handle_request should return Some for tools/call with null arguments");
+        // Must produce a result, not an error.
+        let content = response["result"]["content"]
+            .as_array()
+            .expect("result content must be a JSON array");
+        assert!(
+            !content.is_empty(),
+            "null arguments must produce a valid tool result"
+        );
+        assert_eq!(content[0]["type"], "text", "content type must be 'text'");
+    }
+
+    #[tokio::test]
+    async fn handle_request_tools_call_unknown_tool_returns_internal_error() {
+        // Calling an unknown tool name must return a sanitized error (not expose internals).
+        let (_db, connection) = crate::test_helpers::test_db().await;
+        let request = json!({
+            "method": "tools/call",
+            "params": {"name": "nonexistent_tool", "arguments": {}},
+            "id": 10
+        });
+        let response = handle_request(&connection, &request)
+            .await
+            .expect("handle_request should return Some for unknown tool name");
+        // The result content must contain an error field.
+        let content = response["result"]["content"]
+            .as_array()
+            .expect("result content must be a JSON array");
+        assert!(
+            !content.is_empty(),
+            "unknown tool must return content with error"
+        );
+        let text = content[0]["text"]
+            .as_str()
+            .expect("text field must be a string");
+        assert!(!text.is_empty(), "error text must not be empty");
+    }
 }

--- a/src/normalize/claude_ai.rs
+++ b/src/normalize/claude_ai.rs
@@ -154,6 +154,12 @@ fn extract_content(value: &serde_json::Value) -> String {
 mod tests {
     use super::*;
 
+    /// Parse a JSON string literal into a `serde_json::Value`.
+    /// Reduces boilerplate across tests that build JSON fixtures inline.
+    fn json(source: &str) -> serde_json::Value {
+        serde_json::from_str(source).expect("test JSON fixture must be valid JSON")
+    }
+
     #[test]
     fn parse_array_format() {
         let data: serde_json::Value = serde_json::from_str(
@@ -271,10 +277,9 @@ mod tests {
     fn extract_content_array_with_plain_strings() {
         // Content arrays can contain plain strings (not wrapped in {type: "text"}).
         // This exercises the `item.as_str()` branch inside extract_content.
-        let data: serde_json::Value = serde_json::from_str(
+        let data = json(
             r#"[{"role":"user","content":["plain string one","plain string two"]},{"role":"assistant","content":"reply"}]"#,
-        )
-        .expect("failed to parse JSON fixture for plain string content array test");
+        );
         let result = try_parse(&data).expect("must parse content array with plain strings");
         assert!(
             result.contains("plain string one"),
@@ -292,10 +297,8 @@ mod tests {
         // returns an empty string. The message is skipped if the text fallback is also absent.
         // With only one valid message (the assistant), try_parse returns None because the
         // minimum threshold is 2 messages.
-        let data: serde_json::Value = serde_json::from_str(
-            r#"[{"role":"user","content":42},{"role":"assistant","content":"only valid"}]"#,
-        )
-        .expect("failed to parse JSON fixture for non-string content test");
+        let data =
+            json(r#"[{"role":"user","content":42},{"role":"assistant","content":"only valid"}]"#);
         // User message has numeric content (empty after extraction), only assistant
         // is valid — fewer than 2 messages means None.
         let result = try_parse(&data);
@@ -309,10 +312,7 @@ mod tests {
     fn privacy_export_drops_short_conversations() {
         // A privacy export conversation with fewer than 2 messages must be silently
         // dropped. If all conversations are too short, try_parse returns None.
-        let data: serde_json::Value = serde_json::from_str(
-            r#"[{"chat_messages":[{"role":"user","content":"solo question"}]}]"#,
-        )
-        .expect("failed to parse JSON fixture for short conversation test");
+        let data = json(r#"[{"chat_messages":[{"role":"user","content":"solo question"}]}]"#);
         let result = try_parse(&data);
         assert!(
             result.is_none(),
@@ -324,13 +324,12 @@ mod tests {
     fn privacy_export_mixed_short_and_full_conversations() {
         // A privacy export with one short conversation (dropped) and one full
         // conversation (kept) must return only the full conversation's transcript.
-        let data: serde_json::Value = serde_json::from_str(
+        let data = json(
             r#"[
-                {"chat_messages":[{"role":"user","content":"orphan question"}]},
-                {"chat_messages":[{"role":"user","content":"full question"},{"role":"assistant","content":"full answer"}]}
-            ]"#,
-        )
-        .expect("failed to parse JSON fixture for mixed conversation test");
+            {"chat_messages":[{"role":"user","content":"orphan question"}]},
+            {"chat_messages":[{"role":"user","content":"full question"},{"role":"assistant","content":"full answer"}]}
+        ]"#,
+        );
         let result = try_parse(&data).expect("must parse when at least one conversation is valid");
         // The short conversation's content must not appear.
         assert!(
@@ -350,10 +349,9 @@ mod tests {
     #[test]
     fn messages_with_empty_text_are_skipped() {
         // Messages where both content and text fallback are empty must be skipped.
-        let data: serde_json::Value = serde_json::from_str(
+        let data = json(
             r#"[{"role":"user","content":""},{"role":"assistant","content":""},{"role":"user","content":"actual question"},{"role":"assistant","content":"actual answer"}]"#,
-        )
-        .expect("failed to parse JSON fixture for empty text test");
+        );
         let result = try_parse(&data).expect("must parse when enough non-empty messages exist");
         assert!(
             result.contains("> actual question"),
@@ -369,10 +367,9 @@ mod tests {
     fn non_object_items_in_array_are_skipped() {
         // Non-object items (strings, numbers, nulls) in the message array must be
         // silently skipped without breaking parsing.
-        let data: serde_json::Value = serde_json::from_str(
+        let data = json(
             r#"["not an object", null, 42, {"role":"user","content":"real user"}, {"role":"assistant","content":"real assistant"}]"#,
-        )
-        .expect("failed to parse JSON fixture for non-object items test");
+        );
         let result = try_parse(&data).expect("must parse despite non-object items in array");
         assert!(
             result.contains("> real user"),
@@ -388,10 +385,8 @@ mod tests {
     fn returns_none_for_non_object_non_array_data() {
         // When the top-level JSON value is neither an object nor an array (e.g. a
         // string or number), try_parse must return None.
-        let data_string: serde_json::Value = serde_json::from_str(r#""just a string""#)
-            .expect("failed to parse JSON string fixture");
-        let data_number: serde_json::Value =
-            serde_json::from_str("42").expect("failed to parse JSON number fixture");
+        let data_string = json(r#""just a string""#);
+        let data_number = json("42");
         assert!(
             try_parse(&data_string).is_none(),
             "string value must return None"

--- a/src/normalize/claude_ai.rs
+++ b/src/normalize/claude_ai.rs
@@ -266,4 +266,173 @@ mod tests {
         assert!(result.contains("> hi"), "user turn");
         assert!(result.contains("hello"), "assistant turn");
     }
+
+    #[test]
+    fn extract_content_array_with_plain_strings() {
+        // Content arrays can contain plain strings (not wrapped in {type: "text"}).
+        // This exercises the `item.as_str()` branch inside extract_content.
+        let data: serde_json::Value = serde_json::from_str(
+            r#"[{"role":"user","content":["plain string one","plain string two"]},{"role":"assistant","content":"reply"}]"#,
+        )
+        .expect("failed to parse JSON fixture for plain string content array test");
+        let result = try_parse(&data).expect("must parse content array with plain strings");
+        assert!(
+            result.contains("plain string one"),
+            "first plain string must appear in transcript"
+        );
+        assert!(
+            result.contains("plain string two"),
+            "second plain string must appear in transcript"
+        );
+    }
+
+    #[test]
+    fn extract_content_non_string_non_array_returns_empty() {
+        // When "content" is a number or boolean (neither string nor array), extract_content
+        // returns an empty string. The message is skipped if the text fallback is also absent.
+        // With only one valid message (the assistant), try_parse returns None because the
+        // minimum threshold is 2 messages.
+        let data: serde_json::Value = serde_json::from_str(
+            r#"[{"role":"user","content":42},{"role":"assistant","content":"only valid"}]"#,
+        )
+        .expect("failed to parse JSON fixture for non-string content test");
+        // User message has numeric content (empty after extraction), only assistant
+        // is valid — fewer than 2 messages means None.
+        let result = try_parse(&data);
+        assert!(
+            result.is_none(),
+            "must return None when numeric content produces fewer than 2 messages"
+        );
+    }
+
+    #[test]
+    fn privacy_export_drops_short_conversations() {
+        // A privacy export conversation with fewer than 2 messages must be silently
+        // dropped. If all conversations are too short, try_parse returns None.
+        let data: serde_json::Value = serde_json::from_str(
+            r#"[{"chat_messages":[{"role":"user","content":"solo question"}]}]"#,
+        )
+        .expect("failed to parse JSON fixture for short conversation test");
+        let result = try_parse(&data);
+        assert!(
+            result.is_none(),
+            "single-message conversation must be dropped"
+        );
+    }
+
+    #[test]
+    fn privacy_export_mixed_short_and_full_conversations() {
+        // A privacy export with one short conversation (dropped) and one full
+        // conversation (kept) must return only the full conversation's transcript.
+        let data: serde_json::Value = serde_json::from_str(
+            r#"[
+                {"chat_messages":[{"role":"user","content":"orphan question"}]},
+                {"chat_messages":[{"role":"user","content":"full question"},{"role":"assistant","content":"full answer"}]}
+            ]"#,
+        )
+        .expect("failed to parse JSON fixture for mixed conversation test");
+        let result = try_parse(&data).expect("must parse when at least one conversation is valid");
+        // The short conversation's content must not appear.
+        assert!(
+            !result.contains("orphan question"),
+            "short conversation must be dropped from output"
+        );
+        assert!(
+            result.contains("> full question"),
+            "full conversation user turn must appear"
+        );
+        assert!(
+            result.contains("full answer"),
+            "full conversation assistant turn must appear"
+        );
+    }
+
+    #[test]
+    fn messages_with_empty_text_are_skipped() {
+        // Messages where both content and text fallback are empty must be skipped.
+        let data: serde_json::Value = serde_json::from_str(
+            r#"[{"role":"user","content":""},{"role":"assistant","content":""},{"role":"user","content":"actual question"},{"role":"assistant","content":"actual answer"}]"#,
+        )
+        .expect("failed to parse JSON fixture for empty text test");
+        let result = try_parse(&data).expect("must parse when enough non-empty messages exist");
+        assert!(
+            result.contains("> actual question"),
+            "non-empty user message must appear"
+        );
+        assert!(
+            result.contains("actual answer"),
+            "non-empty assistant message must appear"
+        );
+    }
+
+    #[test]
+    fn non_object_items_in_array_are_skipped() {
+        // Non-object items (strings, numbers, nulls) in the message array must be
+        // silently skipped without breaking parsing.
+        let data: serde_json::Value = serde_json::from_str(
+            r#"["not an object", null, 42, {"role":"user","content":"real user"}, {"role":"assistant","content":"real assistant"}]"#,
+        )
+        .expect("failed to parse JSON fixture for non-object items test");
+        let result = try_parse(&data).expect("must parse despite non-object items in array");
+        assert!(
+            result.contains("> real user"),
+            "valid user message must survive non-object neighbors"
+        );
+        assert!(
+            result.contains("real assistant"),
+            "valid assistant message must survive non-object neighbors"
+        );
+    }
+
+    #[test]
+    fn returns_none_for_non_object_non_array_data() {
+        // When the top-level JSON value is neither an object nor an array (e.g. a
+        // string or number), try_parse must return None.
+        let data_string: serde_json::Value = serde_json::from_str(r#""just a string""#)
+            .expect("failed to parse JSON string fixture");
+        let data_number: serde_json::Value =
+            serde_json::from_str("42").expect("failed to parse JSON number fixture");
+        assert!(
+            try_parse(&data_string).is_none(),
+            "string value must return None"
+        );
+        assert!(
+            try_parse(&data_number).is_none(),
+            "number value must return None"
+        );
+    }
+
+    #[test]
+    fn object_with_chat_messages_key() {
+        // An object with "chat_messages" key (not just "messages") must be parsed.
+        // This exercises the obj.get("chat_messages") fallback in the object branch.
+        let data: serde_json::Value = serde_json::from_str(
+            r#"{"chat_messages":[{"role":"user","content":"chat_msg question"},{"role":"assistant","content":"chat_msg answer"}]}"#,
+        )
+        .expect("failed to parse JSON fixture for chat_messages object test");
+        let result = try_parse(&data).expect("must parse object with chat_messages key");
+        assert!(
+            result.contains("> chat_msg question"),
+            "user turn from chat_messages key must appear"
+        );
+        assert!(
+            result.contains("chat_msg answer"),
+            "assistant turn from chat_messages key must appear"
+        );
+    }
+
+    #[test]
+    fn unknown_role_messages_are_skipped() {
+        // Messages with roles other than user/human/assistant/ai must be skipped.
+        // If only unknown-role messages remain, try_parse returns None.
+        let data: serde_json::Value = serde_json::from_str(
+            r#"[{"role":"system","content":"system prompt"},{"role":"tool","content":"tool output"}]"#,
+        )
+        .expect("failed to parse JSON fixture for unknown role test");
+        let result = try_parse(&data);
+        assert!(
+            result.is_none(),
+            "messages with unknown roles must be skipped, producing None when no valid messages remain"
+        );
+    }
 }

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -238,6 +238,12 @@ mod tests {
                 r#"{"weather": "sunny", "temperature": 72, "units": "fahrenheit"}"#,
                 "weather",
             ),
+            // (non-.json extension — triggers content-sniffing via `content.starts_with('{')`)
+            (
+                "config.txt",
+                r#"{"sniffed_key": "detected by content start", "value": true}"#,
+                "sniffed_key",
+            ),
         ];
         for &(filename, json_content, expected_key) in cases {
             let filepath = temp_directory.path().join(filename);
@@ -258,13 +264,19 @@ mod tests {
 
     #[test]
     fn normalize_two_quote_lines_do_not_short_circuit() {
-        // Fewer than 3 lines starting with > must not short-circuit; JSON parsing is attempted.
+        // Fewer than 3 lines starting with > must not short-circuit to the
+        // transcript passthrough; format detection runs but finds no match,
+        // so the raw content is returned unchanged (after trim).
         let temp_dir = tempfile::tempdir().expect("create temp dir");
         let path = temp_dir.path().join("two_quotes.txt");
-        // Only two > lines — below the threshold of 3 — so format detection runs.
-        std::fs::write(&path, "> first line\n> second line\nplain text here")
-            .expect("write two-quote file");
+        let content = "> first line\n> second line\nplain text here";
+        std::fs::write(&path, content).expect("write two-quote file");
         let result = normalize(&path).expect("two-quote file must return Ok");
+        assert_eq!(
+            result.trim(),
+            content.trim(),
+            "content with only two > lines must be returned unchanged"
+        );
         assert!(!result.is_empty(), "result must not be empty");
     }
 

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -172,8 +172,11 @@ mod tests {
     #[test]
     fn normalize_file_not_found_returns_error() {
         // normalize must return Err when the file does not exist.
-        let path = std::path::Path::new("/nonexistent/path/no_such_file.txt");
-        let result = normalize(path);
+        // Use a temp directory to produce a deterministic nonexistent path.
+        let temp_directory =
+            tempfile::tempdir().expect("failed to create temporary directory for not-found test");
+        let nonexistent_path = temp_directory.path().join("no_such_file.txt");
+        let result = normalize(&nonexistent_path);
         assert!(result.is_err(), "missing file must return Err");
         assert!(
             result
@@ -205,28 +208,52 @@ mod tests {
         let content = "This is just plain text content.\nNo JSON, no > markers here at all.\n";
         std::fs::write(&path, content).expect("write plain text file");
         let result = normalize(&path).expect("plain text must return Ok");
-        assert!(!result.is_empty(), "plain text result must not be empty");
-        assert!(
-            result.contains("plain text"),
-            "plain text content must be preserved"
+        // Exact equality after trim: normalize trims whitespace but must not alter content.
+        assert_eq!(
+            result.trim(),
+            content.trim(),
+            "normalized plain text must exactly equal the original trimmed content"
         );
+        assert!(!result.is_empty(), "plain text result must not be empty");
     }
 
     #[test]
-    fn normalize_json_with_no_known_format_returns_content() {
-        // JSON that doesn't match any known format must be returned as-is.
-        let temp_dir = tempfile::tempdir().expect("create temp dir");
-        let path = temp_dir.path().join("unknown.json");
-        // Valid JSON but not Claude AI, ChatGPT, Slack, or Codex format.
-        std::fs::write(&path, r#"{"unknown_key": "value", "data": [1, 2, 3]}"#)
-            .expect("write unknown json");
-        let result = normalize(&path).expect("unknown JSON must return Ok");
-        assert!(!result.is_empty(), "result must not be empty");
-        // The raw JSON content must be returned since no format matched.
-        assert!(
-            result.contains("unknown_key") || result.contains("data"),
-            "original JSON content must be returned when no format matches"
-        );
+    fn normalize_unrecognized_json_returns_raw_content() {
+        // Valid JSON that does not match any known chat format (Claude Code, Codex,
+        // Claude AI, ChatGPT, Slack) must fall through and return the raw content.
+        // Table-driven: each case uses a different JSON shape and file extension to
+        // exercise distinct code paths (.json extension vs content-sniffing).
+        let temp_directory = tempfile::tempdir()
+            .expect("failed to create temporary directory for unrecognized-JSON test");
+        let cases: &[(&str, &str, &str)] = &[
+            // (.json extension — triggers extension-based JSON path)
+            (
+                "unknown.json",
+                r#"{"unknown_key": "value", "data": [1, 2, 3]}"#,
+                "unknown_key",
+            ),
+            // (.json extension — different JSON shape)
+            (
+                "weather.json",
+                r#"{"weather": "sunny", "temperature": 72, "units": "fahrenheit"}"#,
+                "weather",
+            ),
+        ];
+        for &(filename, json_content, expected_key) in cases {
+            let filepath = temp_directory.path().join(filename);
+            std::fs::write(&filepath, json_content)
+                .expect("failed to write unrecognized JSON test file");
+            let result =
+                normalize(&filepath).expect("normalize must succeed for unrecognized JSON");
+            assert!(
+                !result.is_empty(),
+                "result must not be empty for {filename}"
+            );
+            assert!(
+                result.contains(expected_key),
+                "raw JSON content must be preserved when no format matches ({filename})"
+            );
+        }
     }
 
     #[test]
@@ -261,33 +288,6 @@ mod tests {
         assert!(
             result.contains("reply from assistant"),
             "assistant turn must appear in transcript"
-        );
-    }
-
-    #[test]
-    fn try_normalize_json_no_match_returns_content_as_is() {
-        // A .json file containing valid JSON that does not match any known format
-        // (Claude Code, Codex, Claude AI, ChatGPT, Slack) must fall through
-        // try_normalize_json and return the raw content. This exercises the None
-        // return path of try_normalize_json.
-        let temp_directory =
-            tempfile::tempdir().expect("failed to create temporary directory for normalize test");
-        let filepath = temp_directory.path().join("unrecognized.json");
-        // Valid JSON but matches no known chat format — no "mapping", no "messages",
-        // no JSONL structure, no Slack array-of-messages.
-        let json_content = r#"{"weather": "sunny", "temperature": 72, "units": "fahrenheit"}"#;
-        std::fs::write(&filepath, json_content)
-            .expect("failed to write unrecognized JSON test file");
-        let result = normalize(&filepath).expect("normalize must succeed for unrecognized JSON");
-        // try_normalize_json returns None, so normalize falls through to the final
-        // Ok(content) which returns the trimmed raw content.
-        assert!(
-            result.contains("weather"),
-            "raw JSON content must be preserved when no format matches"
-        );
-        assert!(
-            result.contains("sunny"),
-            "raw JSON values must be preserved when no format matches"
         );
     }
 

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -337,25 +337,26 @@ mod tests {
 
     #[test]
     fn normalize_file_too_large_returns_error() {
-        // Files exceeding the 500 MB safety limit must be rejected. We cannot
-        // create a real 500 MB file in tests, so we test the metadata check by
-        // verifying the error message format matches the production path.
-        // Instead, we verify the error path by checking that the error message
-        // mentions "too large" for an appropriately sized scenario. Since we
-        // cannot practically create a 500 MB file in tests, we verify the
-        // normalize function's other error path (file not found) as a proxy
-        // for the error handling infrastructure being correct.
+        // Files exceeding the 500 MB safety limit must be rejected. Create a sparse
+        // file (no disk space consumed) whose metadata reports a size above MAX_SIZE.
         let temp_directory =
-            tempfile::tempdir().expect("failed to create temporary directory for normalize test");
-        let filepath = temp_directory.path().join("nonexistent_for_size_test.json");
+            tempfile::tempdir().expect("failed to create temporary directory for size-limit test");
+        let filepath = temp_directory.path().join("huge.json");
+        let file = std::fs::File::create(&filepath)
+            .expect("failed to create sparse file for size-limit test");
+        // 500 MB + 1 byte exceeds the MAX_SIZE constant (500 * 1024 * 1024).
+        file.set_len(500 * 1024 * 1024 + 1)
+            .expect("failed to set sparse file length above MAX_SIZE");
+        drop(file);
+
         let result = normalize(&filepath);
-        assert!(result.is_err(), "missing file must produce an error");
+        assert!(result.is_err(), "file exceeding 500 MB must be rejected");
         assert!(
             result
                 .as_ref()
                 .err()
-                .is_some_and(|error| error.to_string().contains("not found")),
-            "error message must indicate file was not found"
+                .is_some_and(|error| error.to_string().contains("too large")),
+            "error message must mention 'too large'"
         );
     }
 }

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -168,4 +168,194 @@ mod tests {
         assert!(result.contains("> hello"));
         // TempDir auto-cleans up when dropped
     }
+
+    #[test]
+    fn normalize_file_not_found_returns_error() {
+        // normalize must return Err when the file does not exist.
+        let path = std::path::Path::new("/nonexistent/path/no_such_file.txt");
+        let result = normalize(path);
+        assert!(result.is_err(), "missing file must return Err");
+        assert!(
+            result
+                .err()
+                .is_some_and(|error| error.to_string().contains("not found")),
+            "error must mention 'not found'"
+        );
+    }
+
+    #[test]
+    fn normalize_empty_file_returns_ok_empty() {
+        // An empty file must normalize to an empty string without error.
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let path = temp_dir.path().join("empty.txt");
+        std::fs::write(&path, "").expect("write empty file");
+        let result = normalize(&path).expect("empty file must return Ok");
+        assert!(
+            result.is_empty(),
+            "empty file content must normalize to empty string"
+        );
+        assert_eq!(result.len(), 0, "result length must be zero");
+    }
+
+    #[test]
+    fn normalize_plain_text_passthrough() {
+        // Plain text (not JSON, not enough > markers) must be returned as-is.
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let path = temp_dir.path().join("plain.txt");
+        let content = "This is just plain text content.\nNo JSON, no > markers here at all.\n";
+        std::fs::write(&path, content).expect("write plain text file");
+        let result = normalize(&path).expect("plain text must return Ok");
+        assert!(!result.is_empty(), "plain text result must not be empty");
+        assert!(
+            result.contains("plain text"),
+            "plain text content must be preserved"
+        );
+    }
+
+    #[test]
+    fn normalize_json_with_no_known_format_returns_content() {
+        // JSON that doesn't match any known format must be returned as-is.
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let path = temp_dir.path().join("unknown.json");
+        // Valid JSON but not Claude AI, ChatGPT, Slack, or Codex format.
+        std::fs::write(&path, r#"{"unknown_key": "value", "data": [1, 2, 3]}"#)
+            .expect("write unknown json");
+        let result = normalize(&path).expect("unknown JSON must return Ok");
+        assert!(!result.is_empty(), "result must not be empty");
+        // The raw JSON content must be returned since no format matched.
+        assert!(
+            result.contains("unknown_key") || result.contains("data"),
+            "original JSON content must be returned when no format matches"
+        );
+    }
+
+    #[test]
+    fn normalize_two_quote_lines_do_not_short_circuit() {
+        // Fewer than 3 lines starting with > must not short-circuit; JSON parsing is attempted.
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let path = temp_dir.path().join("two_quotes.txt");
+        // Only two > lines — below the threshold of 3 — so format detection runs.
+        std::fs::write(&path, "> first line\n> second line\nplain text here")
+            .expect("write two-quote file");
+        let result = normalize(&path).expect("two-quote file must return Ok");
+        assert!(!result.is_empty(), "result must not be empty");
+    }
+
+    #[test]
+    fn normalize_jsonl_extension_triggers_json_path() {
+        // A .jsonl file with Claude Code JSONL content must be detected via the
+        // extension check even though .jsonl is not .json. This exercises the
+        // `extension == "jsonl"` branch in normalize().
+        let temp_directory =
+            tempfile::tempdir().expect("failed to create temporary directory for normalize test");
+        let filepath = temp_directory.path().join("conversation.jsonl");
+        let content = r#"{"type":"human","message":{"content":"hello from jsonl"}}
+{"type":"assistant","message":{"content":"reply from assistant"}}"#;
+        std::fs::write(&filepath, content).expect("failed to write .jsonl test file");
+        let result = normalize(&filepath).expect("normalize must succeed for valid .jsonl file");
+        // The Claude Code JSONL parser must have matched; verify transcript markers.
+        assert!(
+            result.contains("> hello from jsonl"),
+            "user turn must be prefixed with > marker"
+        );
+        assert!(
+            result.contains("reply from assistant"),
+            "assistant turn must appear in transcript"
+        );
+    }
+
+    #[test]
+    fn try_normalize_json_no_match_returns_content_as_is() {
+        // A .json file containing valid JSON that does not match any known format
+        // (Claude Code, Codex, Claude AI, ChatGPT, Slack) must fall through
+        // try_normalize_json and return the raw content. This exercises the None
+        // return path of try_normalize_json.
+        let temp_directory =
+            tempfile::tempdir().expect("failed to create temporary directory for normalize test");
+        let filepath = temp_directory.path().join("unrecognized.json");
+        // Valid JSON but matches no known chat format — no "mapping", no "messages",
+        // no JSONL structure, no Slack array-of-messages.
+        let json_content = r#"{"weather": "sunny", "temperature": 72, "units": "fahrenheit"}"#;
+        std::fs::write(&filepath, json_content)
+            .expect("failed to write unrecognized JSON test file");
+        let result = normalize(&filepath).expect("normalize must succeed for unrecognized JSON");
+        // try_normalize_json returns None, so normalize falls through to the final
+        // Ok(content) which returns the trimmed raw content.
+        assert!(
+            result.contains("weather"),
+            "raw JSON content must be preserved when no format matches"
+        );
+        assert!(
+            result.contains("sunny"),
+            "raw JSON values must be preserved when no format matches"
+        );
+    }
+
+    #[test]
+    fn normalize_json_content_without_json_extension() {
+        // A file without .json/.jsonl extension but whose content starts with '{'
+        // must still trigger the JSON detection path. This exercises the
+        // `content.starts_with('{')` branch.
+        let temp_directory =
+            tempfile::tempdir().expect("failed to create temporary directory for normalize test");
+        let filepath = temp_directory.path().join("conversation.txt");
+        // Claude AI format as a JSON object — starts with '{' but has .txt extension.
+        let content = r#"{"messages":[{"role":"user","content":"detected by content"},{"role":"assistant","content":"yes indeed"}]}"#;
+        std::fs::write(&filepath, content).expect("failed to write JSON-content .txt test file");
+        let result = normalize(&filepath).expect("normalize must succeed for JSON content in .txt");
+        assert!(
+            result.contains("> detected by content"),
+            "user turn must be parsed from JSON content in non-.json file"
+        );
+        assert!(
+            result.contains("yes indeed"),
+            "assistant turn must be parsed from JSON content in non-.json file"
+        );
+    }
+
+    #[test]
+    fn normalize_json_array_content_without_json_extension() {
+        // A file without .json extension but whose content starts with '[' must
+        // still trigger the JSON detection path. This exercises the
+        // `content.starts_with('[')` branch.
+        let temp_directory =
+            tempfile::tempdir().expect("failed to create temporary directory for normalize test");
+        let filepath = temp_directory.path().join("chat.log");
+        // Claude AI flat array format — starts with '[' but has .log extension.
+        let content = r#"[{"role":"user","content":"array start"},{"role":"assistant","content":"array reply"}]"#;
+        std::fs::write(&filepath, content).expect("failed to write JSON-array .log test file");
+        let result = normalize(&filepath).expect("normalize must succeed for JSON array in .log");
+        assert!(
+            result.contains("> array start"),
+            "user turn must be parsed from JSON array in non-.json file"
+        );
+        assert!(
+            result.contains("array reply"),
+            "assistant turn must be parsed from JSON array in non-.json file"
+        );
+    }
+
+    #[test]
+    fn normalize_file_too_large_returns_error() {
+        // Files exceeding the 500 MB safety limit must be rejected. We cannot
+        // create a real 500 MB file in tests, so we test the metadata check by
+        // verifying the error message format matches the production path.
+        // Instead, we verify the error path by checking that the error message
+        // mentions "too large" for an appropriately sized scenario. Since we
+        // cannot practically create a 500 MB file in tests, we verify the
+        // normalize function's other error path (file not found) as a proxy
+        // for the error handling infrastructure being correct.
+        let temp_directory =
+            tempfile::tempdir().expect("failed to create temporary directory for normalize test");
+        let filepath = temp_directory.path().join("nonexistent_for_size_test.json");
+        let result = normalize(&filepath);
+        assert!(result.is_err(), "missing file must produce an error");
+        assert!(
+            result
+                .as_ref()
+                .err()
+                .is_some_and(|error| error.to_string().contains("not found")),
+            "error message must indicate file was not found"
+        );
+    }
 }

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -225,27 +225,24 @@ mod tests {
         // exercise distinct code paths (.json extension vs content-sniffing).
         let temp_directory = tempfile::tempdir()
             .expect("failed to create temporary directory for unrecognized-JSON test");
-        let cases: &[(&str, &str, &str)] = &[
+        let cases: &[(&str, &str)] = &[
             // (.json extension — triggers extension-based JSON path)
             (
                 "unknown.json",
                 r#"{"unknown_key": "value", "data": [1, 2, 3]}"#,
-                "unknown_key",
             ),
             // (.json extension — different JSON shape)
             (
                 "weather.json",
                 r#"{"weather": "sunny", "temperature": 72, "units": "fahrenheit"}"#,
-                "weather",
             ),
             // (non-.json extension — triggers content-sniffing via `content.starts_with('{')`)
             (
                 "config.txt",
                 r#"{"sniffed_key": "detected by content start", "value": true}"#,
-                "sniffed_key",
             ),
         ];
-        for &(filename, json_content, expected_key) in cases {
+        for &(filename, json_content) in cases {
             let filepath = temp_directory.path().join(filename);
             std::fs::write(&filepath, json_content)
                 .expect("failed to write unrecognized JSON test file");
@@ -255,9 +252,10 @@ mod tests {
                 !result.is_empty(),
                 "result must not be empty for {filename}"
             );
-            assert!(
-                result.contains(expected_key),
-                "raw JSON content must be preserved when no format matches ({filename})"
+            assert_eq!(
+                result.trim(),
+                json_content.trim(),
+                "unrecognized JSON must be returned as raw content unchanged ({filename})"
             );
         }
     }

--- a/src/palace/convo_miner.rs
+++ b/src/palace/convo_miner.rs
@@ -1113,9 +1113,11 @@ mod tests {
             !rows.is_empty(),
             "at least one drawer must be filed after mining"
         );
+        // Pair assertion: verify the drawer has the correct wing.
+        let drawer_id: String = rows[0].get(0).expect("drawer id column must be readable");
         assert!(
-            !rows.is_empty(),
-            "drawer count must be positive after filing"
+            drawer_id.starts_with("drawer_"),
+            "drawer id must start with the 'drawer_' prefix"
         );
     }
 
@@ -1151,7 +1153,11 @@ mod tests {
         .await
         .expect("query for drawers after dry run should succeed");
         assert!(rows.is_empty(), "dry run must not insert any drawers");
-        assert_eq!(rows.len(), 0, "drawer count must be zero after dry run");
+        // Pair assertion: the conversation file must still exist (not consumed).
+        assert!(
+            temp_directory.path().join("convo2.txt").exists(),
+            "dry run must not delete or rename the source file"
+        );
     }
 
     #[tokio::test]
@@ -1236,10 +1242,10 @@ mod tests {
         .await
         .expect("query for drawers after too-short run should succeed");
         assert!(rows.is_empty(), "too-short files must not produce drawers");
-        assert_eq!(
-            rows.len(),
-            0,
-            "drawer count must be zero for too-short input"
+        // Pair assertion: the tiny file must still exist on disk (not consumed).
+        assert!(
+            temp_directory.path().join("tiny.txt").exists(),
+            "too-short file must not be deleted or renamed"
         );
     }
 
@@ -1274,9 +1280,11 @@ mod tests {
             !rows.is_empty(),
             "mine_convos with None wing must file at least one drawer"
         );
+        // Pair assertion: the drawer id must follow the expected prefix format.
+        let drawer_id: String = rows[0].get(0).expect("drawer id column must be readable");
         assert!(
-            !rows.is_empty(),
-            "drawer count must be positive after wing-derived mining"
+            drawer_id.starts_with("drawer_"),
+            "drawer id must start with the 'drawer_' prefix"
         );
     }
 

--- a/src/palace/convo_miner.rs
+++ b/src/palace/convo_miner.rs
@@ -1358,9 +1358,9 @@ mod tests {
             limited_file_count, 1,
             "limit=1 must process exactly one source file"
         );
-        assert!(
-            limited_file_count <= unlimited_file_count,
-            "limited run must not process more files than unlimited run"
+        assert_eq!(
+            unlimited_file_count, 2,
+            "unlimited run must process both source files (a.txt and b.txt)"
         );
     }
 

--- a/src/palace/convo_miner.rs
+++ b/src/palace/convo_miner.rs
@@ -620,6 +620,8 @@ pub async fn mine_convos(
 }
 
 #[cfg(test)]
+// Test code — .expect() is acceptable with a descriptive message.
+#[allow(clippy::expect_used)]
 mod tests {
     use super::*;
 
@@ -787,5 +789,584 @@ mod tests {
                 "chunk indices must be 0-based and contiguous"
             );
         }
+    }
+
+    #[test]
+    fn chunk_by_paragraph_multiple_paragraphs() {
+        // Content with multiple double-newline-separated paragraphs above MIN_CHUNK_SIZE
+        // must produce one chunk per paragraph with 0-based contiguous indices.
+        let content = "First paragraph with enough text to exceed the minimum size check here.\n\n\
+                       Second paragraph with its own content that also exceeds the minimum.\n\n\
+                       Third paragraph rounds out the set for thorough coverage.";
+        let chunks = chunk_by_paragraph(content);
+        assert!(
+            chunks.len() >= 2,
+            "multiple paragraphs must produce multiple chunks"
+        );
+        // Chunk indices must be contiguous from 0.
+        for (expected, chunk) in chunks.iter().enumerate() {
+            assert_eq!(
+                chunk.chunk_index, expected,
+                "chunk indices must be 0-based and contiguous"
+            );
+        }
+        assert!(
+            !chunks[0].content.is_empty(),
+            "first chunk must contain content"
+        );
+    }
+
+    #[test]
+    fn chunk_by_paragraph_long_content_no_double_newlines() {
+        // Content with more than 20 single-newline-separated lines but no double-newlines
+        // triggers the line-grouping fallback (chunks of 25 lines each).
+        let lines: Vec<String> = (0..26)
+            .map(|i| format!("Line {i} has enough content to pass the minimum size filter here."))
+            .collect();
+        let content = lines.join("\n");
+        let chunks = chunk_by_paragraph(&content);
+        // Two groups: first 25 lines and one trailing line (filtered if too short).
+        assert!(
+            !chunks.is_empty(),
+            "long single-block content must produce at least one chunk"
+        );
+        for chunk in &chunks {
+            assert!(
+                chunk.content.trim().len() > MIN_CHUNK_SIZE,
+                "every chunk must exceed MIN_CHUNK_SIZE"
+            );
+        }
+    }
+
+    #[test]
+    fn chunk_by_paragraph_short_paragraph_filtered() {
+        // A paragraph shorter than MIN_CHUNK_SIZE must be excluded from output.
+        let content = "short\n\nThis second paragraph has enough characters to exceed the minimum chunk threshold.";
+        let chunks = chunk_by_paragraph(content);
+        // "short" (5 chars) is below MIN_CHUNK_SIZE=30 and must be filtered.
+        assert_eq!(
+            chunks.len(),
+            1,
+            "short paragraph must be excluded; only long one survives"
+        );
+        assert!(
+            chunks[0].content.contains("second paragraph"),
+            "the surviving chunk must contain the long paragraph"
+        );
+    }
+
+    #[test]
+    fn detect_convo_room_general_fallback() {
+        // Content with no recognisable topic keywords must fall through to "general".
+        let content =
+            "This text contains no particular domain keywords at all, just random filler.";
+        let room = detect_convo_room(content);
+        assert_eq!(
+            room, "general",
+            "unrecognised content must produce 'general'"
+        );
+        assert!(!room.is_empty(), "room name must never be empty");
+    }
+
+    #[test]
+    fn detect_convo_room_architecture_keywords() {
+        // Content with architecture keywords must be classified as "architecture".
+        let content = "We discussed the system architecture, service interface design, and module components.";
+        let room = detect_convo_room(content);
+        assert_eq!(
+            room, "architecture",
+            "architecture keywords must map to 'architecture'"
+        );
+        assert!(!room.is_empty(), "room name must not be empty");
+    }
+
+    #[test]
+    fn detect_convo_room_planning_keywords() {
+        // Content with planning keywords must be classified as "planning".
+        let content =
+            "We need a roadmap with milestones, priorities, and sprint backlogs for the deadline.";
+        let room = detect_convo_room(content);
+        assert_eq!(room, "planning", "planning keywords must map to 'planning'");
+        assert!(!room.is_empty(), "room name must not be empty");
+    }
+
+    #[test]
+    fn detect_convo_room_decisions_keywords() {
+        // Content with decision keywords must be classified as "decisions".
+        let content = "We decided and chose the approach after considering the trade-off and alternative options.";
+        let room = detect_convo_room(content);
+        assert_eq!(
+            room, "decisions",
+            "decision keywords must map to 'decisions'"
+        );
+        assert!(!room.is_empty(), "room name must not be empty");
+    }
+
+    #[test]
+    fn detect_convo_room_problems_keywords() {
+        // Content with problem/issue keywords must be classified as "problems".
+        let content =
+            "There was a problem with a broken component that crashed; we found a workaround.";
+        let room = detect_convo_room(content);
+        assert_eq!(room, "problems", "problem keywords must map to 'problems'");
+        assert!(!room.is_empty(), "room name must not be empty");
+    }
+
+    #[test]
+    fn chunk_exchanges_routes_to_paragraph_when_preamble_precedes_quote() {
+        // Content whose first non-empty line is NOT a '>' marker must be routed to
+        // chunk_by_paragraph, preserving preamble text that chunk_by_exchange would drop.
+        let content = "This preamble paragraph is long enough to exceed the minimum chunk size threshold.\n\n\
+                       > user question here\nAI answer follows for the exchange.";
+        let chunks = chunk_exchanges(content);
+        // Preamble must be represented in output (chunk_by_paragraph preserves it).
+        assert!(
+            !chunks.is_empty(),
+            "non-empty content with preamble must produce chunks"
+        );
+        let all_text: String = chunks.iter().map(|c| c.content.as_str()).collect();
+        assert!(
+            all_text.contains("preamble"),
+            "preamble text must be preserved when routing to chunk_by_paragraph"
+        );
+    }
+
+    #[test]
+    fn walk_convos_collects_valid_extensions_excludes_meta_json() {
+        // walk_convos must collect .txt, .md, .json, .jsonl files but exclude .meta.json.
+        // The .meta.json exclusion is critical: Claude Code writes per-session metadata
+        // files with this suffix that are not conversation transcripts.
+        let temp_directory =
+            tempfile::tempdir().expect("failed to create temporary directory for walk_convos test");
+        std::fs::write(temp_directory.path().join("convo.txt"), "some content here")
+            .expect("failed to write test txt file");
+        std::fs::write(temp_directory.path().join("convo.md"), "# markdown content")
+            .expect("failed to write test md file");
+        std::fs::write(temp_directory.path().join("session.meta.json"), "{}")
+            .expect("failed to write test meta.json file");
+        std::fs::write(temp_directory.path().join("image.png"), b"\x89PNG")
+            .expect("failed to write test png file");
+
+        let mut files = Vec::new();
+        walk_convos(temp_directory.path(), &mut files);
+
+        let names: Vec<String> = files
+            .iter()
+            .filter_map(|p| p.file_name())
+            .map(|n| n.to_string_lossy().to_string())
+            .collect();
+
+        assert!(
+            names.contains(&"convo.txt".to_string()),
+            "txt must be collected"
+        );
+        assert!(
+            names.contains(&"convo.md".to_string()),
+            "md must be collected"
+        );
+        assert!(
+            !names.contains(&"session.meta.json".to_string()),
+            "meta.json must be excluded — it is Claude Code session metadata, not a transcript"
+        );
+        assert!(
+            !names.contains(&"image.png".to_string()),
+            "png must be excluded — not a supported conversation extension"
+        );
+        assert_eq!(names.len(), 2, "exactly two valid files must be collected");
+    }
+
+    #[test]
+    fn walk_convos_skips_tool_results_and_memory_dirs() {
+        // walk_convos must not descend into "tool-results" or "memory" directories
+        // — these contain Claude Code artefacts, not conversation transcripts.
+        let temp_directory = tempfile::tempdir()
+            .expect("failed to create temporary directory for walk_convos skip-dirs test");
+        let tool_results_directory = temp_directory.path().join("tool-results");
+        let memory_directory = temp_directory.path().join("memory");
+        std::fs::create_dir_all(&tool_results_directory)
+            .expect("failed to create tool-results directory");
+        std::fs::create_dir_all(&memory_directory).expect("failed to create memory directory");
+        std::fs::write(tool_results_directory.join("result.txt"), "tool output")
+            .expect("failed to write tool result file");
+        std::fs::write(memory_directory.join("note.md"), "memory note")
+            .expect("failed to write memory note file");
+        std::fs::write(
+            temp_directory.path().join("valid.txt"),
+            "valid conversation",
+        )
+        .expect("failed to write valid conversation file");
+
+        let mut files = Vec::new();
+        walk_convos(temp_directory.path(), &mut files);
+
+        let names: Vec<String> = files
+            .iter()
+            .filter_map(|p| p.file_name())
+            .map(|n| n.to_string_lossy().to_string())
+            .collect();
+
+        assert_eq!(
+            names,
+            vec!["valid.txt".to_string()],
+            "only the top-level valid.txt must be collected"
+        );
+        assert!(
+            !names.contains(&"result.txt".to_string()),
+            "files in tool-results must be excluded — not conversation transcripts"
+        );
+        assert!(
+            !names.contains(&"note.md".to_string()),
+            "files in memory must be excluded — not conversation transcripts"
+        );
+    }
+
+    // -- async tests ---------------------------------------------------------
+
+    #[tokio::test]
+    async fn mine_convos_write_chunks_stores_drawers_in_db() {
+        // Verify that mine_convos_write_chunks inserts exactly the provided chunks.
+        let (_db, connection) = crate::test_helpers::test_db().await;
+        let chunks = vec![
+            Chunk {
+                content: "First chunk content with enough bytes to exceed minimum size."
+                    .to_string(),
+                chunk_index: 0,
+            },
+            Chunk {
+                content: "Second chunk follows with more content for the second drawer."
+                    .to_string(),
+                chunk_index: 1,
+            },
+        ];
+        let opts = MineParams {
+            wing: Some("test_wing".to_string()),
+            agent: "test_agent".to_string(),
+            limit: 0,
+            dry_run: false,
+            respect_gitignore: true,
+        };
+
+        mine_convos_write_chunks(
+            &connection,
+            &chunks,
+            "test_wing",
+            "technical",
+            "source.txt",
+            1_700_000_000.0,
+            &opts,
+        )
+        .await
+        .expect("mine_convos_write_chunks should succeed for valid chunks and connection");
+
+        // Pair assertion: verify the rows landed in the database.
+        let rows = crate::db::query_all(
+            &connection,
+            "SELECT id FROM drawers WHERE wing = 'test_wing'",
+            (),
+        )
+        .await
+        .expect("query for drawers after write should succeed");
+        assert_eq!(
+            rows.len(),
+            2,
+            "both chunks must be stored as separate drawers"
+        );
+        assert!(
+            rows[0].get::<String>(0).is_ok(),
+            "drawer id must be a valid string column"
+        );
+    }
+
+    #[tokio::test]
+    async fn mine_convos_processes_conversation_files() {
+        // End-to-end: mine_convos must scan a temp directory and file conversation chunks.
+        let temp_directory =
+            tempfile::tempdir().expect("failed to create temporary directory for mine_convos test");
+        // Exchange-format file: starts with '>' so chunk_by_exchange is used.
+        let content = "> user asks about architecture\n\
+                       The assistant explains component design and interface patterns in detail.";
+        std::fs::write(temp_directory.path().join("convo1.txt"), content)
+            .expect("failed to write test conversation file convo1.txt");
+
+        let (_db, connection) = crate::test_helpers::test_db().await;
+        let opts = MineParams {
+            wing: Some("test_wing".to_string()),
+            agent: "test_agent".to_string(),
+            limit: 0,
+            dry_run: false,
+            respect_gitignore: true,
+        };
+
+        mine_convos(&connection, temp_directory.path(), "full", &opts)
+            .await
+            .expect("mine_convos should succeed for a directory with valid conversation files");
+
+        // Pair assertion: at least one drawer must exist after mining.
+        let rows = crate::db::query_all(
+            &connection,
+            "SELECT id FROM drawers WHERE wing = 'test_wing'",
+            (),
+        )
+        .await
+        .expect("query for drawers after mining should succeed");
+        assert!(
+            !rows.is_empty(),
+            "at least one drawer must be filed after mining"
+        );
+        assert!(
+            !rows.is_empty(),
+            "drawer count must be positive after filing"
+        );
+    }
+
+    #[tokio::test]
+    async fn mine_convos_dry_run_writes_nothing() {
+        // In dry-run mode mine_convos must report without inserting any drawers.
+        let temp_directory =
+            tempfile::tempdir().expect("failed to create temporary directory for dry-run test");
+        let content = "> user asks about planning and roadmap details\n\
+                       The assistant replies about milestones, priorities, and sprints.";
+        std::fs::write(temp_directory.path().join("convo2.txt"), content)
+            .expect("failed to write test conversation file convo2.txt");
+
+        let (_db, connection) = crate::test_helpers::test_db().await;
+        let opts = MineParams {
+            wing: Some("dry_wing".to_string()),
+            agent: "test_agent".to_string(),
+            limit: 0,
+            dry_run: true,
+            respect_gitignore: true,
+        };
+
+        mine_convos(&connection, temp_directory.path(), "full", &opts)
+            .await
+            .expect("mine_convos dry run should succeed without writing to the database");
+
+        // Nothing should be written.
+        let rows = crate::db::query_all(
+            &connection,
+            "SELECT id FROM drawers WHERE wing = 'dry_wing'",
+            (),
+        )
+        .await
+        .expect("query for drawers after dry run should succeed");
+        assert!(rows.is_empty(), "dry run must not insert any drawers");
+        assert_eq!(rows.len(), 0, "drawer count must be zero after dry run");
+    }
+
+    #[tokio::test]
+    async fn mine_convos_skips_already_mined_files() {
+        // A file that is already mined must not produce duplicate drawers on a second run.
+        let temp_directory =
+            tempfile::tempdir().expect("failed to create temporary directory for dedup test");
+        let content =
+            "> question about decisions and alternatives\nAnswer with trade-off discussion here.";
+        std::fs::write(temp_directory.path().join("already_mined.txt"), content)
+            .expect("failed to write test conversation file already_mined.txt");
+
+        let (_db, connection) = crate::test_helpers::test_db().await;
+        let opts = MineParams {
+            wing: Some("skip_wing".to_string()),
+            agent: "test_agent".to_string(),
+            limit: 0,
+            dry_run: false,
+            respect_gitignore: true,
+        };
+
+        // First run: file gets mined.
+        mine_convos(&connection, temp_directory.path(), "full", &opts)
+            .await
+            .expect("first mine_convos run should succeed");
+        let first_count = crate::db::query_all(
+            &connection,
+            "SELECT id FROM drawers WHERE wing = 'skip_wing'",
+            (),
+        )
+        .await
+        .expect("query for drawers after first run should succeed")
+        .len();
+
+        // Second run: file is already filed; count must not increase.
+        mine_convos(&connection, temp_directory.path(), "full", &opts)
+            .await
+            .expect("second mine_convos run should succeed without re-filing");
+        let second_count = crate::db::query_all(
+            &connection,
+            "SELECT id FROM drawers WHERE wing = 'skip_wing'",
+            (),
+        )
+        .await
+        .expect("query for drawers after second run should succeed")
+        .len();
+
+        assert!(first_count >= 1, "first run must add at least one drawer");
+        assert_eq!(
+            first_count, second_count,
+            "second run must not add drawers for an already-mined file"
+        );
+    }
+
+    #[tokio::test]
+    async fn mine_convos_skips_too_short_files() {
+        // Files with content below MIN_CHUNK_SIZE must be counted as too-short
+        // and must not produce any drawers.
+        let temp_directory =
+            tempfile::tempdir().expect("failed to create temporary directory for too-short test");
+        std::fs::write(temp_directory.path().join("tiny.txt"), "tiny")
+            .expect("failed to write too-short test file tiny.txt");
+
+        let (_db, connection) = crate::test_helpers::test_db().await;
+        let opts = MineParams {
+            wing: Some("short_wing".to_string()),
+            agent: "test_agent".to_string(),
+            limit: 0,
+            dry_run: false,
+            respect_gitignore: true,
+        };
+
+        mine_convos(&connection, temp_directory.path(), "full", &opts)
+            .await
+            .expect("mine_convos should return Ok even for too-short files");
+
+        let rows = crate::db::query_all(
+            &connection,
+            "SELECT id FROM drawers WHERE wing = 'short_wing'",
+            (),
+        )
+        .await
+        .expect("query for drawers after too-short run should succeed");
+        assert!(rows.is_empty(), "too-short files must not produce drawers");
+        assert_eq!(
+            rows.len(),
+            0,
+            "drawer count must be zero for too-short input"
+        );
+    }
+
+    #[tokio::test]
+    async fn mine_convos_derives_wing_from_directory_name() {
+        // When opts.wing is None the wing is derived from the directory name.
+        let temp_directory = tempfile::tempdir()
+            .expect("failed to create temporary directory for wing-derivation test");
+        let content = "> user asks about architecture and service design patterns\n\
+             The assistant explains the module structure and interface components here.";
+        std::fs::write(temp_directory.path().join("test.txt"), content)
+            .expect("failed to write test conversation file test.txt");
+
+        let (_db, connection) = crate::test_helpers::test_db().await;
+        let opts = MineParams {
+            wing: None, // Falls back to directory name.
+            agent: "test_agent".to_string(),
+            limit: 0,
+            dry_run: false,
+            respect_gitignore: true,
+        };
+
+        mine_convos(&connection, temp_directory.path(), "full", &opts)
+            .await
+            .expect("mine_convos with derived wing should succeed");
+
+        // A drawer must exist; the wing is whatever the temp directory's last component is.
+        let rows = crate::db::query_all(&connection, "SELECT id FROM drawers", ())
+            .await
+            .expect("query for all drawers should succeed");
+        assert!(
+            !rows.is_empty(),
+            "mine_convos with None wing must file at least one drawer"
+        );
+        assert!(
+            !rows.is_empty(),
+            "drawer count must be positive after wing-derived mining"
+        );
+    }
+
+    #[tokio::test]
+    async fn mine_convos_with_limit_caps_files_processed() {
+        // opts.limit=1 must process at most one file even when the directory has more.
+        let temp_directory =
+            tempfile::tempdir().expect("failed to create temporary directory for limit test");
+        let content =
+            "> question about technical architecture design\nThe assistant explains the pattern.";
+        std::fs::write(temp_directory.path().join("a.txt"), content)
+            .expect("failed to write test file a.txt");
+        std::fs::write(temp_directory.path().join("b.txt"), content)
+            .expect("failed to write test file b.txt");
+
+        let (_db, connection) = crate::test_helpers::test_db().await;
+        let opts = MineParams {
+            wing: Some("limit_wing".to_string()),
+            agent: "test_agent".to_string(),
+            limit: 1,
+            dry_run: false,
+            respect_gitignore: true,
+        };
+
+        mine_convos(&connection, temp_directory.path(), "full", &opts)
+            .await
+            .expect("mine_convos with limit=1 should succeed");
+
+        // Only one file should have been processed; compare against unlimited run.
+        let limited_count = crate::db::query_all(
+            &connection,
+            "SELECT id FROM drawers WHERE wing = 'limit_wing'",
+            (),
+        )
+        .await
+        .expect("query for limited drawers should succeed")
+        .len();
+
+        let (_db2, connection2) = crate::test_helpers::test_db().await;
+        let opts_unlimited = MineParams {
+            wing: Some("unlimited_wing".to_string()),
+            agent: "test_agent".to_string(),
+            limit: 0,
+            dry_run: false,
+            respect_gitignore: true,
+        };
+        mine_convos(&connection2, temp_directory.path(), "full", &opts_unlimited)
+            .await
+            .expect("mine_convos with limit=0 should succeed");
+        let unlimited_count = crate::db::query_all(
+            &connection2,
+            "SELECT id FROM drawers WHERE wing = 'unlimited_wing'",
+            (),
+        )
+        .await
+        .expect("query for unlimited drawers should succeed")
+        .len();
+
+        assert!(limited_count >= 1, "limit=1 must file at least one drawer");
+        assert!(
+            limited_count <= unlimited_count,
+            "limited run must not exceed unlimited run's drawer count"
+        );
+    }
+
+    #[tokio::test]
+    async fn mine_convos_not_a_directory_returns_error() {
+        // Passing a non-directory path must return Err rather than panicking.
+        let temp_directory =
+            tempfile::tempdir().expect("failed to create temporary directory for error test");
+        let file_path = temp_directory.path().join("not_a_dir.txt");
+        std::fs::write(&file_path, "content").expect("failed to write not_a_dir.txt");
+
+        let (_db, connection) = crate::test_helpers::test_db().await;
+        let opts = MineParams {
+            wing: Some("err_wing".to_string()),
+            agent: "agent".to_string(),
+            limit: 0,
+            dry_run: false,
+            respect_gitignore: true,
+        };
+
+        let result = mine_convos(&connection, &file_path, "full", &opts).await;
+        assert!(result.is_err(), "non-directory path must return Err");
+        assert!(
+            result
+                .err()
+                .is_some_and(|error| error.to_string().contains("directory")
+                    || error.to_string().contains("not found")),
+            "error message must mention 'directory' or 'not found'"
+        );
     }
 }

--- a/src/palace/convo_miner.rs
+++ b/src/palace/convo_miner.rs
@@ -1272,19 +1272,29 @@ mod tests {
             .await
             .expect("mine_convos with derived wing should succeed");
 
-        // A drawer must exist; the wing is whatever the temp directory's last component is.
-        let rows = crate::db::query_all(&connection, "SELECT id FROM drawers", ())
+        // Compute the expected wing from the temp directory's last path component.
+        let expected_wing = temp_directory
+            .path()
+            .canonicalize()
+            .expect("temp directory must be canonicalizable")
+            .file_name()
+            .expect("canonicalized temp directory must have a file name")
+            .to_string_lossy()
+            .to_lowercase()
+            .replace([' ', '-'], "_");
+
+        let rows = crate::db::query_all(&connection, "SELECT wing FROM drawers", ())
             .await
-            .expect("query for all drawers should succeed");
+            .expect("query for drawer wing should succeed");
         assert!(
             !rows.is_empty(),
             "mine_convos with None wing must file at least one drawer"
         );
-        // Pair assertion: the drawer id must follow the expected prefix format.
-        let drawer_id: String = rows[0].get(0).expect("drawer id column must be readable");
-        assert!(
-            drawer_id.starts_with("drawer_"),
-            "drawer id must start with the 'drawer_' prefix"
+        // Verify the wing was actually derived from the directory name.
+        let actual_wing: String = rows[0].get(0).expect("wing column must be readable");
+        assert_eq!(
+            actual_wing, expected_wing,
+            "wing must be derived from the temp directory name"
         );
     }
 
@@ -1313,14 +1323,15 @@ mod tests {
             .await
             .expect("mine_convos with limit=1 should succeed");
 
-        // Only one file should have been processed; compare against unlimited run.
-        let limited_count = crate::db::query_all(
+        // Count distinct source files processed, not individual drawers (a single
+        // file may produce multiple drawers via chunking).
+        let limited_file_count = crate::db::query_all(
             &connection,
-            "SELECT id FROM drawers WHERE wing = 'limit_wing'",
+            "SELECT DISTINCT source_file FROM drawers WHERE wing = 'limit_wing'",
             (),
         )
         .await
-        .expect("query for limited drawers should succeed")
+        .expect("query for limited distinct source files should succeed")
         .len();
 
         let (_db2, connection2) = crate::test_helpers::test_db().await;
@@ -1334,19 +1345,22 @@ mod tests {
         mine_convos(&connection2, temp_directory.path(), "full", &opts_unlimited)
             .await
             .expect("mine_convos with limit=0 should succeed");
-        let unlimited_count = crate::db::query_all(
+        let unlimited_file_count = crate::db::query_all(
             &connection2,
-            "SELECT id FROM drawers WHERE wing = 'unlimited_wing'",
+            "SELECT DISTINCT source_file FROM drawers WHERE wing = 'unlimited_wing'",
             (),
         )
         .await
-        .expect("query for unlimited drawers should succeed")
+        .expect("query for unlimited distinct source files should succeed")
         .len();
 
-        assert!(limited_count >= 1, "limit=1 must file at least one drawer");
+        assert_eq!(
+            limited_file_count, 1,
+            "limit=1 must process exactly one source file"
+        );
         assert!(
-            limited_count <= unlimited_count,
-            "limited run must not exceed unlimited run's drawer count"
+            limited_file_count <= unlimited_file_count,
+            "limited run must not process more files than unlimited run"
         );
     }
 

--- a/src/palace/entity_detect.rs
+++ b/src/palace/entity_detect.rs
@@ -618,6 +618,99 @@ mod tests {
     }
 
     #[test]
+    fn detect_entities_with_project_entities() {
+        // Exercises the project classification branch in detect_entities.
+        // Each project name appears 4+ times with build/deploy verbs and zero
+        // person signals, pushing person_ratio <= 0.3 so classify_entity picks
+        // the "project" branch. Person names get speech verbs and pronouns to
+        // land in the "person" bucket and verify both arms fire in one call.
+        let temp_directory = tempfile::tempdir()
+            .expect("failed to create temporary directory for entity detection test");
+
+        let file_path_one = temp_directory.path().join("notes_one.txt");
+        let file_path_two = temp_directory.path().join("notes_two.txt");
+
+        // Palantir: 4 project-verb hits, no person signals.
+        // Vortex: 4 project-verb hits plus a versioned reference.
+        // Clara: 5 person-verb hits with pronouns nearby → person bucket.
+        let content_one = "\
+Clara said hello to the team. She was excited.\n\
+We have been building Palantir for months now.\n\
+Clara asked about the deploy timeline. She wanted details.\n\
+We finished deploying Palantir to staging yesterday.\n\
+Clara told everyone the release is on track.\n\
+The Palantir architecture is solid and well tested.\n\
+Shipping Palantir went smoothly after the final review.\n\
+We started building Vortex as a side project last week.\n\
+Clara laughed when she saw the Vortex demo.\n\
+Deploying Vortex to the cluster took only minutes.\n";
+
+        let content_two = "\
+Clara replied with detailed feedback on the Vortex pipeline.\n\
+The team launched Vortex v2 with improved throughput.\n\
+She reviewed the Vortex-v3 release candidate too.\n\
+Installing Palantir on the new servers was straightforward.\n\
+Clara said the migration is complete. He agreed.\n";
+
+        let mut file_one = std::fs::File::create(&file_path_one)
+            .expect("failed to create first temp file for project entity test");
+        file_one
+            .write_all(content_one.as_bytes())
+            .expect("failed to write first temp file for project entity test");
+
+        let mut file_two = std::fs::File::create(&file_path_two)
+            .expect("failed to create second temp file for project entity test");
+        file_two
+            .write_all(content_two.as_bytes())
+            .expect("failed to write second temp file for project entity test");
+
+        let paths: Vec<&Path> = vec![file_path_one.as_path(), file_path_two.as_path()];
+        let result = detect_entities(&paths, 10);
+
+        // Postcondition: detection found entities across multiple categories.
+        let total_entities = result.people.len() + result.projects.len() + result.uncertain.len();
+        assert!(
+            total_entities > 0,
+            "detection should find at least one entity across all categories"
+        );
+
+        // Project bucket should contain at least one of Palantir or Vortex.
+        // Both names carry strong project signals (build/deploy verbs, versioned
+        // references) and no person signals, so person_ratio should be <= 0.3.
+        let project_names: Vec<&str> = result.projects.iter().map(|e| e.name.as_str()).collect();
+        let has_project_entity = project_names.contains(&"Palantir")
+            || project_names.contains(&"Vortex")
+            || result
+                .uncertain
+                .iter()
+                .any(|e| e.name == "Palantir" || e.name == "Vortex");
+        assert!(
+            has_project_entity,
+            "Palantir or Vortex should appear in projects or uncertain; \
+             projects={project_names:?}, uncertain={:?}",
+            result.uncertain.iter().map(|e| &e.name).collect::<Vec<_>>()
+        );
+
+        // Clara should land in people or uncertain — she has speech verb and
+        // pronoun signals across two signal categories.
+        let has_person_entity = result.people.iter().any(|e| e.name == "Clara")
+            || result.uncertain.iter().any(|e| e.name == "Clara");
+        assert!(
+            has_person_entity,
+            "Clara should appear in people or uncertain"
+        );
+
+        // Verify project entities have reasonable confidence (> 0.0).
+        for project in &result.projects {
+            assert!(
+                project.confidence > 0.0,
+                "project entity '{}' should have positive confidence",
+                project.name
+            );
+        }
+    }
+
+    #[test]
     fn detect_entities_empty_files() {
         // Empty files should produce no candidates — but extract_candidates asserts
         // non-empty text, so detect_entities handles the empty-read case by

--- a/src/palace/room_detect.rs
+++ b/src/palace/room_detect.rs
@@ -391,4 +391,67 @@ mod tests {
         assert!(names.contains(&"general"));
         // TempDir auto-cleans up when dropped
     }
+
+    #[test]
+    fn detect_rooms_from_folders_scans_subdirectories_one_level_deep() {
+        // detect_rooms_from_folders descends one level into subdirectories to find
+        // rooms that are nested under a parent directory (e.g. `app/frontend`).
+        // This test exercises the sub-directory scanning branch (lines 148-162).
+        let temp_directory = tempfile::tempdir()
+            .expect("failed to create temporary directory for subdirectory test");
+        let parent_directory = temp_directory.path().join("app");
+        std::fs::create_dir_all(parent_directory.join("frontend"))
+            .expect("failed to create nested frontend directory");
+        std::fs::create_dir_all(parent_directory.join("backend"))
+            .expect("failed to create nested backend directory");
+        // Also create a file (not a directory) to exercise the is_dir() filter.
+        std::fs::write(parent_directory.join("README.md"), "# readme")
+            .expect("failed to write README.md in parent directory");
+
+        let rooms = detect_rooms_from_folders(temp_directory.path());
+        let names: Vec<&str> = rooms.iter().map(|room| room.name.as_str()).collect();
+
+        // Sub-directory rooms must be detected via the one-level-deeper scan.
+        assert!(
+            names.contains(&"frontend"),
+            "nested frontend directory must be detected as a room"
+        );
+        assert!(
+            names.contains(&"backend"),
+            "nested backend directory must be detected as a room"
+        );
+        // General room must always be present.
+        assert!(
+            names.contains(&"general"),
+            "general room must always be included"
+        );
+    }
+
+    #[test]
+    fn detect_rooms_from_folders_skips_node_modules_in_subdirs() {
+        // Directories in SKIP_DIRS (like node_modules) must be excluded from room
+        // detection even when nested one level deep inside a parent directory.
+        // The sub-directory scan only matches names in folder_map — "frontend" is
+        // a known mapped name, "node_modules" is in SKIP_DIRS and must be excluded.
+        let temp_directory =
+            tempfile::tempdir().expect("failed to create temporary directory for skip-dirs test");
+        let parent_directory = temp_directory.path().join("project");
+        std::fs::create_dir_all(parent_directory.join("node_modules"))
+            .expect("failed to create nested node_modules directory");
+        std::fs::create_dir_all(parent_directory.join("frontend"))
+            .expect("failed to create nested frontend directory");
+
+        let rooms = detect_rooms_from_folders(temp_directory.path());
+        let names: Vec<&str> = rooms.iter().map(|room| room.name.as_str()).collect();
+
+        assert!(
+            !names.contains(&"node_modules"),
+            "node_modules must be excluded from room detection"
+        );
+        // "frontend" is in the folder_map — the sub-directory scan must detect it.
+        assert!(
+            names.contains(&"frontend"),
+            "non-skipped subdirectory 'frontend' must be detected via folder_map"
+        );
+    }
 }

--- a/tests/app_dispatch.rs
+++ b/tests/app_dispatch.rs
@@ -1,0 +1,398 @@
+//! Integration tests for the `app::run` dispatcher.
+//!
+//! Exercises CLI command paths through the real dispatch logic without requiring
+//! a live palace database. Commands that need a DB (`Mine`, `Search`, `WakeUp`,
+//! `Compress`, `Repair`, `Mcp`) are tested elsewhere; here we cover the routes
+//! that only touch the filesystem.
+
+// Test code — .expect() is acceptable with a descriptive message.
+#![allow(clippy::expect_used)]
+
+use std::path::PathBuf;
+
+use mempalace::cli::{Cli, Command};
+
+#[tokio::test]
+async fn app_run_init_creates_config_with_yes_flag() {
+    // Command::Init with yes=true must write mempalace.yaml without blocking on stdin.
+    let temp_directory =
+        tempfile::tempdir().expect("failed to create temporary directory for init test");
+
+    let cli_instance = Cli {
+        command: Command::Init {
+            directory: temp_directory.path().to_path_buf(),
+            yes: true,
+            no_gitignore: false,
+        },
+    };
+
+    mempalace::app::run(cli_instance)
+        .await
+        .expect("app::run with Command::Init should succeed");
+
+    // mempalace.yaml must have been written.
+    let config_path = temp_directory.path().join("mempalace.yaml");
+    assert!(
+        config_path.exists(),
+        "mempalace.yaml must be created after init"
+    );
+    let config_content =
+        std::fs::read_to_string(&config_path).expect("mempalace.yaml must be readable after init");
+    assert!(
+        config_content.contains("wing:"),
+        "mempalace.yaml must contain a wing field"
+    );
+}
+
+#[tokio::test]
+async fn app_run_split_with_no_mega_files_returns_ok() {
+    // Command::Split on a directory with no mega-files must return Ok harmlessly.
+    let temp_directory =
+        tempfile::tempdir().expect("failed to create temporary directory for split test");
+    // Write a non-mega .txt file — only one session, below min_sessions threshold.
+    std::fs::write(
+        temp_directory.path().join("single.txt"),
+        "Just some plain text content here.\nNo Claude Code session markers at all.",
+    )
+    .expect("failed to write single-session test file");
+
+    let cli_instance = Cli {
+        command: Command::Split {
+            directory: temp_directory.path().to_path_buf(),
+            output_dir: None,
+            dry_run: false,
+            min_sessions: 2,
+            no_gitignore: false,
+        },
+    };
+
+    mempalace::app::run(cli_instance)
+        .await
+        .expect("app::run with Command::Split should return Ok when no mega-files found");
+    // The file must still exist — nothing was split.
+    assert!(
+        temp_directory.path().join("single.txt").exists(),
+        "non-mega file must remain untouched"
+    );
+}
+
+#[tokio::test]
+async fn app_run_status_with_no_palace_returns_ok() {
+    // Command::Status with MEMPALACE_DIR pointing to an empty temp directory must
+    // return Ok and print "No palace found" rather than erroring.
+    let temp_directory =
+        tempfile::tempdir().expect("failed to create temporary directory for status test");
+    let temp_directory_path_string = temp_directory
+        .path()
+        .to_str()
+        .expect("temporary directory path must be valid UTF-8")
+        .to_string();
+
+    let cli_instance = Cli {
+        command: Command::Status,
+    };
+
+    temp_env::async_with_vars(
+        [
+            ("MEMPALACE_DIR", Some(temp_directory_path_string.as_str())),
+            ("MEMPALACE_PALACE_PATH", None),
+        ],
+        async {
+            mempalace::app::run(cli_instance)
+                .await
+                .expect("app::run with Command::Status should return Ok when no palace exists");
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn app_run_mine_with_projects_mode_and_db() {
+    // Command::Mine with mode=projects must open the palace, mine files, and return Ok.
+    let temp_directory =
+        tempfile::tempdir().expect("failed to create temporary project directory for mine test");
+    let palace_directory =
+        tempfile::tempdir().expect("failed to create temporary palace directory for mine test");
+    let palace_db_path = palace_directory.path().join("palace.db");
+    let palace_db_path_string = palace_db_path
+        .to_str()
+        .expect("palace database path must be valid UTF-8")
+        .to_string();
+
+    // Write a source file and a mempalace.yaml config.
+    std::fs::write(temp_directory.path().join("hello.rs"), "fn main() {}")
+        .expect("failed to write test source file hello.rs");
+    std::fs::write(
+        temp_directory.path().join("mempalace.yaml"),
+        "wing: test_project\nrooms:\n  - name: general\n    description: General\n    keywords: []",
+    )
+    .expect("failed to write mempalace.yaml for mine test");
+
+    let cli_instance = Cli {
+        command: Command::Mine {
+            directory: temp_directory.path().to_path_buf(),
+            mode: "projects".to_string(),
+            extract_mode: "full".to_string(),
+            wing: None,
+            agent: "test_agent".to_string(),
+            limit: 0,
+            dry_run: false,
+            no_gitignore: false,
+        },
+    };
+
+    temp_env::async_with_vars(
+        [
+            (
+                "MEMPALACE_DIR",
+                Some(palace_directory.path().to_str().expect("valid UTF-8")),
+            ),
+            (
+                "MEMPALACE_PALACE_PATH",
+                Some(palace_db_path_string.as_str()),
+            ),
+        ],
+        async {
+            mempalace::app::run(cli_instance)
+                .await
+                .expect("app::run with Command::Mine projects should succeed");
+        },
+    )
+    .await;
+
+    // Palace database must have been created.
+    assert!(palace_db_path.exists(), "palace.db must exist after mining");
+}
+
+#[tokio::test]
+async fn app_run_mine_with_convos_mode_and_db() {
+    // Command::Mine with mode=convos must scan a conversation directory and file chunks.
+    let temp_directory = tempfile::tempdir()
+        .expect("failed to create temporary conversation directory for mine test");
+    let palace_directory = tempfile::tempdir()
+        .expect("failed to create temporary palace directory for convos mine test");
+    let palace_db_path = palace_directory.path().join("palace.db");
+    let palace_db_path_string = palace_db_path
+        .to_str()
+        .expect("palace database path must be valid UTF-8")
+        .to_string();
+
+    // Write a conversation file with exchange markers.
+    std::fs::write(
+        temp_directory.path().join("conversation.txt"),
+        "> user asks about system architecture and design patterns\n\
+         The assistant explains the component structure and interface modules in detail.",
+    )
+    .expect("failed to write test conversation file");
+
+    let cli_instance = Cli {
+        command: Command::Mine {
+            directory: temp_directory.path().to_path_buf(),
+            mode: "convos".to_string(),
+            extract_mode: "full".to_string(),
+            wing: Some("test_convos".to_string()),
+            agent: "test_agent".to_string(),
+            limit: 0,
+            dry_run: false,
+            no_gitignore: false,
+        },
+    };
+
+    temp_env::async_with_vars(
+        [
+            (
+                "MEMPALACE_DIR",
+                Some(palace_directory.path().to_str().expect("valid UTF-8")),
+            ),
+            (
+                "MEMPALACE_PALACE_PATH",
+                Some(palace_db_path_string.as_str()),
+            ),
+        ],
+        async {
+            mempalace::app::run(cli_instance)
+                .await
+                .expect("app::run with Command::Mine convos should succeed");
+        },
+    )
+    .await;
+
+    assert!(
+        palace_db_path.exists(),
+        "palace.db must exist after convos mining"
+    );
+}
+
+#[tokio::test]
+async fn app_run_search_with_palace() {
+    // Command::Search must open the palace and execute a query.
+    let palace_directory =
+        tempfile::tempdir().expect("failed to create temporary palace directory for search test");
+    let palace_db_path = palace_directory.path().join("palace.db");
+    let palace_db_path_string = palace_db_path
+        .to_str()
+        .expect("palace database path must be valid UTF-8")
+        .to_string();
+
+    let cli_instance = Cli {
+        command: Command::Search {
+            query: "test query".to_string(),
+            wing: None,
+            room: None,
+            results: 10,
+        },
+    };
+
+    temp_env::async_with_vars(
+        [
+            (
+                "MEMPALACE_DIR",
+                Some(palace_directory.path().to_str().expect("valid UTF-8")),
+            ),
+            (
+                "MEMPALACE_PALACE_PATH",
+                Some(palace_db_path_string.as_str()),
+            ),
+        ],
+        async {
+            mempalace::app::run(cli_instance)
+                .await
+                .expect("app::run with Command::Search should succeed on an empty palace");
+        },
+    )
+    .await;
+
+    assert!(
+        palace_db_path.exists(),
+        "palace.db must exist after search creates it"
+    );
+}
+
+#[tokio::test]
+async fn app_run_wakeup_with_palace() {
+    // Command::WakeUp must open the palace and generate wake-up context.
+    let palace_directory =
+        tempfile::tempdir().expect("failed to create temporary palace directory for wakeup test");
+    let palace_db_path = palace_directory.path().join("palace.db");
+    let palace_db_path_string = palace_db_path
+        .to_str()
+        .expect("palace database path must be valid UTF-8")
+        .to_string();
+
+    let cli_instance = Cli {
+        command: Command::WakeUp { wing: None },
+    };
+
+    temp_env::async_with_vars(
+        [
+            (
+                "MEMPALACE_DIR",
+                Some(palace_directory.path().to_str().expect("valid UTF-8")),
+            ),
+            (
+                "MEMPALACE_PALACE_PATH",
+                Some(palace_db_path_string.as_str()),
+            ),
+        ],
+        async {
+            mempalace::app::run(cli_instance)
+                .await
+                .expect("app::run with Command::WakeUp should succeed on an empty palace");
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn app_run_compress_with_palace() {
+    // Command::Compress must open the palace and process drawers (no-op on empty).
+    let palace_directory =
+        tempfile::tempdir().expect("failed to create temporary palace directory for compress test");
+    let palace_db_path = palace_directory.path().join("palace.db");
+    let palace_db_path_string = palace_db_path
+        .to_str()
+        .expect("palace database path must be valid UTF-8")
+        .to_string();
+
+    let cli_instance = Cli {
+        command: Command::Compress {
+            wing: None,
+            dry_run: true,
+            config: None,
+        },
+    };
+
+    temp_env::async_with_vars(
+        [
+            (
+                "MEMPALACE_DIR",
+                Some(palace_directory.path().to_str().expect("valid UTF-8")),
+            ),
+            (
+                "MEMPALACE_PALACE_PATH",
+                Some(palace_db_path_string.as_str()),
+            ),
+        ],
+        async {
+            mempalace::app::run(cli_instance)
+                .await
+                .expect("app::run with Command::Compress should succeed on an empty palace");
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn app_run_repair_with_palace() {
+    // Command::Repair must open the palace, back it up, and rebuild the index.
+    let palace_directory =
+        tempfile::tempdir().expect("failed to create temporary palace directory for repair test");
+    let palace_db_path = palace_directory.path().join("palace.db");
+    let palace_db_path_string = palace_db_path
+        .to_str()
+        .expect("palace database path must be valid UTF-8")
+        .to_string();
+
+    // Pre-create the palace so open_palace() can find it, and so repair can copy it.
+    let palace_db_path_for_setup = PathBuf::from(&palace_db_path_string);
+    {
+        let (database, connection) = mempalace::db::open_db(&palace_db_path_string)
+            .await
+            .expect("failed to open palace database for test setup");
+        mempalace::schema::ensure_schema(&connection)
+            .await
+            .expect("failed to apply schema for test setup");
+        // Drop connection and database to release locks before repair runs.
+        drop(connection);
+        drop(database);
+    }
+
+    let cli_instance = Cli {
+        command: Command::Repair,
+    };
+
+    temp_env::async_with_vars(
+        [
+            (
+                "MEMPALACE_DIR",
+                Some(palace_directory.path().to_str().expect("valid UTF-8")),
+            ),
+            (
+                "MEMPALACE_PALACE_PATH",
+                Some(palace_db_path_string.as_str()),
+            ),
+        ],
+        async {
+            mempalace::app::run(cli_instance)
+                .await
+                .expect("app::run with Command::Repair should succeed");
+        },
+    )
+    .await;
+
+    // Backup file must exist after repair.
+    assert!(
+        palace_db_path_for_setup.with_extension("db.bak").exists(),
+        "palace.db.bak must exist after repair"
+    );
+}

--- a/tests/app_dispatch.rs
+++ b/tests/app_dispatch.rs
@@ -301,6 +301,12 @@ async fn app_run_wakeup_with_palace() {
         },
     )
     .await;
+
+    // open_palace() must have created the database file as a side effect.
+    assert!(
+        palace_db_path.exists(),
+        "palace.db must exist after wakeup creates it via open_palace"
+    );
 }
 
 #[tokio::test]
@@ -340,6 +346,12 @@ async fn app_run_compress_with_palace() {
         },
     )
     .await;
+
+    // open_palace() must have created the database file as a side effect.
+    assert!(
+        palace_db_path.exists(),
+        "palace.db must exist after compress creates it via open_palace"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Add 226 new tests (600 → 826) raising line coverage from 86.35% to 95.05%
- Unit tests across 16 source files covering previously-untested functions: `mine_convos`, `split_file`, `expand_tilde`, `repair::run`, `init::run`, `add_triple_validate_params`, and more
- Integration test (`tests/app_dispatch.rs`) exercising `app::run` with all CLI `Command` variants via temp directories and env overrides
- Export `app` and `cli` modules from `lib.rs` for integration test access

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Library now exposes top-level app and CLI modules for broader integration.

* **Tests**
  * Wide expansion of automated tests and integration coverage across CLI commands, config/migrations, parsing/normalization, conversation mining, entity/room/emotion detection, knowledge-graph validation, DB repair/backup behavior, and end-to-end dispatcher flows — improving reliability and observable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->