### PR TITLE
Add Codecov configuration

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto # default
+        threshold: 0.5% # Allow a maximum drop of 0.5% in coverage
+    patch:
+      default:
+        target: 90%


### PR DESCRIPTION
## Summary

- Add `codecov.yml` with project coverage threshold set to auto (0.5% max drop) and 90% patch target
- Prevents PRs from silently degrading the coverage baseline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured code coverage enforcement rules. Project coverage is set to permit a maximum drop of 0.5% from the baseline level, while patch coverage is required to maintain a minimum target of 90%.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->