### PR TITLE
Use header, diff, files layout for Codecov comments

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -9,5 +9,5 @@ coverage:
         target: 90%
 
 comment:
-  layout: "condensed_header, condensed_files, condensed_footer"
+  layout: "header, diff, files"
   require_changes: true


### PR DESCRIPTION
## Summary

- Switch from `condensed_header, condensed_files, condensed_footer` (merged in #46) to `header, diff, files`
- The non-condensed layout renders the base/head/delta diff table inline, making coverage improvements visible at a glance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage comment layout to display header, diff, and files sections in pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->