### PR TITLE
Show coverage diff in Codecov PR comments

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,8 +2,12 @@ coverage:
   status:
     project:
       default:
-        target: auto # default
-        threshold: 0.5% # Allow a maximum drop of 0.5% in coverage
+        target: auto
+        threshold: 0.5%
     patch:
       default:
         target: 90%
+
+comment:
+  layout: "header, diff"
+  require_changes: true


### PR DESCRIPTION
## Summary

- Configure Codecov comment layout to show the coverage change summary instead of the per-file patch table
- Suppress comments on PRs that do not affect coverage