### PR TITLE
Use condensed layout for Codecov PR comments

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -9,5 +9,5 @@ coverage:
         target: 90%
 
 comment:
-  layout: "header, diff"
+  layout: "condensed_header, condensed_files, condensed_footer"
   require_changes: true


### PR DESCRIPTION
## Summary

- Switch Codecov comment layout from `header, diff` to `condensed_header, condensed_files, condensed_footer`
- The condensed header renders a base/head/delta table, making overall coverage improvements visible rather than leading with uncovered line counts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage reporting configuration to use a condensed format for internal coverage comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->