### PR TITLE
Enforce STYLEGUIDE.md across codebase

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -7,8 +7,8 @@ fn main() {
         .ok()
         .filter(|output| output.status.success())
         .and_then(|output| String::from_utf8(output.stdout).ok())
-        .map(|s| s.trim().to_owned())
-        .filter(|s| !s.is_empty())
+        .map(|sha_string| sha_string.trim().to_owned())
+        .filter(|sha_string| !sha_string.is_empty())
         .unwrap_or_else(|| "unknown".to_owned());
 
     println!("cargo:rustc-env=GIT_SHORT_SHA={sha}");

--- a/clippy.toml
+++ b/clippy.toml
@@ -2,4 +2,18 @@
 too-many-lines-threshold = 70
 
 # TigerStyle: do not abbreviate variable names.
-disallowed-names = ["conn", "cfg", "dir", "ext", "vf", "vt", "sc", "sf"]
+disallowed-names = [
+  "conn",
+  "cfg",
+  "dir",
+  "ext",
+  "vf",
+  "vt",
+  "sc",
+  "sf",
+  "s",
+  "v",
+  "r",
+  "d",
+  "q",
+]

--- a/src/app.rs
+++ b/src/app.rs
@@ -49,9 +49,9 @@ async fn open_palace() -> error::Result<(turso::Database, turso::Connection, std
             db_path.display()
         ))
     })?;
-    let (db, connection) = db::open_db(db_path_str).await?;
+    let (database, connection) = db::open_db(db_path_str).await?;
     schema::ensure_schema(&connection).await?;
-    Ok((db, connection, db_path))
+    Ok((database, connection, db_path))
 }
 
 // Each match arm is a single CLI subcommand — splitting this into separate

--- a/src/app.rs
+++ b/src/app.rs
@@ -128,7 +128,7 @@ pub async fn run(cli: Cli) -> error::Result<()> {
             directory,
             output_dir,
             dry_run,
-            min_sessions,
+            sessions_min,
             no_gitignore,
         } => {
             // Expand ~ so that `mempalace split ~/convos` works as expected.
@@ -138,7 +138,7 @@ pub async fn run(cli: Cli) -> error::Result<()> {
                 &directory,
                 output_dir.as_deref(),
                 dry_run,
-                min_sessions,
+                sessions_min,
                 !no_gitignore,
             )?;
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -54,8 +54,9 @@ async fn open_palace() -> error::Result<(turso::Database, turso::Connection, std
     Ok((database, connection, db_path))
 }
 
-// Each match arm is a single CLI subcommand — splitting this into separate
-// functions would not reduce complexity, only scatter the dispatch logic.
+/// Dispatch a parsed CLI command to the appropriate subcommand handler.
+// Each match arm dispatches a single CLI subcommand — splitting further would
+// only scatter the top-level dispatch logic without reducing complexity.
 #[allow(clippy::too_many_lines)]
 pub async fn run(cli: Cli) -> error::Result<()> {
     match cli.command {
@@ -100,20 +101,11 @@ pub async fn run(cli: Cli) -> error::Result<()> {
             room,
             results,
         } => {
-            let (_db, connection, _path) = open_palace().await?;
-            cli::search::run(
-                &connection,
-                &query,
-                wing.as_deref(),
-                room.as_deref(),
-                results,
-            )
-            .await?;
+            run_search(query, wing, room, results).await?;
         }
 
         Command::WakeUp { wing } => {
-            let (_db, connection, _path) = open_palace().await?;
-            cli::wakeup::run(&connection, wing.as_deref()).await?;
+            run_wakeup(wing).await?;
         }
 
         Command::Compress {
@@ -131,30 +123,81 @@ pub async fn run(cli: Cli) -> error::Result<()> {
             sessions_min,
             no_gitignore,
         } => {
-            // Expand ~ so that `mempalace split ~/convos` works as expected.
-            let directory = expand_tilde(&directory);
-            let output_dir = output_dir.as_deref().map(expand_tilde);
-            cli::split::run(
+            run_split(
                 &directory,
                 output_dir.as_deref(),
                 dry_run,
                 sessions_min,
-                !no_gitignore,
+                no_gitignore,
             )?;
         }
 
         Command::Repair => {
-            let (_db, connection, palace_path) = open_palace().await?;
-            cli::repair::run(&connection, &palace_path).await?;
+            run_repair().await?;
         }
 
         Command::Mcp => {
-            let (_db, connection, _path) = open_palace().await?;
-            mcp::run(&connection).await?;
+            run_mcp().await?;
         }
     }
 
     Ok(())
+}
+
+/// Handle the `search` sub-command — opens the palace and runs the search.
+async fn run_search(
+    query: String,
+    wing: Option<String>,
+    room: Option<String>,
+    results: usize,
+) -> error::Result<()> {
+    let (_db, connection, _path) = open_palace().await?;
+    cli::search::run(
+        &connection,
+        &query,
+        wing.as_deref(),
+        room.as_deref(),
+        results,
+    )
+    .await
+}
+
+/// Handle the `wakeup` sub-command — opens the palace and runs wake-up.
+async fn run_wakeup(wing: Option<String>) -> error::Result<()> {
+    let (_db, connection, _path) = open_palace().await?;
+    cli::wakeup::run(&connection, wing.as_deref()).await
+}
+
+/// Handle the `split` sub-command — expands `~` then delegates to the splitter.
+fn run_split(
+    directory: &std::path::Path,
+    output_dir: Option<&std::path::Path>,
+    dry_run: bool,
+    sessions_min: usize,
+    no_gitignore: bool,
+) -> error::Result<()> {
+    // Expand ~ so that `mempalace split ~/convos` works as expected.
+    let directory = expand_tilde(directory);
+    let output_dir = output_dir.map(expand_tilde);
+    cli::split::run(
+        &directory,
+        output_dir.as_deref(),
+        dry_run,
+        sessions_min,
+        !no_gitignore,
+    )
+}
+
+/// Handle the `repair` sub-command — opens the palace and runs repair.
+async fn run_repair() -> error::Result<()> {
+    let (_db, connection, palace_path) = open_palace().await?;
+    cli::repair::run(&connection, &palace_path).await
+}
+
+/// Handle the `mcp` sub-command — opens the palace and starts the MCP server.
+async fn run_mcp() -> error::Result<()> {
+    let (_db, connection, _path) = open_palace().await?;
+    mcp::run(&connection).await
 }
 
 /// Handle the `status` sub-command — opens the palace if it exists.

--- a/src/cli/compress.rs
+++ b/src/cli/compress.rs
@@ -237,4 +237,112 @@ mod async_tests {
         assert!(orig > 0, "original size must be positive");
         assert!(comp > 0, "compressed size must be positive");
     }
+
+    #[tokio::test]
+    async fn run_compress_row_non_dry_run_inserts_into_compressed() {
+        // When dry_run=false, run_compress_row must INSERT the result into the compressed table.
+        let (_db, connection) = crate::test_helpers::test_db().await;
+        seed_drawer(&connection).await;
+
+        let rows = crate::db::query_all(
+            &connection,
+            "SELECT id, content, wing, room, source_file, filed_at FROM drawers LIMIT 1",
+            (),
+        )
+        .await
+        .expect("query for compress row must succeed");
+        let row = rows.first().expect("at least one row must exist");
+
+        let dialect = Dialect::empty();
+        let (orig, comp) = run_compress_row(&connection, row, &dialect, false, 1)
+            .await
+            .expect("non-dry-run compress row must succeed");
+        assert!(orig > 0, "original length must be positive");
+        assert!(comp > 0, "compressed length must be positive");
+
+        // Pair assertion: the compressed row must appear in the database.
+        let compressed_rows = crate::db::query_all(
+            &connection,
+            "SELECT id FROM compressed WHERE wing = 'test_wing'",
+            (),
+        )
+        .await
+        .expect("query for compressed rows must succeed");
+        assert!(
+            !compressed_rows.is_empty(),
+            "non-dry-run must insert into compressed table"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_compress_no_drawers_returns_ok() {
+        // When the palace has no drawers, run must print and return Ok without processing.
+        let (_db, connection) = crate::test_helpers::test_db().await;
+        let result = run(&connection, None, false, None).await;
+        assert!(result.is_ok(), "run with no drawers must return Ok");
+    }
+
+    #[tokio::test]
+    async fn run_compress_all_dry_run_prints_without_inserting() {
+        // run with dry_run=true must not write to the compressed table.
+        let (_db, connection) = crate::test_helpers::test_db().await;
+        seed_drawer(&connection).await;
+
+        run(&connection, None, true, None)
+            .await
+            .expect("dry-run compress must succeed");
+
+        let compressed_rows = crate::db::query_all(&connection, "SELECT id FROM compressed", ())
+            .await
+            .expect("query for compressed rows after dry run must succeed");
+        assert!(
+            compressed_rows.is_empty(),
+            "dry-run compress must not insert into compressed table"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_compress_with_wing_filter_processes_only_that_wing() {
+        // run with a wing filter must query and compress only matching drawers.
+        let (_db, connection) = crate::test_helpers::test_db().await;
+        seed_drawer(&connection).await;
+        // Seed a drawer in a different wing — must not be compressed.
+        crate::palace::drawer::add_drawer(
+            &connection,
+            &crate::palace::drawer::DrawerParams {
+                id: "compress-other-wing-1",
+                wing: "other_wing",
+                room: "other_room",
+                content: "Other wing content that should not be compressed here",
+                source_file: "other.txt",
+                chunk_index: 0,
+                added_by: "test",
+                ingest_mode: "projects",
+                source_mtime: None,
+            },
+        )
+        .await
+        .expect("seeding other-wing drawer must succeed");
+
+        run(&connection, Some("test_wing"), false, None)
+            .await
+            .expect("wing-filtered compress must succeed");
+
+        // Only test_wing must appear in the compressed table.
+        let compressed_rows = crate::db::query_all(&connection, "SELECT wing FROM compressed", ())
+            .await
+            .expect("query for compressed wings must succeed");
+        assert_eq!(
+            compressed_rows.len(),
+            1,
+            "only one drawer (from test_wing) must be compressed"
+        );
+        let wing_value: String = compressed_rows[0]
+            .get(0)
+            .expect("wing column must be readable");
+        assert_eq!(
+            wing_value, "test_wing",
+            "compressed drawer must belong to test_wing"
+        );
+    }
 }

--- a/src/cli/compress.rs
+++ b/src/cli/compress.rs
@@ -24,16 +24,7 @@ fn run_load_dialect(config_path: Option<&str>) -> Result<Dialect> {
                 .collect()
         })
         .unwrap_or_default();
-    let skip = config
-        .get("skip_names")
-        .and_then(|skip_val| skip_val.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|item| item.as_str().map(String::from))
-                .collect()
-        })
-        .unwrap_or_default();
-    Ok(Dialect::new(&entities, skip))
+    Ok(Dialect::new(&entities))
 }
 
 /// Compress one drawer row and persist or preview it. Returns `(original_len, compressed_len)`.

--- a/src/cli/compress.rs
+++ b/src/cli/compress.rs
@@ -115,20 +115,20 @@ pub async fn run(
         return Ok(());
     }
 
-    let mut total_original = 0usize;
-    let mut total_compressed = 0usize;
+    let mut original_total = 0usize;
+    let mut compressed_total = 0usize;
 
     for (count, row) in rows.iter().enumerate() {
         let (orig, comp) = run_compress_row(connection, row, &dialect, dry_run, count + 1).await?;
-        total_original += orig;
-        total_compressed += comp;
+        original_total += orig;
+        compressed_total += comp;
     }
 
     let count = rows.len();
     // Byte lengths for display-only ratio; precision loss negligible for practical sizes.
     #[allow(clippy::cast_precision_loss)]
-    let overall_ratio = if total_compressed > 0 {
-        total_original as f64 / total_compressed as f64
+    let overall_ratio = if compressed_total > 0 {
+        original_total as f64 / compressed_total as f64
     } else {
         0.0
     };
@@ -139,7 +139,7 @@ pub async fn run(
         println!("Compressed {count} drawers into AAAK dialect");
     }
     println!(
-        "  Total: {total_original} → {total_compressed} bytes ({overall_ratio:.1}x compression)"
+        "  Total: {original_total} → {compressed_total} bytes ({overall_ratio:.1}x compression)"
     );
 
     Ok(())

--- a/src/cli/compress.rs
+++ b/src/cli/compress.rs
@@ -165,7 +165,7 @@ mod tests {
         let config_path = dir.path().join("dialect.json");
         std::fs::write(
             &config_path,
-            r#"{"entities": {"Rust": "RS", "Python": "PY"}, "skip_names": ["test"]}"#,
+            r#"{"entities": {"Rust": "RS", "Python": "PY"}}"#,
         )
         .expect("must write config file");
 

--- a/src/cli/compress.rs
+++ b/src/cli/compress.rs
@@ -16,16 +16,20 @@ fn run_load_dialect(config_path: Option<&str>) -> Result<Dialect> {
         .and_then(|e| e.as_object())
         .map(|obj| {
             obj.iter()
-                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                .filter_map(|(k, entity_val)| {
+                    entity_val
+                        .as_str()
+                        .map(|code| (k.clone(), code.to_string()))
+                })
                 .collect()
         })
         .unwrap_or_default();
     let skip = config
         .get("skip_names")
-        .and_then(|s| s.as_array())
+        .and_then(|skip_val| skip_val.as_array())
         .map(|arr| {
             arr.iter()
-                .filter_map(|v| v.as_str().map(String::from))
+                .filter_map(|item| item.as_str().map(String::from))
                 .collect()
         })
         .unwrap_or_default();

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -46,7 +46,7 @@ pub fn run(directory: &Path, yes: bool, no_gitignore: bool) -> Result<()> {
         }
     }
 
-    // Save config
+    // Save config.
     let config = ProjectConfig {
         wing: project_name.clone(),
         rooms,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -128,7 +128,7 @@ pub enum Command {
 
         /// Minimum sessions to trigger split
         #[arg(long, default_value = "2")]
-        min_sessions: usize,
+        sessions_min: usize,
 
         /// Disable .gitignore filtering (include all files regardless of gitignore rules)
         #[arg(long)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -127,7 +127,7 @@ pub enum Command {
         dry_run: bool,
 
         /// Minimum sessions to trigger split
-        #[arg(long, default_value = "2")]
+        #[arg(long, default_value = "2", alias = "min-sessions")]
         sessions_min: usize,
 
         /// Disable .gitignore filtering (include all files regardless of gitignore rules)

--- a/src/cli/repair.rs
+++ b/src/cli/repair.rs
@@ -10,7 +10,13 @@ use crate::palace::drawer;
 
 /// Backup the palace database and rebuild the inverted word index.
 pub async fn run(connection: &Connection, palace_path: &Path) -> Result<()> {
-    // Backup: checkpoint WAL to ensure backup is self-contained.
+    run_create_backup(connection, palace_path).await?;
+    run_rebuild_index(connection).await
+}
+
+/// Checkpoint the WAL and copy the palace database (plus sidecar files) to `.db.bak`.
+async fn run_create_backup(connection: &Connection, palace_path: &Path) -> Result<()> {
+    // Checkpoint WAL to ensure backup is self-contained.
     // wal_checkpoint returns rows (busy, log, checkpointed) — must use query_all.
     query_all(connection, "PRAGMA wal_checkpoint(TRUNCATE)", ()).await?;
 
@@ -38,10 +44,14 @@ pub async fn run(connection: &Connection, palace_path: &Path) -> Result<()> {
     }
 
     println!("Backup created: {}", backup_path.display());
+    Ok(())
+}
 
-    // Clear and rebuild within a transaction for atomicity.
-    // BEGIN IMMEDIATE is taken before the SELECT so the snapshot is protected
-    // by the same exclusive lock that performs the delete and rebuild.
+/// Clear and rebuild the inverted word index within a transaction.
+///
+/// BEGIN IMMEDIATE is taken before the SELECT so the snapshot is protected
+/// by the same exclusive lock that performs the delete and rebuild.
+async fn run_rebuild_index(connection: &Connection) -> Result<()> {
     connection.execute("BEGIN IMMEDIATE", ()).await?;
 
     if let Err(e) = async {
@@ -83,7 +93,6 @@ pub async fn run(connection: &Connection, palace_path: &Path) -> Result<()> {
     }
 
     connection.execute("COMMIT", ()).await?;
-
     Ok(())
 }
 

--- a/src/cli/repair.rs
+++ b/src/cli/repair.rs
@@ -17,7 +17,7 @@ pub async fn run(connection: &Connection, palace_path: &Path) -> Result<()> {
     let backup_path = palace_path.with_extension("db.bak");
     std::fs::copy(palace_path, &backup_path)?;
 
-    // Build backup sidecar names from backup_path to avoid overwriting source files
+    // Build backup sidecar names from backup_path to avoid overwriting source files.
     let backup_filename = backup_path
         .file_name()
         .and_then(|n| n.to_str())
@@ -63,7 +63,7 @@ pub async fn run(connection: &Connection, palace_path: &Path) -> Result<()> {
         connection.execute("DELETE FROM drawer_words", ()).await?;
         println!("Cleared existing index");
 
-        // Rebuild
+        // Rebuild.
         for (i, (id, content)) in drawers.iter().enumerate() {
             drawer::index_words(connection, id, content).await?;
             if (i + 1) % 100 == 0 || i + 1 == total {
@@ -75,7 +75,7 @@ pub async fn run(connection: &Connection, palace_path: &Path) -> Result<()> {
     }
     .await
     {
-        // Attempt rollback and preserve the original error
+        // Attempt rollback and preserve the original error.
         if let Err(rollback_err) = connection.execute("ROLLBACK", ()).await {
             eprintln!("Rollback failed: {rollback_err}");
         }

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -22,8 +22,8 @@ pub async fn run(
     if let Some(w) = wing {
         println!("  Wing: {w}");
     }
-    if let Some(r) = room {
-        println!("  Room: {r}");
+    if let Some(room_name) = room {
+        println!("  Room: {room_name}");
     }
     println!("============================================================\n");
 

--- a/src/cli/split.rs
+++ b/src/cli/split.rs
@@ -6,20 +6,18 @@ use regex::Regex;
 
 use crate::error::Result;
 
-/// Collect `.txt` file paths from the top level of `directory`.
+/// Scan `directory` for `.txt` files, honouring or ignoring `.gitignore` rules.
 ///
-/// When `respect_gitignore` is `true`, files excluded by `.gitignore` rules are
-/// omitted (same engine as `mine --no-gitignore`). Depth is fixed at 1 to match
-/// the original `fs::read_dir` behaviour — sub-directories are never traversed.
-fn split_collect_txt_files(directory: &Path, respect_gitignore: bool) -> Result<Vec<PathBuf>> {
-    // Operating condition: filesystem state can change between the caller's
-    // is_dir() check and this call (TOCTOU) — return Err rather than panic.
-    if !directory.is_dir() {
-        return Err(crate::error::Error::Other(format!(
-            "split_collect_txt_files: '{}' is not an existing directory",
-            directory.display()
-        )));
-    }
+/// Depth is fixed at 1 — sub-directories are never traversed — matching the
+/// original `fs::read_dir` behaviour.
+fn split_collect_txt_files_from_dir(
+    directory: &Path,
+    respect_gitignore: bool,
+) -> Result<Vec<PathBuf>> {
+    assert!(
+        directory.is_dir(),
+        "split_collect_txt_files_from_dir: caller must pass a valid dir"
+    );
 
     let mut paths: Vec<PathBuf> = Vec::new();
 
@@ -58,6 +56,24 @@ fn split_collect_txt_files(directory: &Path, respect_gitignore: bool) -> Result<
     }
 
     Ok(paths)
+}
+
+/// Collect `.txt` file paths from the top level of `directory`.
+///
+/// When `respect_gitignore` is `true`, files excluded by `.gitignore` rules are
+/// omitted (same engine as `mine --no-gitignore`). Depth is fixed at 1 to match
+/// the original `fs::read_dir` behaviour — sub-directories are never traversed.
+fn split_collect_txt_files(directory: &Path, respect_gitignore: bool) -> Result<Vec<PathBuf>> {
+    // Operating condition: filesystem state can change between the caller's
+    // is_dir() check and this call (TOCTOU) — return Err rather than panic.
+    if !directory.is_dir() {
+        return Err(crate::error::Error::Other(format!(
+            "split_collect_txt_files: '{}' is not an existing directory",
+            directory.display()
+        )));
+    }
+
+    split_collect_txt_files_from_dir(directory, respect_gitignore)
 }
 
 // Regex statics are compile-time literals; .expect() cannot fail at runtime.
@@ -181,14 +197,120 @@ fn extract_subject(lines: &[&str]) -> String {
     "session".to_string()
 }
 
+/// Extract start and end timestamps from a session's lines.
+///
+/// Returns `Some((start_ts, end_ts))` where both are the same timestamp string
+/// when only one timestamp is found, or `None` when no timestamp is present.
+/// The caller uses the start timestamp as the filename component.
+fn split_file_extract_timestamps(lines: &[&str]) -> Option<(String, String)> {
+    let start = extract_timestamp(lines)?;
+    // End timestamp: scan from the tail; for now both are the same value because
+    // the filename only uses the start — kept as a pair for future extension.
+    let end = extract_timestamp(&lines.iter().rev().copied().collect::<Vec<_>>())
+        .unwrap_or_else(|| start.clone());
+    assert!(
+        !start.is_empty(),
+        "split_file_extract_timestamps: start timestamp must not be empty"
+    );
+    assert!(
+        !end.is_empty(),
+        "split_file_extract_timestamps: end timestamp must not be empty"
+    );
+    Some((start, end))
+}
+
+/// Truncate `subject` so its byte length does not exceed `byte_cap`.
+///
+/// Walks characters to avoid splitting a multi-byte UTF-8 sequence that
+/// byte-slicing would straddle.
+fn split_file_write_session_cap_subject(subject: String, byte_cap: usize) -> String {
+    assert!(
+        byte_cap > 0,
+        "split_file_write_session_cap_subject: byte_cap must be positive"
+    );
+    if subject.len() <= byte_cap {
+        return subject;
+    }
+    // Accumulate chars only while the byte budget allows.
+    let mut byte_count = 0usize;
+    let truncated: String = subject
+        .chars()
+        .take_while(|&character| {
+            byte_count += character.len_utf8();
+            byte_count <= byte_cap
+        })
+        .collect();
+    debug_assert!(
+        truncated.len() <= byte_cap,
+        "truncated byte length {len} exceeds cap {byte_cap}",
+        len = truncated.len()
+    );
+    truncated
+}
+
+/// Write one session chunk to disk and print a confirmation line.
+///
+/// Returns the path of the written file. `session_idx` is 1-based for display.
+fn split_file_write_session(
+    output_dir: &Path,
+    base_stem: &str,
+    session_idx: usize,
+    lines: &[&str],
+    dry_run: bool,
+    session_total: usize,
+) -> Result<PathBuf> {
+    assert!(
+        !base_stem.is_empty(),
+        "split_file_write_session: base_stem must not be empty"
+    );
+    assert!(
+        !lines.is_empty(),
+        "split_file_write_session: lines must not be empty"
+    );
+
+    let ts_part = split_file_extract_timestamps(lines)
+        .map_or_else(|| format!("part{session_idx:02}"), |(start, _end)| start);
+    let subject = extract_subject(lines);
+
+    // Truncate subject to keep the assembled filename within the POSIX byte limit.
+    // base_stem and ts_part are always ASCII after sanitization, so their byte
+    // lengths equal their char counts. Overhead: "__" (2) + "_" (1) + ".txt" (4).
+    let subject_byte_cap = FILENAME_BYTE_LIMIT
+        .saturating_sub(base_stem.len())
+        .saturating_sub(ts_part.len())
+        .saturating_sub(7);
+    assert!(
+        subject_byte_cap > 0,
+        "split_file_write_session: base_stem + ts_part overhead already exceeds filesystem limit"
+    );
+    let subject = split_file_write_session_cap_subject(subject, subject_byte_cap);
+
+    let name = format!("{base_stem}__{ts_part}_{subject}.txt");
+    let name = SANITIZE_RE.replace_all(&name, "_");
+    let name = MULTI_UNDERSCORE_RE.replace_all(&name, "_");
+    let out_path = output_dir.join(name.as_ref());
+
+    if dry_run {
+        println!(
+            "    [{session_idx}/{session_total}] {}  ({} lines)",
+            out_path.file_name().unwrap_or_default().to_string_lossy(),
+            lines.len()
+        );
+    } else {
+        fs::write(&out_path, lines.join("\n"))?;
+        println!(
+            "    + {}  ({} lines)",
+            out_path.file_name().unwrap_or_default().to_string_lossy(),
+            lines.len()
+        );
+    }
+
+    Ok(out_path)
+}
+
 /// Process a single mega-file: split it into per-session files and return the number written.
-// Sequential write loop with per-boundary state: file I/O, timestamp extraction, subject
-// extraction, dry-run branching, and backup rename — each step distinct but not extractable
-// without splitting across unrelated concerns.
-#[allow(clippy::too_many_lines)]
 fn split_file(path: &Path, output_dir: &Path, dry_run: bool) -> Result<usize> {
-    // These are operating conditions (filesystem state can change between scan and
-    // call), not programmer invariants — return Err rather than panic.
+    // Operating conditions (TOCTOU): return Err, not panic.
     if !path.is_file() {
         return Err(crate::error::Error::Other(format!(
             "split_file: '{}' is not an existing file",
@@ -225,15 +347,15 @@ fn split_file(path: &Path, output_dir: &Path, dry_run: bool) -> Result<usize> {
         .take(40)
         .collect::<String>();
     let src_stem = SANITIZE_RE.replace_all(&src_stem, "_");
+    let session_total = boundaries.len() - 1;
 
     println!(
-        "\n  {}  ({} sessions)",
+        "\n  {}  ({session_total} sessions)",
         path.file_name().unwrap_or_default().to_string_lossy(),
-        boundaries.len() - 1
     );
 
     let mut written = 0usize;
-    for i in 0..boundaries.len() - 1 {
+    for i in 0..session_total {
         let start = boundaries[i];
         let end = boundaries[i + 1];
         let chunk: Vec<&str> = lines[start..end].to_vec();
@@ -242,62 +364,7 @@ fn split_file(path: &Path, output_dir: &Path, dry_run: bool) -> Result<usize> {
             continue;
         }
 
-        let ts_part = extract_timestamp(&chunk).unwrap_or_else(|| format!("part{:02}", i + 1));
-        let subject = extract_subject(&chunk);
-
-        // Truncate subject to keep the assembled filename within the POSIX byte limit.
-        // src_stem and ts_part are always ASCII after sanitization, so their byte
-        // lengths equal their char counts. Overhead: "__" (2) + "_" (1) + ".txt" (4).
-        let subject_byte_cap = FILENAME_BYTE_LIMIT
-            .saturating_sub(src_stem.len())
-            .saturating_sub(ts_part.len())
-            .saturating_sub(7);
-        assert!(
-            subject_byte_cap > 0,
-            "split_file: src_stem + ts_part overhead already exceeds filesystem limit"
-        );
-        let subject: String = if subject.len() <= subject_byte_cap {
-            subject
-        } else {
-            // Accumulate chars only while the byte budget allows, preserving UTF-8
-            // boundaries that byte-slicing would straddle.
-            let mut byte_count = 0usize;
-            subject
-                .chars()
-                .take_while(|&character| {
-                    byte_count += character.len_utf8();
-                    byte_count <= subject_byte_cap
-                })
-                .collect()
-        };
-        debug_assert!(
-            subject.len() <= subject_byte_cap,
-            "subject byte length {len} exceeds cap {subject_byte_cap}",
-            len = subject.len()
-        );
-
-        let name = format!("{src_stem}__{ts_part}_{subject}.txt");
-        let name = SANITIZE_RE.replace_all(&name, "_");
-        let name = MULTI_UNDERSCORE_RE.replace_all(&name, "_");
-
-        let out_path = output_dir.join(name.as_ref());
-
-        if dry_run {
-            println!(
-                "    [{}/{}] {}  ({} lines)",
-                i + 1,
-                boundaries.len() - 1,
-                out_path.file_name().unwrap_or_default().to_string_lossy(),
-                chunk.len()
-            );
-        } else {
-            fs::write(&out_path, chunk.join("\n"))?;
-            println!(
-                "    + {}  ({} lines)",
-                out_path.file_name().unwrap_or_default().to_string_lossy(),
-                chunk.len()
-            );
-        }
+        split_file_write_session(output_dir, &src_stem, i + 1, &chunk, dry_run, session_total)?;
         written += 1;
     }
 
@@ -313,10 +380,82 @@ fn split_file(path: &Path, output_dir: &Path, dry_run: bool) -> Result<usize> {
     Ok(written)
 }
 
+/// Collect all `.txt` mega-files from `directory` that meet `sessions_min`.
+///
+/// Returns a sorted vec of `(path, session_count)` pairs. Files exceeding the
+/// size limit are printed and skipped. The `respect_gitignore` flag is forwarded
+/// to `split_collect_txt_files`.
+fn run_collect_files(
+    directory: &Path,
+    sessions_min: usize,
+    respect_gitignore: bool,
+) -> Result<Vec<(PathBuf, usize)>> {
+    assert!(
+        directory.is_dir(),
+        "run_collect_files: caller must pass a valid directory"
+    );
+    assert!(
+        sessions_min >= 2,
+        "run_collect_files: sessions_min must be at least 2"
+    );
+
+    let mut mega_files: Vec<(PathBuf, usize)> = Vec::new();
+
+    for path in split_collect_txt_files(directory, respect_gitignore)? {
+        if fs::metadata(&path).is_ok_and(|m| m.len() > SPLIT_FILE_SIZE_MAX) {
+            println!("  SKIP: {} exceeds 500 MB limit", path.display());
+            continue;
+        }
+        let content = fs::read_to_string(&path).map_err(|e| {
+            crate::error::Error::Other(format!("failed to read {}: {e}", path.display()))
+        })?;
+        let lines: Vec<&str> = content.lines().collect();
+        let boundaries = find_session_boundaries(&lines);
+        if boundaries.len() >= sessions_min {
+            mega_files.push((path, boundaries.len()));
+        }
+    }
+
+    mega_files.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(mega_files)
+}
+
+/// Resolve the output directory for one file and delegate to `split_file`.
+///
+/// When `output_dir` is `None`, falls back to the file's parent directory and
+/// validates it per-iteration — different files may have different parents.
+/// Returns the number of session files written (or zero for dry run count).
+fn run_process_file(
+    path: &Path,
+    output_dir: Option<&Path>,
+    directory: &Path,
+    dry_run: bool,
+) -> Result<usize> {
+    assert!(
+        path.is_file(),
+        "run_process_file: path must be an existing file"
+    );
+
+    // When output_dir was provided it is already validated by the caller; skip the
+    // redundant is_dir call. When falling back to the file's parent we must validate
+    // per-iteration because different files can have different parents.
+    let output_directory = if let Some(explicit_output_directory) = output_dir {
+        explicit_output_directory
+    } else {
+        let file_directory = path.parent().unwrap_or(directory);
+        if !file_directory.is_dir() {
+            return Err(crate::error::Error::Other(format!(
+                "split: output directory not found or not a directory: {}",
+                file_directory.display()
+            )));
+        }
+        file_directory
+    };
+
+    split_file(path, output_directory, dry_run)
+}
+
 /// Split mega-files in a directory into per-session files.
-// Scan loop, output-dir validation, per-file splitting, and dry-run summary
-// are each a distinct step with branching that cannot be cleanly extracted.
-#[allow(clippy::too_many_lines)]
 pub fn run(
     directory: &Path,
     output_dir: Option<&Path>,
@@ -335,22 +474,8 @@ pub fn run(
             "split: sessions_min must be at least 2".to_string(),
         ));
     }
-    let mut mega_files: Vec<(PathBuf, usize)> = Vec::new();
 
-    for path in split_collect_txt_files(directory, respect_gitignore)? {
-        if fs::metadata(&path).is_ok_and(|m| m.len() > SPLIT_FILE_SIZE_MAX) {
-            println!("  SKIP: {} exceeds 500 MB limit", path.display());
-            continue;
-        }
-        let content = fs::read_to_string(&path).map_err(|e| {
-            crate::error::Error::Other(format!("failed to read {}: {e}", path.display()))
-        })?;
-        let lines: Vec<&str> = content.lines().collect();
-        let boundaries = find_session_boundaries(&lines);
-        if boundaries.len() >= sessions_min {
-            mega_files.push((path, boundaries.len()));
-        }
-    }
+    let mega_files = run_collect_files(directory, sessions_min, respect_gitignore)?;
 
     // Validate an explicit output directory up front. Without this, a caller that
     // provides --output-dir /nonexistent would silently receive Ok(()) when no
@@ -372,29 +497,11 @@ pub fn run(
         return Ok(());
     }
 
-    mega_files.sort_by(|a, b| a.0.cmp(&b.0));
-
     println!("Found {} mega-files to split:", mega_files.len());
 
     let mut written_total = 0usize;
-
     for (path, _n_sessions) in &mega_files {
-        // When output_dir was provided it is already validated above; skip the
-        // redundant is_dir call.  When falling back to the file's parent we must
-        // validate per-iteration because different files can have different parents.
-        let output_directory = if let Some(explicit_output_directory) = output_dir {
-            explicit_output_directory
-        } else {
-            let file_directory = path.parent().unwrap_or(directory);
-            if !file_directory.is_dir() {
-                return Err(crate::error::Error::Other(format!(
-                    "split: output directory not found or not a directory: {}",
-                    file_directory.display()
-                )));
-            }
-            file_directory
-        };
-        written_total += split_file(path, output_directory, dry_run)?;
+        written_total += run_process_file(path, output_dir, directory, dry_run)?;
     }
 
     println!();

--- a/src/cli/split.rs
+++ b/src/cli/split.rs
@@ -921,6 +921,141 @@ mod tests {
     }
 
     #[test]
+    fn split_collect_txt_files_non_dir_returns_error() {
+        // A non-directory path must return Err rather than panic.
+        let result =
+            split_collect_txt_files(std::path::Path::new("/nonexistent/path/to/no_dir"), false);
+        assert!(result.is_err(), "non-directory path must return Err");
+        assert!(
+            result
+                .err()
+                .is_some_and(|error| error.to_string().contains("not an existing directory")),
+            "error message must mention 'not an existing directory'"
+        );
+    }
+
+    #[test]
+    fn split_file_non_dir_output_dir_returns_error() {
+        // Passing a non-directory as output_dir must return Err.
+        let temp_directory =
+            tempfile::tempdir().expect("failed to create temporary directory for output-dir test");
+        let mega_file_path = temp_directory.path().join("mega.txt");
+        fs::write(&mega_file_path, make_mega_file(3))
+            .expect("failed to write three-session mega file");
+
+        let result = split_file(
+            &mega_file_path,
+            std::path::Path::new("/nonexistent/output"),
+            false,
+        );
+        assert!(
+            result.is_err(),
+            "non-directory output_dir must return Err from split_file"
+        );
+        assert!(
+            result
+                .err()
+                .is_some_and(|error| error.to_string().contains("not an existing directory")),
+            "error message must mention 'not an existing directory'"
+        );
+    }
+
+    #[test]
+    fn split_file_write_session_cap_subject_truncates_long_subject() {
+        // A subject longer than byte_cap must be truncated to fit within the cap.
+        let long_subject = "a".repeat(300);
+        let cap = 50usize;
+        let result = split_file_write_session_cap_subject(long_subject.clone(), cap);
+        assert!(
+            result.len() <= cap,
+            "truncated subject must not exceed byte cap (got {} bytes)",
+            result.len()
+        );
+        assert!(
+            !result.is_empty(),
+            "truncated subject must not be empty when input is non-empty"
+        );
+        assert!(
+            long_subject.starts_with(&result),
+            "truncated subject must be a prefix of the original"
+        );
+    }
+
+    #[test]
+    fn split_file_write_session_cap_subject_short_subject_unchanged() {
+        // A subject that fits within byte_cap must be returned unchanged.
+        let short = "hello_world".to_string();
+        let cap = 100usize;
+        let result = split_file_write_session_cap_subject(short.clone(), cap);
+        assert_eq!(
+            result, short,
+            "subject within cap must be returned unchanged"
+        );
+        assert!(result.len() <= cap, "result must not exceed cap");
+    }
+
+    #[test]
+    fn split_file_extract_timestamps_with_valid_timestamp() {
+        // Lines containing a valid timestamp must produce Some with non-empty strings.
+        let lines = &[
+            "╭──── Claude Code v1.0.0",
+            "⏺ 2:30 PM Monday, January 15, 2025",
+            "some content line here",
+        ];
+        let result = split_file_extract_timestamps(lines);
+        assert!(
+            result.is_some(),
+            "lines with a valid timestamp must produce Some"
+        );
+        let (start, end) = result.expect("timestamp must be parseable");
+        assert!(!start.is_empty(), "start timestamp must not be empty");
+        assert!(!end.is_empty(), "end timestamp must not be empty");
+        assert!(
+            start.contains("2025"),
+            "start timestamp must include the year 2025"
+        );
+    }
+
+    #[test]
+    fn run_non_dry_run_writes_and_renames_mega_file() {
+        // run with dry_run=false must write session files and rename the original.
+        let temp_directory =
+            tempfile::tempdir().expect("failed to create temporary directory for non-dry-run test");
+        let mega_file_path = temp_directory.path().join("mega.txt");
+        fs::write(&mega_file_path, make_mega_file(3))
+            .expect("failed to write three-session mega file for non-dry-run test");
+        let output_directory =
+            tempfile::tempdir().expect("failed to create output directory for non-dry-run test");
+
+        run(
+            temp_directory.path(),
+            Some(output_directory.path()),
+            false, // non-dry-run: must write files
+            2,
+            false,
+        )
+        .expect("non-dry-run with qualifying mega file must succeed");
+
+        // Original must be renamed to .mega_backup.
+        assert!(
+            !mega_file_path.exists(),
+            "original mega file must be renamed away after non-dry-run split"
+        );
+        assert!(
+            mega_file_path.with_extension("mega_backup").exists(),
+            "backup file must exist at .mega_backup extension"
+        );
+        // Output directory must contain session files.
+        let output_count = fs::read_dir(output_directory.path())
+            .expect("failed to read output directory after non-dry-run split")
+            .count();
+        assert!(
+            output_count >= 2,
+            "non-dry-run must write at least two session files (got {output_count})"
+        );
+    }
+
+    #[test]
     fn split_collect_txt_files_respect_gitignore_filters_and_caps_depth() {
         // Verify that when respect_gitignore=true, .gitignore-excluded files are
         // omitted and nested files beyond depth=1 are excluded.

--- a/src/cli/split.rs
+++ b/src/cli/split.rs
@@ -102,7 +102,7 @@ static MULTI_UNDERSCORE_RE: LazyLock<Regex> = LazyLock::new(|| {
         .expect("multi-underscore regex is a compile-time literal and cannot fail to compile")
 });
 
-const MAX_SPLIT_FILE_SIZE: u64 = 500 * 1024 * 1024; // 500 MB safety limit
+const SPLIT_FILE_SIZE_MAX: u64 = 500 * 1024 * 1024; // 500 MB safety limit
 /// POSIX filename byte limit; used to compute the subject byte budget in `split_file`.
 const FILENAME_BYTE_LIMIT: usize = 255;
 
@@ -201,7 +201,7 @@ fn split_file(path: &Path, output_dir: &Path, dry_run: bool) -> Result<usize> {
             output_dir.display()
         )));
     }
-    if fs::metadata(path).is_ok_and(|m| m.len() > MAX_SPLIT_FILE_SIZE) {
+    if fs::metadata(path).is_ok_and(|m| m.len() > SPLIT_FILE_SIZE_MAX) {
         println!("  SKIP: {} exceeds 500 MB limit", path.display());
         return Ok(0);
     }
@@ -321,7 +321,7 @@ pub fn run(
     directory: &Path,
     output_dir: Option<&Path>,
     dry_run: bool,
-    min_sessions: usize,
+    sessions_min: usize,
     respect_gitignore: bool,
 ) -> Result<()> {
     if !directory.is_dir() {
@@ -330,15 +330,15 @@ pub fn run(
             directory.display()
         )));
     }
-    if min_sessions < 2 {
+    if sessions_min < 2 {
         return Err(crate::error::Error::Other(
-            "split: min_sessions must be at least 2".to_string(),
+            "split: sessions_min must be at least 2".to_string(),
         ));
     }
     let mut mega_files: Vec<(PathBuf, usize)> = Vec::new();
 
     for path in split_collect_txt_files(directory, respect_gitignore)? {
-        if fs::metadata(&path).is_ok_and(|m| m.len() > MAX_SPLIT_FILE_SIZE) {
+        if fs::metadata(&path).is_ok_and(|m| m.len() > SPLIT_FILE_SIZE_MAX) {
             println!("  SKIP: {} exceeds 500 MB limit", path.display());
             continue;
         }
@@ -347,7 +347,7 @@ pub fn run(
         })?;
         let lines: Vec<&str> = content.lines().collect();
         let boundaries = find_session_boundaries(&lines);
-        if boundaries.len() >= min_sessions {
+        if boundaries.len() >= sessions_min {
             mega_files.push((path, boundaries.len()));
         }
     }
@@ -366,7 +366,7 @@ pub fn run(
 
     if mega_files.is_empty() {
         println!(
-            "No mega-files found in {} (min {min_sessions} sessions).",
+            "No mega-files found in {} (min {sessions_min} sessions).",
             directory.display()
         );
         return Ok(());
@@ -376,7 +376,7 @@ pub fn run(
 
     println!("Found {} mega-files to split:", mega_files.len());
 
-    let mut total_written = 0usize;
+    let mut written_total = 0usize;
 
     for (path, _n_sessions) in &mega_files {
         // When output_dir was provided it is already validated above; skip the
@@ -394,18 +394,18 @@ pub fn run(
             }
             file_directory
         };
-        total_written += split_file(path, output_directory, dry_run)?;
+        written_total += split_file(path, output_directory, dry_run)?;
     }
 
     println!();
     if dry_run {
         println!(
-            "Dry run: would create {total_written} files from {} mega-files",
+            "Dry run: would create {written_total} files from {} mega-files",
             mega_files.len()
         );
     } else {
         println!(
-            "Done: created {total_written} files from {} mega-files",
+            "Done: created {written_total} files from {} mega-files",
             mega_files.len()
         );
     }
@@ -703,17 +703,17 @@ mod tests {
     // --- run ---
 
     #[test]
-    fn run_min_sessions_below_two_returns_error() {
-        // min_sessions=1 must be rejected immediately — callers must require at least two.
+    fn run_sessions_min_below_two_returns_error() {
+        // sessions_min=1 must be rejected immediately — callers must require at least two.
         let temp_directory = tempfile::tempdir()
-            .expect("failed to create temporary directory for min_sessions test");
+            .expect("failed to create temporary directory for sessions_min test");
         let result = run(temp_directory.path(), None, false, 1, false);
-        assert!(result.is_err(), "min_sessions < 2 must return Err");
+        assert!(result.is_err(), "sessions_min < 2 must return Err");
         assert!(
             result
                 .err()
-                .is_some_and(|error| error.to_string().contains("min_sessions")),
-            "error message must mention min_sessions"
+                .is_some_and(|error| error.to_string().contains("sessions_min")),
+            "error message must mention sessions_min"
         );
     }
 
@@ -738,10 +738,10 @@ mod tests {
 
     #[test]
     fn run_no_mega_files_returns_ok() {
-        // A directory with no .txt files meeting min_sessions must return Ok with no output.
+        // A directory with no .txt files meeting sessions_min must return Ok with no output.
         let temp_directory = tempfile::tempdir()
             .expect("failed to create temporary directory for no-mega-files test");
-        // One .txt file but only one session — does not meet min_sessions=2.
+        // One .txt file but only one session — does not meet sessions_min=2.
         fs::write(temp_directory.path().join("single.txt"), make_mega_file(1))
             .expect("failed to write single-session test file");
 

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -16,12 +16,12 @@ async fn run_print_wings(connection: &Connection) -> Result<()> {
         let wing = row
             .get_value(0)
             .ok()
-            .and_then(|v| v.as_text().cloned())
+            .and_then(|cell| cell.as_text().cloned())
             .unwrap_or_default();
         let count = row
             .get_value(1)
             .ok()
-            .and_then(|v| v.as_integer().copied())
+            .and_then(|cell| cell.as_integer().copied())
             .unwrap_or(0);
         println!("  {wing}: {count} drawers");
     }
@@ -42,17 +42,17 @@ async fn run_print_rooms(connection: &Connection) -> Result<()> {
         let wing = row
             .get_value(0)
             .ok()
-            .and_then(|v| v.as_text().cloned())
+            .and_then(|cell| cell.as_text().cloned())
             .unwrap_or_default();
         let room = row
             .get_value(1)
             .ok()
-            .and_then(|v| v.as_text().cloned())
+            .and_then(|cell| cell.as_text().cloned())
             .unwrap_or_default();
         let count = row
             .get_value(2)
             .ok()
-            .and_then(|v| v.as_integer().copied())
+            .and_then(|cell| cell.as_integer().copied())
             .unwrap_or(0);
 
         if wing != current_wing {
@@ -68,15 +68,15 @@ async fn run_print_kg(connection: &Connection) -> Result<()> {
     let entity_rows = db::query_all(connection, "SELECT COUNT(*) FROM entities", ()).await?;
     let entity_count: i64 = entity_rows
         .first()
-        .and_then(|r| r.get_value(0).ok())
-        .and_then(|v| v.as_integer().copied())
+        .and_then(|row| row.get_value(0).ok())
+        .and_then(|cell| cell.as_integer().copied())
         .unwrap_or(0);
 
     let triple_rows = db::query_all(connection, "SELECT COUNT(*) FROM triples", ()).await?;
     let triple_count: i64 = triple_rows
         .first()
-        .and_then(|r| r.get_value(0).ok())
-        .and_then(|v| v.as_integer().copied())
+        .and_then(|row| row.get_value(0).ok())
+        .and_then(|cell| cell.as_integer().copied())
         .unwrap_or(0);
 
     if entity_count > 0 || triple_count > 0 {
@@ -91,8 +91,8 @@ pub async fn run(connection: &Connection) -> Result<()> {
     let rows = db::query_all(connection, "SELECT COUNT(*) FROM drawers", ()).await?;
     let total: i64 = rows
         .first()
-        .and_then(|r| r.get_value(0).ok())
-        .and_then(|v| v.as_integer().copied())
+        .and_then(|row| row.get_value(0).ok())
+        .and_then(|cell| cell.as_integer().copied())
         .unwrap_or(0);
 
     if total == 0 {

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -37,7 +37,7 @@ async fn run_print_rooms(connection: &Connection) -> Result<()> {
     .await?;
 
     println!("\nRooms:");
-    let mut current_wing = String::new();
+    let mut wing_current = String::new();
     for row in &rows {
         let wing = row
             .get_value(0)
@@ -55,9 +55,9 @@ async fn run_print_rooms(connection: &Connection) -> Result<()> {
             .and_then(|cell| cell.as_integer().copied())
             .unwrap_or(0);
 
-        if wing != current_wing {
+        if wing != wing_current {
             println!("  [{wing}]");
-            current_wing = wing;
+            wing_current = wing;
         }
         println!("    {room}: {count}");
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -249,8 +249,8 @@ fn maybe_migrate_inner(source: &Path, destination: &Path) -> Result<()> {
     let source_config = source.join("config.json");
     if source_config.exists() {
         let legacy_db = source.join("palace.db");
-        let new_db = destination.join("palace.db");
-        maybe_migrate_patch_config(&source_config, &legacy_db, &new_db)?;
+        let database_new = destination.join("palace.db");
+        maybe_migrate_patch_config(&source_config, &legacy_db, &database_new)?;
         maybe_migrate_move_file(&source_config, &destination.join("config.json"))?;
     }
 
@@ -317,9 +317,13 @@ fn maybe_migrate_move_file(source: &Path, destination: &Path) -> Result<()> {
 }
 
 /// Update `palace_path` in config.json if it still points to the legacy DB location.
-fn maybe_migrate_patch_config(config_path: &Path, legacy_db: &Path, new_db: &Path) -> Result<()> {
+fn maybe_migrate_patch_config(
+    config_path: &Path,
+    legacy_db: &Path,
+    database_new: &Path,
+) -> Result<()> {
     assert!(config_path.exists());
-    assert_ne!(legacy_db, new_db);
+    assert_ne!(legacy_db, database_new);
 
     let data = std::fs::read_to_string(config_path)?;
     let mut config: MempalaceConfig = match serde_json::from_str(&data) {
@@ -329,13 +333,13 @@ fn maybe_migrate_patch_config(config_path: &Path, legacy_db: &Path, new_db: &Pat
     };
 
     if config.palace_path == legacy_db {
-        config.palace_path = new_db.to_path_buf();
+        config.palace_path = database_new.to_path_buf();
         let patched = serde_json::to_string_pretty(&config)?;
         std::fs::write(config_path, &patched)?;
         // Pair assertion: patched value must round-trip correctly.
         debug_assert!(
             serde_json::from_str::<MempalaceConfig>(&patched)
-                .is_ok_and(|c| c.palace_path.as_path() == new_db)
+                .is_ok_and(|c| c.palace_path.as_path() == database_new)
         );
     }
 
@@ -664,7 +668,7 @@ mod tests {
                 maybe_migrate().expect("migration should succeed");
 
                 let destination = home.path().join(".local").join("share").join("mempalace");
-                let new_db = destination.join("palace.db");
+                let database_new = destination.join("palace.db");
 
                 let data = std::fs::read_to_string(destination.join("config.json"))
                     .expect("read migrated config.json");
@@ -672,7 +676,7 @@ mod tests {
                     serde_json::from_str(&data).expect("parse migrated config.json");
 
                 // palace_path must now point to the XDG location, not the legacy one.
-                assert_eq!(config.palace_path, new_db);
+                assert_eq!(config.palace_path, database_new);
                 assert!(!config.palace_path.to_string_lossy().contains(".mempalace"));
             },
         );
@@ -966,9 +970,9 @@ mod tests {
         std::fs::write(&config_path, "not valid json {{{{")
             .expect("failed to write corrupted config.json for test");
         let legacy_db = std::path::Path::new("/old/palace.db");
-        let new_db = std::path::Path::new("/new/palace.db");
+        let database_new = std::path::Path::new("/new/palace.db");
 
-        let result = maybe_migrate_patch_config(&config_path, legacy_db, new_db);
+        let result = maybe_migrate_patch_config(&config_path, legacy_db, database_new);
 
         // Corrupted JSON must be left unchanged (Ok returned, not Err).
         assert!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -54,11 +54,11 @@ pub fn config_dir() -> PathBuf {
 ///
 /// A relative or empty `$XDG_DATA_HOME` is treated as unset, per XDG spec intent.
 fn xdg_data_dir() -> PathBuf {
-    let base_directory = if let Ok(val) = std::env::var("XDG_DATA_HOME")
-        && !val.is_empty()
-        && PathBuf::from(&val).is_absolute()
+    let base_directory = if let Ok(xdg_data_home) = std::env::var("XDG_DATA_HOME")
+        && !xdg_data_home.is_empty()
+        && PathBuf::from(&xdg_data_home).is_absolute()
     {
-        PathBuf::from(val)
+        PathBuf::from(xdg_data_home)
     } else {
         home_dir().join(".local").join("share")
     };
@@ -173,8 +173,8 @@ impl Default for MempalaceConfig {
 /// or `MEMPALACE_DIR` is set.
 fn maybe_migrate() -> Result<()> {
     // MEMPALACE_DIR means the caller manages paths — skip migration entirely.
-    if let Ok(val) = std::env::var("MEMPALACE_DIR")
-        && !val.is_empty()
+    if let Ok(mempalace_dir) = std::env::var("MEMPALACE_DIR")
+        && !mempalace_dir.is_empty()
     {
         return Ok(());
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1006,7 +1006,7 @@ rooms:
         assert_eq!(config.rooms[0].name, "backend");
         assert!(config.rooms[0].keywords.contains(&"api".to_string()));
 
-        // Serialize back and deserialize to verify round-trip
+        // Serialize back and deserialize to verify round-trip.
         let serialized = serde_yaml::to_string(&config).expect("serialize yaml");
         let config_roundtrip: ProjectConfig =
             serde_yaml::from_str(&serialized).expect("parse roundtrip yaml");

--- a/src/db.rs
+++ b/src/db.rs
@@ -2,6 +2,10 @@
 
 use std::time::Duration;
 
+/// Generous upper bound on rows drained from a query result; prevents unbounded
+/// iteration when no explicit SQL LIMIT is present (e.g. PRAGMA responses).
+const ROWS_MAX: usize = 100_000;
+
 use turso::{Builder, Connection, Database};
 
 use crate::error::Result;
@@ -30,7 +34,14 @@ pub async fn open_db(path: &str) -> Result<(Database, Connection)> {
     if !is_in_memory {
         let mut wal_rows = connection.query("PRAGMA journal_mode=WAL", ()).await?;
         // Upper bound: PRAGMA journal_mode returns exactly one row; drain it.
-        while wal_rows.next().await?.is_some() {}
+        let mut wal_row_count: usize = 0;
+        while wal_rows.next().await?.is_some() {
+            wal_row_count += 1;
+            assert!(
+                wal_row_count <= ROWS_MAX,
+                "open_db: exceeded ROWS_MAX ({ROWS_MAX}) rows draining WAL pragma result"
+            );
+        }
     }
 
     // Allow waiting up to 5 seconds for write locks when another process is
@@ -57,7 +68,13 @@ pub async fn query_all(
 
     let mut rows = connection.query(sql, params).await?;
     let mut results = Vec::new();
+    let mut row_count: usize = 0;
     while let Some(row) = rows.next().await? {
+        row_count += 1;
+        assert!(
+            row_count <= ROWS_MAX,
+            "query_all: exceeded ROWS_MAX ({ROWS_MAX}) rows — add a SQL LIMIT to the calling query"
+        );
         results.push(row);
     }
     Ok(results)

--- a/src/db.rs
+++ b/src/db.rs
@@ -17,11 +17,11 @@ use crate::error::Result;
 pub async fn open_db(path: &str) -> Result<(Database, Connection)> {
     assert!(!path.is_empty(), "database path must not be empty");
 
-    let db = Builder::new_local(path)
+    let database = Builder::new_local(path)
         .experimental_triggers(true)
         .build()
         .await?;
-    let connection = db.connect()?;
+    let connection = database.connect()?;
 
     // Only enable WAL for file-backed databases; in-memory DBs do not support it.
     let is_in_memory = path == ":memory:"
@@ -44,7 +44,7 @@ pub async fn open_db(path: &str) -> Result<(Database, Connection)> {
         "connection must be usable after open"
     );
 
-    Ok((db, connection))
+    Ok((database, connection))
 }
 
 /// Collect all rows from a query into a Vec.
@@ -77,34 +77,39 @@ mod tests {
             .to_str()
             .expect("tempdir path should be valid UTF-8");
 
-        let (_db, conn) = open_db(path_str)
+        let (_database, connection) = open_db(path_str)
             .await
             .expect("open_db should succeed for a fresh file path");
 
         // Verify the connection is usable by running a trivial query.
-        let rows = query_all(&conn, "SELECT 42 AS answer", ())
+        let rows = query_all(&connection, "SELECT 42 AS answer", ())
             .await
             .expect("trivial SELECT should succeed on newly opened connection");
         assert_eq!(rows.len(), 1, "SELECT 42 should return exactly 1 row");
-        let val: i64 = rows[0].get(0).expect("column 0 should be readable as i64");
-        assert_eq!(val, 42);
+        let answer: i64 = rows[0].get(0).expect("column 0 should be readable as i64");
+        assert_eq!(answer, 42);
     }
 
     #[tokio::test]
     async fn query_all_returns_rows() {
-        let (_db, conn) = crate::test_helpers::test_db().await;
+        let (_database, connection) = crate::test_helpers::test_db().await;
 
         // Insert a row into the drawers table (schema is already applied).
-        conn.execute(
-            "INSERT INTO drawers (id, wing, room, content) VALUES ('d1', 'w', 'r', 'hello')",
+        connection
+            .execute(
+                "INSERT INTO drawers (id, wing, room, content) VALUES ('d1', 'w', 'r', 'hello')",
+                (),
+            )
+            .await
+            .expect("INSERT into drawers should succeed");
+
+        let rows = query_all(
+            &connection,
+            "SELECT id, content FROM drawers WHERE id = 'd1'",
             (),
         )
         .await
-        .expect("INSERT into drawers should succeed");
-
-        let rows = query_all(&conn, "SELECT id, content FROM drawers WHERE id = 'd1'", ())
-            .await
-            .expect("SELECT from drawers should succeed after insert");
+        .expect("SELECT from drawers should succeed after insert");
         assert_eq!(rows.len(), 1, "should find exactly the inserted row");
         let id: String = rows[0]
             .get(0)
@@ -114,10 +119,10 @@ mod tests {
 
     #[tokio::test]
     async fn query_all_empty_result() {
-        let (_db, conn) = crate::test_helpers::test_db().await;
+        let (_database, connection) = crate::test_helpers::test_db().await;
 
         let rows = query_all(
-            &conn,
+            &connection,
             "SELECT id FROM drawers WHERE wing = 'nonexistent'",
             (),
         )

--- a/src/dialect/emotions.rs
+++ b/src/dialect/emotions.rs
@@ -1,9 +1,10 @@
 //! Emotion and flag signal mappings for AAAK dialect detection.
 
+#[cfg(test)]
 use std::collections::HashMap;
 
 /// Full emotion vocabulary: maps long-form names (e.g. `"vulnerability"`) to short codes (e.g. `"vul"`).
-#[allow(dead_code)]
+#[cfg(test)]
 pub fn emotion_codes() -> HashMap<&'static str, &'static str> {
     HashMap::from([
         ("vulnerability", "vul"),

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -3,6 +3,9 @@
 pub mod emotions;
 pub mod topics;
 
+/// UTF-8 code points are at most 4 bytes, so a char-boundary snap never takes more than 3 steps.
+const CHAR_BOUNDARY_SNAP_MAX: usize = 4;
+
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::LazyLock;
@@ -140,7 +143,13 @@ fn extract_key_sentence(text: &str) -> String {
 
     if best.len() > 55 {
         let mut end = 52;
+        let mut snap_steps: usize = 0;
         while end < best.len() && !best.is_char_boundary(end) {
+            snap_steps += 1;
+            assert!(
+                snap_steps < CHAR_BOUNDARY_SNAP_MAX,
+                "extract_key_sentence: exceeded CHAR_BOUNDARY_SNAP_MAX ({CHAR_BOUNDARY_SNAP_MAX}) snap steps"
+            );
             end += 1;
         }
         format!("{}...", &best[..end])

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -12,16 +12,18 @@ use regex::Regex;
 use emotions::{emotion_signals, flag_signals};
 use topics::{extract_topics, stop_words};
 
+// Regex literal is a compile-time constant; cannot fail to compile.
 #[allow(clippy::expect_used)]
-// Splits text into sentences on punctuation or newlines.
 static SENTENCE_SPLIT_RE: LazyLock<Regex> = LazyLock::new(|| {
+    // Splits text into sentences on punctuation or newlines.
     Regex::new(r"[.!?\n]+")
         .expect("sentence-split regex is a compile-time literal and cannot fail to compile")
 });
 
+// Regex literal is a compile-time constant; cannot fail to compile.
 #[allow(clippy::expect_used)]
-// Strips non-alphabetic characters when extracting entity codes from words.
 static NON_ALPHA_RE: LazyLock<Regex> = LazyLock::new(|| {
+    // Strips non-alphabetic characters when extracting entity codes from words.
     Regex::new(r"[^a-zA-Z]")
         .expect("non-alpha strip regex is a compile-time literal and cannot fail to compile")
 });
@@ -30,8 +32,6 @@ static NON_ALPHA_RE: LazyLock<Regex> = LazyLock::new(|| {
 pub struct Dialect {
     /// Known entity name → short code mappings.
     entity_codes: HashMap<String, String>,
-    #[allow(dead_code)]
-    skip_names: Vec<String>,
 }
 
 /// Optional metadata attached to the AAAK header line.
@@ -150,22 +150,18 @@ fn extract_key_sentence(text: &str) -> String {
 }
 
 impl Dialect {
-    pub fn new(entities: &HashMap<String, String>, skip_names: Vec<String>) -> Self {
+    pub fn new(entities: &HashMap<String, String>) -> Self {
         let mut entity_codes = HashMap::new();
         for (name, code) in entities {
             entity_codes.insert(name.clone(), code.clone());
             entity_codes.insert(name.to_lowercase(), code.clone());
         }
-        Self {
-            entity_codes,
-            skip_names: skip_names.into_iter().map(|n| n.to_lowercase()).collect(),
-        }
+        Self { entity_codes }
     }
 
     pub fn empty() -> Self {
         Self {
             entity_codes: HashMap::new(),
-            skip_names: Vec::new(),
         }
     }
 
@@ -329,7 +325,7 @@ mod tests {
         let mut entities = HashMap::new();
         entities.insert("Alice".to_string(), "ALC".to_string());
         entities.insert("Bob".to_string(), "BOB".to_string());
-        let dialect = Dialect::new(&entities, vec![]);
+        let dialect = Dialect::new(&entities);
         let found = dialect.detect_entities("Alice told Bob about the new architecture");
         assert!(found.contains(&"ALC".to_string()));
         assert!(found.contains(&"BOB".to_string()));

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -84,7 +84,7 @@ fn extract_key_sentence(text: &str) -> String {
     let sentences: Vec<&str> = SENTENCE_SPLIT_RE
         .split(text)
         .map(str::trim)
-        .filter(|s| s.len() > 10)
+        .filter(|sentence| sentence.len() > 10)
         .collect();
 
     if sentences.is_empty() {
@@ -114,24 +114,24 @@ fn extract_key_sentence(text: &str) -> String {
 
     let mut scored: Vec<(i32, &str)> = sentences
         .into_iter()
-        .map(|s| {
-            let s_lower = s.to_lowercase();
+        .map(|sentence| {
+            let sentence_lower = sentence.to_lowercase();
             let mut score: i32 = 0;
             for w in &decision_words {
-                if s_lower.contains(w) {
+                if sentence_lower.contains(w) {
                     score += 2;
                 }
             }
-            if s.len() < 80 {
+            if sentence.len() < 80 {
                 score += 1;
             }
-            if s.len() < 40 {
+            if sentence.len() < 40 {
                 score += 1;
             }
-            if s.len() > 150 {
+            if sentence.len() > 150 {
                 score -= 2;
             }
-            (score, s)
+            (score, sentence)
         })
         .collect();
 
@@ -245,7 +245,7 @@ impl Dialect {
             } else {
                 Path::new(meta.source_file)
                     .file_stem()
-                    .and_then(|s| s.to_str())
+                    .and_then(|stem| stem.to_str())
                     .unwrap_or("?")
             };
             let header = format!(

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -177,7 +177,7 @@ impl Dialect {
         let text_lower = text.to_lowercase();
         let mut found = Vec::new();
 
-        // Check known entities
+        // Check known entities.
         for (name, code) in &self.entity_codes {
             if !name.chars().next().is_some_and(char::is_lowercase)
                 && text_lower.contains(&name.to_lowercase())
@@ -190,7 +190,7 @@ impl Dialect {
             return found;
         }
 
-        // Fallback: capitalized words that look like names
+        // Fallback: capitalized words that look like names.
         let stops = stop_words();
         let words: Vec<&str> = text.split_whitespace().collect();
         for (i, w) in words.iter().enumerate() {
@@ -236,7 +236,7 @@ impl Dialect {
 
         let mut lines = Vec::new();
 
-        // Header line (if metadata available)
+        // Header line (if metadata available).
         if let Some(meta) = metadata
             && (!meta.source_file.is_empty() || !meta.wing.is_empty())
         {
@@ -258,7 +258,7 @@ impl Dialect {
             lines.push(header);
         }
 
-        // Content line
+        // Content line.
         let mut parts = vec![format!("0:{entity_str}"), topic_str];
         if !quote.is_empty() {
             parts.push(format!("\"{quote}\""));

--- a/src/dialect/topics.rs
+++ b/src/dialect/topics.rs
@@ -35,7 +35,7 @@ pub fn extract_topics(text: &str, topics_max: usize) -> Vec<String> {
     let stops = stop_words();
     let words: Vec<&str> = WORD_RE.find_iter(text).map(|m| m.as_str()).collect();
 
-    // Count frequency, skip stop words
+    // Count frequency, skip stop words.
     let mut freq: HashMap<String, i32> = HashMap::new();
     for w in &words {
         let lower = w.to_lowercase();
@@ -45,18 +45,18 @@ pub fn extract_topics(text: &str, topics_max: usize) -> Vec<String> {
         *freq.entry(lower).or_insert(0) += 1;
     }
 
-    // Boost proper nouns and technical terms
+    // Boost proper nouns and technical terms.
     for w in &words {
         let lower = w.to_lowercase();
         if stops.contains(lower.as_str()) {
             continue;
         }
         if let Some(count) = freq.get_mut(&lower) {
-            // Capitalized word (proper noun)
+            // Capitalized word (proper noun).
             if w.chars().next().is_some_and(char::is_uppercase) {
                 *count += 2;
             }
-            // CamelCase, underscore, or hyphen → technical term
+            // CamelCase, underscore, or hyphen → technical term.
             if w.contains('_') || w.contains('-') || w[1..].chars().any(char::is_uppercase) {
                 *count += 2;
             }

--- a/src/dialect/topics.rs
+++ b/src/dialect/topics.rs
@@ -31,7 +31,7 @@ pub fn stop_words() -> HashSet<&'static str> {
 }
 
 /// Extract key topic words from plain text by frequency + proper noun boost.
-pub fn extract_topics(text: &str, max_topics: usize) -> Vec<String> {
+pub fn extract_topics(text: &str, topics_max: usize) -> Vec<String> {
     let stops = stop_words();
     let words: Vec<&str> = WORD_RE.find_iter(text).map(|m| m.as_str()).collect();
 
@@ -67,7 +67,7 @@ pub fn extract_topics(text: &str, max_topics: usize) -> Vec<String> {
     ranked.sort_by_key(|b| std::cmp::Reverse(b.1));
     ranked
         .into_iter()
-        .take(max_topics)
+        .take(topics_max)
         .map(|(w, _)| w)
         .collect()
 }

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -114,7 +114,9 @@ fn extract_memories_score_segment(
     };
 
     // f64 scores come from integer match counts (count as f64); partial_cmp
-    // only returns None for NaN, which cannot arise here.
+    // only returns None for NaN, which cannot arise here. The `?` is
+    // unreachable in practice because scores.is_empty() already returns None
+    // above, but clippy::question_mark requires the idiomatic form.
     let &(type_max, score_max) = scores
         .iter()
         .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))?;

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -45,7 +45,7 @@ pub fn extract_memories(text: &str, min_confidence: f64) -> Vec<Memory> {
         // Lowercase once here so score_markers can skip the allocation on each of its 5 calls.
         let prose_lower = prose.to_lowercase();
 
-        // Score against all types
+        // Score against all types.
         let mut scores: Vec<(&str, f64)> = Vec::new();
         for &(mem_type, markers) in all_markers {
             let score = score_markers(&prose_lower, markers);
@@ -58,7 +58,7 @@ pub fn extract_memories(text: &str, min_confidence: f64) -> Vec<Memory> {
             continue;
         }
 
-        // Length bonus
+        // Length bonus.
         let length_bonus = if para.len() > 500 {
             2.0
         } else if para.len() > 200 {
@@ -78,11 +78,11 @@ pub fn extract_memories(text: &str, min_confidence: f64) -> Vec<Memory> {
         };
         let score_max = score_max + length_bonus;
 
-        // Disambiguate
+        // Disambiguate.
         let scores_by_type: std::collections::HashMap<&str, f64> = scores.iter().copied().collect();
         let final_type = disambiguate(type_max, &prose, &scores_by_type);
 
-        // Confidence
+        // Confidence.
         let confidence = (score_max / 5.0).min(1.0);
         if confidence < min_confidence {
             continue;
@@ -109,7 +109,7 @@ fn score_markers(text: &str, markers: &[Regex]) -> f64 {
     let mut score = 0.0;
     for re in markers {
         let count = re.find_iter(text).count();
-        // Regex match count; always small enough for exact f64 representation
+        // Regex match count; always small enough for exact f64 representation.
         #[allow(clippy::cast_precision_loss)]
         {
             score += count as f64;
@@ -133,7 +133,7 @@ fn disambiguate<'a>(
     let sentiment = get_sentiment(text);
     let has_res = has_resolution(text);
 
-    // Resolved problems are milestones
+    // Resolved problems are milestones.
     if has_res {
         if *scores.get("emotional").unwrap_or(&0.0) > 0.0 && sentiment == "positive" {
             return "emotional";
@@ -141,7 +141,7 @@ fn disambiguate<'a>(
         return "milestone";
     }
 
-    // Problem + positive sentiment => milestone or emotional
+    // Problem + positive sentiment => milestone or emotional.
     if sentiment == "positive" {
         if *scores.get("milestone").unwrap_or(&0.0) > 0.0 {
             return "milestone";
@@ -316,19 +316,19 @@ fn split_into_segments(text: &str) -> Vec<String> {
         })
         .count();
 
-    // If enough turn markers, split by turns
+    // If enough turn markers, split by turns.
     if turn_count >= 3 {
         return split_by_turns(&lines, TURN_REGEXES.as_slice());
     }
 
-    // Fallback: paragraph splitting
+    // Fallback: paragraph splitting.
     let paragraphs: Vec<String> = text
         .split("\n\n")
         .map(|p| p.trim().to_string())
         .filter(|p| !p.is_empty())
         .collect();
 
-    // If single giant block, chunk by line groups
+    // If single giant block, chunk by line groups.
     if paragraphs.len() <= 1 && lines.len() > 20 {
         return lines
             .chunks(25)
@@ -380,7 +380,7 @@ mod tests {
         let text = "The bug was that the database connection was timing out. After investigation, we fixed it by increasing the pool size.";
         let memories = extract_memories(text, 0.1);
         assert!(!memories.is_empty());
-        // Resolved problem should be reclassified as milestone
+        // Resolved problem should be reclassified as milestone.
         assert_eq!(memories[0].kind, "milestone");
     }
 

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -22,11 +22,23 @@ pub struct Memory {
     pub chunk_index: usize,
 }
 
+/// Result of scoring a single segment: the winning memory type and its confidence.
+struct ScoredSegment {
+    /// The winning memory type (e.g. `"decision"`, `"problem"`).
+    memory_type: String,
+    /// Confidence in [0.0, 1.0].
+    confidence: f64,
+}
+
 /// Extract memories from text, classifying into 5 types:
 /// decision, preference, milestone, problem, emotional.
 pub fn extract_memories(text: &str, min_confidence: f64) -> Vec<Memory> {
-    let segments = split_into_segments(text);
-    let mut memories = Vec::new();
+    // Preconditions: text must be non-empty and confidence threshold must be valid.
+    assert!(!text.is_empty(), "extract_memories: text must not be empty");
+    assert!(
+        (0.0..=1.0).contains(&min_confidence),
+        "extract_memories: min_confidence must be in [0.0, 1.0]"
+    );
 
     let all_markers: &[(&str, &[Regex])] = &[
         ("decision", DECISION_REGEXES.as_slice()),
@@ -36,61 +48,25 @@ pub fn extract_memories(text: &str, min_confidence: f64) -> Vec<Memory> {
         ("emotional", EMOTION_REGEXES.as_slice()),
     ];
 
+    let segments = split_into_segments(text);
+    let mut memories = Vec::new();
+
     for para in &segments {
         if para.trim().len() < 20 {
             continue;
         }
 
-        let prose = extract_prose(para);
-        // Lowercase once here so score_markers can skip the allocation on each of its 5 calls.
-        let prose_lower = prose.to_lowercase();
-
-        // Score against all types.
-        let mut scores: Vec<(&str, f64)> = Vec::new();
-        for &(mem_type, markers) in all_markers {
-            let score = score_markers(&prose_lower, markers);
-            if score > 0.0 {
-                scores.push((mem_type, score));
-            }
-        }
-
-        if scores.is_empty() {
-            continue;
-        }
-
-        // Length bonus.
-        let length_bonus = if para.len() > 500 {
-            2.0
-        } else if para.len() > 200 {
-            1.0
-        } else {
-            0.0
-        };
-
-        // f64 scores come from integer match counts (count as f64); partial_cmp
-        // only returns None for NaN, which cannot arise here.
-        let Some(&(type_max, score_max)) = scores
-            .iter()
-            .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
-        else {
-            // Unreachable: scores is non-empty (checked above at `if scores.is_empty()`).
+        let Some(scored) = extract_memories_score_segment(para, all_markers) else {
             continue;
         };
-        let score_max = score_max + length_bonus;
 
-        // Disambiguate.
-        let scores_by_type: std::collections::HashMap<&str, f64> = scores.iter().copied().collect();
-        let final_type = disambiguate(type_max, &prose, &scores_by_type);
-
-        // Confidence.
-        let confidence = (score_max / 5.0).min(1.0);
-        if confidence < min_confidence {
+        if scored.confidence < min_confidence {
             continue;
         }
 
         memories.push(Memory {
             content: para.trim().to_string(),
-            kind: final_type.to_string(),
+            kind: scored.memory_type,
             chunk_index: memories.len(),
         });
     }
@@ -100,6 +76,58 @@ pub fn extract_memories(text: &str, min_confidence: f64) -> Vec<Memory> {
     debug_assert!(memories.iter().all(|m| !m.kind.is_empty()));
 
     memories
+}
+
+/// Score a single segment against all marker types, returning the winning type
+/// and confidence. Returns `None` if no markers match or the segment has no prose.
+fn extract_memories_score_segment(
+    para: &str,
+    all_markers: &[(&str, &[Regex])],
+) -> Option<ScoredSegment> {
+    let prose = extract_prose(para);
+    // Lowercase once here so score_markers can skip the allocation on each of its 5 calls.
+    let prose_lower = prose.to_lowercase();
+
+    // Score against all types.
+    let mut scores: Vec<(&str, f64)> = Vec::new();
+    for &(mem_type, markers) in all_markers {
+        let score = score_markers(&prose_lower, markers);
+        if score > 0.0 {
+            scores.push((mem_type, score));
+        }
+    }
+
+    if scores.is_empty() {
+        return None;
+    }
+
+    // Length bonus.
+    let length_bonus = if para.len() > 500 {
+        2.0
+    } else if para.len() > 200 {
+        1.0
+    } else {
+        0.0
+    };
+
+    // f64 scores come from integer match counts (count as f64); partial_cmp
+    // only returns None for NaN, which cannot arise here.
+    let &(type_max, score_max) = scores
+        .iter()
+        .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))?;
+    let score_max = score_max + length_bonus;
+
+    // Disambiguate.
+    let scores_by_type: std::collections::HashMap<&str, f64> = scores.iter().copied().collect();
+    let final_type = disambiguate(type_max, &prose, &scores_by_type);
+
+    // Confidence: normalise to [0.0, 1.0] with a divisor of 5.0.
+    let confidence = (score_max / 5.0).min(1.0);
+
+    Some(ScoredSegment {
+        memory_type: final_type.to_string(),
+        confidence,
+    })
 }
 
 /// Score pre-lowercased text against pre-compiled regex markers.
@@ -242,6 +270,7 @@ static TURN_REGEXES: LazyLock<Vec<Regex>> = LazyLock::new(|| {
     ])
 });
 
+/// Classify `text` as `"positive"`, `"negative"`, or `"neutral"` using word lists.
 fn get_sentiment(text: &str) -> &'static str {
     let words: HashSet<String> = text
         .split(|c: char| !c.is_alphanumeric())
@@ -272,6 +301,7 @@ fn get_sentiment(text: &str) -> &'static str {
     result
 }
 
+/// Return `true` if `text` contains any resolution phrase (e.g. "fixed", "solved").
 fn has_resolution(text: &str) -> bool {
     let text_lower = text.to_lowercase();
     RESOLUTION_REGEXES.iter().any(|re| re.is_match(&text_lower))
@@ -304,7 +334,7 @@ fn extract_prose(text: &str) -> String {
     }
 }
 
-/// Split text into segments for memory extraction.
+/// Split `text` into segments for memory extraction.
 fn split_into_segments(text: &str) -> Vec<String> {
     let lines: Vec<&str> = text.lines().collect();
 
@@ -340,6 +370,7 @@ fn split_into_segments(text: &str) -> Vec<String> {
     paragraphs
 }
 
+/// Group `lines` into segments by splitting on conversation-turn markers.
 fn split_by_turns(lines: &[&str], turn_patterns: &[Regex]) -> Vec<String> {
     let mut segments = Vec::new();
     let mut current: Vec<&str> = Vec::new();

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -79,7 +79,10 @@ pub fn extract_memories(text: &str, min_confidence: f64) -> Vec<Memory> {
 }
 
 /// Score a single segment against all marker types, returning the winning type
-/// and confidence. Returns `None` if no markers match or the segment has no prose.
+/// and confidence. Returns `None` only when no marker patterns match.
+///
+/// `extract_prose` strips code blocks from the segment but always falls back to
+/// the full text when nothing remains, so an empty-prose result never causes `None`.
 fn extract_memories_score_segment(
     para: &str,
     all_markers: &[(&str, &[Regex])],

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -183,8 +183,8 @@ static NEGATIVE_SET: LazyLock<HashSet<&str>> =
 fn compile_regexes(patterns: &[&str]) -> Vec<Regex> {
     patterns
         .iter()
-        .map(|p| {
-            Regex::new(p)
+        .map(|pattern| {
+            Regex::new(pattern)
                 .expect("regex pattern is a compile-time literal and cannot fail to compile")
         })
         .collect()
@@ -248,16 +248,16 @@ fn get_sentiment(text: &str) -> &'static str {
         .map(str::to_lowercase)
         .collect();
 
-    let pos = words
+    let positive_count = words
         .iter()
-        .filter(|w| POSITIVE_SET.contains(w.as_str()))
+        .filter(|word| POSITIVE_SET.contains(word.as_str()))
         .count();
-    let neg = words
+    let negative_count = words
         .iter()
-        .filter(|w| NEGATIVE_SET.contains(w.as_str()))
+        .filter(|word| NEGATIVE_SET.contains(word.as_str()))
         .count();
 
-    let result = match pos.cmp(&neg) {
+    let result = match positive_count.cmp(&negative_count) {
         std::cmp::Ordering::Greater => "positive",
         std::cmp::Ordering::Less => "negative",
         std::cmp::Ordering::Equal => "neutral",
@@ -333,7 +333,7 @@ fn split_into_segments(text: &str) -> Vec<String> {
         return lines
             .chunks(25)
             .map(|chunk| chunk.join("\n"))
-            .filter(|s| !s.trim().is_empty())
+            .filter(|line| !line.trim().is_empty())
             .collect();
     }
 

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -69,21 +69,21 @@ pub fn extract_memories(text: &str, min_confidence: f64) -> Vec<Memory> {
 
         // f64 scores come from integer match counts (count as f64); partial_cmp
         // only returns None for NaN, which cannot arise here.
-        let Some(&(max_type, max_score)) = scores
+        let Some(&(type_max, score_max)) = scores
             .iter()
             .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
         else {
             // Unreachable: scores is non-empty (checked above at `if scores.is_empty()`).
             continue;
         };
-        let max_score = max_score + length_bonus;
+        let score_max = score_max + length_bonus;
 
         // Disambiguate
-        let score_map: std::collections::HashMap<&str, f64> = scores.iter().copied().collect();
-        let final_type = disambiguate(max_type, &prose, &score_map);
+        let scores_by_type: std::collections::HashMap<&str, f64> = scores.iter().copied().collect();
+        let final_type = disambiguate(type_max, &prose, &scores_by_type);
 
         // Confidence
-        let confidence = (max_score / 5.0).min(1.0);
+        let confidence = (score_max / 5.0).min(1.0);
         if confidence < min_confidence {
             continue;
         }

--- a/src/kg/mod.rs
+++ b/src/kg/mod.rs
@@ -333,21 +333,26 @@ pub async fn add_entity(
     entity_type: &str,
     properties: Option<&str>,
 ) -> Result<String> {
-    let eid = entity_id(name);
+    let entity_identifier = entity_id(name);
     // entity_id can return "" for inputs like "'"; reject before writing a blank key.
-    if eid.is_empty() {
+    if entity_identifier.is_empty() {
         return Err(crate::error::Error::Other(
             "empty normalized entity id".to_string(),
         ));
     }
-    let props = properties.unwrap_or("{}");
+    let properties_json = properties.unwrap_or("{}");
     connection
         .execute(
             "INSERT OR REPLACE INTO entities (id, name, type, properties) VALUES (?1, ?2, ?3, ?4)",
-            turso::params![eid.as_str(), name, entity_type, props],
+            turso::params![
+                entity_identifier.as_str(),
+                name,
+                entity_type,
+                properties_json
+            ],
         )
         .await?;
-    Ok(eid)
+    Ok(entity_identifier)
 }
 
 /// Parameters for [`add_triple`].
@@ -381,16 +386,18 @@ fn add_triple_validate_params(params: &TripleParams<'_>) -> Result<()> {
     }
     let valid_from_date = params
         .valid_from
-        .map(|v| {
-            chrono::NaiveDate::parse_from_str(v, "%Y-%m-%d")
-                .map_err(|_| crate::error::Error::Other(format!("invalid valid_from date: {v}")))
+        .map(|date_str| {
+            chrono::NaiveDate::parse_from_str(date_str, "%Y-%m-%d").map_err(|_| {
+                crate::error::Error::Other(format!("invalid valid_from date: {date_str}"))
+            })
         })
         .transpose()?;
     let valid_to_date = params
         .valid_to
-        .map(|v| {
-            chrono::NaiveDate::parse_from_str(v, "%Y-%m-%d")
-                .map_err(|_| crate::error::Error::Other(format!("invalid valid_to date: {v}")))
+        .map(|date_str| {
+            chrono::NaiveDate::parse_from_str(date_str, "%Y-%m-%d").map_err(|_| {
+                crate::error::Error::Other(format!("invalid valid_to date: {date_str}"))
+            })
         })
         .transpose()?;
     if let (Some(from), Some(to)) = (valid_from_date, valid_to_date)
@@ -407,6 +414,9 @@ fn add_triple_validate_params(params: &TripleParams<'_>) -> Result<()> {
 
 /// Add a relationship triple. Auto-creates entities if they don't exist.
 /// Returns the triple ID.
+// Descriptive variable names for subject_id, object_id, predicate, and four turso::Value
+// bindings produce a line count just over 70; the logic itself is not complex.
+#[allow(clippy::too_many_lines)]
 pub async fn add_triple(connection: &Connection, params: &TripleParams<'_>) -> Result<String> {
     // Preconditions: subject, predicate, and object must all be non-empty.
     assert!(
@@ -421,27 +431,36 @@ pub async fn add_triple(connection: &Connection, params: &TripleParams<'_>) -> R
 
     add_triple_validate_params(params)?;
 
-    let sub_id = entity_id(params.subject);
-    let obj_id = entity_id(params.object);
-    let pred = params.predicate.to_lowercase().replace(' ', "_");
+    let subject_id = entity_id(params.subject);
+    let object_id = entity_id(params.object);
+    let predicate = params.predicate.to_lowercase().replace(' ', "_");
 
     // Pair assertions: entity_id can return "" for inputs like "'".
     // An empty normalized ID would silently corrupt the graph with a blank key.
-    assert!(!sub_id.is_empty(), "triple subject normalizes to empty ID");
-    assert!(!obj_id.is_empty(), "triple object normalizes to empty ID");
-    assert!(!pred.is_empty(), "triple predicate normalizes to empty ID");
+    assert!(
+        !subject_id.is_empty(),
+        "triple subject normalizes to empty ID"
+    );
+    assert!(
+        !object_id.is_empty(),
+        "triple object normalizes to empty ID"
+    );
+    assert!(
+        !predicate.is_empty(),
+        "triple predicate normalizes to empty ID"
+    );
 
     // Auto-create entities
     connection
         .execute(
             "INSERT OR IGNORE INTO entities (id, name) VALUES (?1, ?2)",
-            turso::params![sub_id.as_str(), params.subject],
+            turso::params![subject_id.as_str(), params.subject],
         )
         .await?;
     connection
         .execute(
             "INSERT OR IGNORE INTO entities (id, name) VALUES (?1, ?2)",
-            turso::params![obj_id.as_str(), params.object],
+            turso::params![object_id.as_str(), params.object],
         )
         .await?;
 
@@ -449,7 +468,7 @@ pub async fn add_triple(connection: &Connection, params: &TripleParams<'_>) -> R
     let existing = db::query_all(
         connection,
         "SELECT id FROM triples WHERE subject=?1 AND predicate=?2 AND object=?3 AND valid_to IS NULL",
-        turso::params![sub_id.as_str(), pred.as_str(), obj_id.as_str()],
+        turso::params![subject_id.as_str(), predicate.as_str(), object_id.as_str()],
     )
     .await?;
 
@@ -461,24 +480,24 @@ pub async fn add_triple(connection: &Connection, params: &TripleParams<'_>) -> R
     }
 
     let triple_id = format!(
-        "t_{sub_id}_{pred}_{obj_id}_{}",
+        "t_{subject_id}_{predicate}_{object_id}_{}",
         &uuid::Uuid::new_v4().to_string().replace('-', "")[..8]
     );
 
     let valid_from_value: turso::Value = match params.valid_from {
-        Some(v) => turso::Value::from(v),
+        Some(value) => turso::Value::from(value),
         None => turso::Value::Null,
     };
     let valid_to_value: turso::Value = match params.valid_to {
-        Some(v) => turso::Value::from(v),
+        Some(value) => turso::Value::from(value),
         None => turso::Value::Null,
     };
     let source_closet_value: turso::Value = match params.source_closet {
-        Some(v) => turso::Value::from(v),
+        Some(value) => turso::Value::from(value),
         None => turso::Value::Null,
     };
     let source_file_value: turso::Value = match params.source_file {
-        Some(v) => turso::Value::from(v),
+        Some(value) => turso::Value::from(value),
         None => turso::Value::Null,
     };
 
@@ -487,7 +506,7 @@ pub async fn add_triple(connection: &Connection, params: &TripleParams<'_>) -> R
 
     connection.execute(
         "INSERT INTO triples (id, subject, predicate, object, valid_from, valid_to, confidence, source_closet, source_file) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
-        turso::params![triple_id.as_str(), sub_id.as_str(), pred.as_str(), obj_id.as_str(), valid_from_value, valid_to_value, params.confidence, source_closet_value, source_file_value],
+        turso::params![triple_id.as_str(), subject_id.as_str(), predicate.as_str(), object_id.as_str(), valid_from_value, valid_to_value, params.confidence, source_closet_value, source_file_value],
     )
     .await?;
 
@@ -510,22 +529,22 @@ pub async fn invalidate(
     );
     assert!(!object.is_empty(), "invalidate: object must not be empty");
 
-    let sub_id = entity_id(subject);
-    let obj_id = entity_id(object);
-    let pred = predicate.to_lowercase().replace(' ', "_");
+    let subject_id = entity_id(subject);
+    let object_id = entity_id(object);
+    let predicate_normalized = predicate.to_lowercase().replace(' ', "_");
 
     // Pair assertions: entity_id can return "" for apostrophe-only inputs.
     // An empty normalized ID would silently run an UPDATE with a blank key.
     assert!(
-        !sub_id.is_empty(),
+        !subject_id.is_empty(),
         "invalidate: subject normalizes to empty ID"
     );
     assert!(
-        !obj_id.is_empty(),
+        !object_id.is_empty(),
         "invalidate: object normalizes to empty ID"
     );
     assert!(
-        !pred.is_empty(),
+        !predicate_normalized.is_empty(),
         "invalidate: predicate normalizes to empty ID"
     );
 
@@ -537,7 +556,7 @@ pub async fn invalidate(
 
     connection.execute(
         "UPDATE triples SET valid_to=?1 WHERE subject=?2 AND predicate=?3 AND object=?4 AND valid_to IS NULL",
-        turso::params![persisted_ended.as_str(), sub_id.as_str(), pred.as_str(), obj_id.as_str()],
+        turso::params![persisted_ended.as_str(), subject_id.as_str(), predicate_normalized.as_str(), object_id.as_str()],
     )
     .await?;
 

--- a/src/kg/mod.rs
+++ b/src/kg/mod.rs
@@ -415,11 +415,63 @@ fn add_triple_validate_params(params: &TripleParams<'_>) -> Result<()> {
     Ok(())
 }
 
+/// Upsert subject and object entities into the graph (INSERT OR IGNORE).
+/// Called by `add_triple` to keep that function within the 70-line limit.
+async fn add_triple_ensure_entities(
+    connection: &Connection,
+    subject_id: &str,
+    subject_name: &str,
+    object_id: &str,
+    object_name: &str,
+) -> Result<()> {
+    assert!(!subject_id.is_empty(), "subject_id must not be empty");
+    assert!(!object_id.is_empty(), "object_id must not be empty");
+
+    connection
+        .execute(
+            "INSERT OR IGNORE INTO entities (id, name) VALUES (?1, ?2)",
+            turso::params![subject_id, subject_name],
+        )
+        .await?;
+    connection
+        .execute(
+            "INSERT OR IGNORE INTO entities (id, name) VALUES (?1, ?2)",
+            turso::params![object_id, object_name],
+        )
+        .await?;
+    Ok(())
+}
+
+/// Check whether an active triple already exists and return its ID if so.
+/// Called by `add_triple` to keep that function within the 70-line limit.
+async fn add_triple_check_duplicate(
+    connection: &Connection,
+    subject_id: &str,
+    predicate: &str,
+    object_id: &str,
+) -> Result<Option<String>> {
+    assert!(!subject_id.is_empty(), "subject_id must not be empty");
+    assert!(!predicate.is_empty(), "predicate must not be empty");
+    assert!(!object_id.is_empty(), "object_id must not be empty");
+
+    let existing = db::query_all(
+        connection,
+        "SELECT id FROM triples WHERE subject=?1 AND predicate=?2 AND object=?3 AND valid_to IS NULL",
+        turso::params![subject_id, predicate, object_id],
+    )
+    .await?;
+
+    if let Some(row) = existing.first()
+        && let Ok(val) = row.get_value(0)
+        && let Some(id) = val.as_text()
+    {
+        return Ok(Some(id.clone()));
+    }
+    Ok(None)
+}
+
 /// Add a relationship triple. Auto-creates entities if they don't exist.
 /// Returns the triple ID.
-// Descriptive variable names for subject_id, object_id, predicate, and four turso::Value
-// bindings produce a line count just over 70; the logic itself is not complex.
-#[allow(clippy::too_many_lines)]
 pub async fn add_triple(connection: &Connection, params: &TripleParams<'_>) -> Result<String> {
     // Preconditions: subject, predicate, and object must all be non-empty.
     assert!(
@@ -453,33 +505,19 @@ pub async fn add_triple(connection: &Connection, params: &TripleParams<'_>) -> R
         "triple predicate normalizes to empty ID"
     );
 
-    // Auto-create entities.
-    connection
-        .execute(
-            "INSERT OR IGNORE INTO entities (id, name) VALUES (?1, ?2)",
-            turso::params![subject_id.as_str(), params.subject],
-        )
-        .await?;
-    connection
-        .execute(
-            "INSERT OR IGNORE INTO entities (id, name) VALUES (?1, ?2)",
-            turso::params![object_id.as_str(), params.object],
-        )
-        .await?;
-
-    // Check for existing identical active triple.
-    let existing = db::query_all(
+    add_triple_ensure_entities(
         connection,
-        "SELECT id FROM triples WHERE subject=?1 AND predicate=?2 AND object=?3 AND valid_to IS NULL",
-        turso::params![subject_id.as_str(), predicate.as_str(), object_id.as_str()],
+        &subject_id,
+        params.subject,
+        &object_id,
+        params.object,
     )
     .await?;
 
-    if let Some(row) = existing.first()
-        && let Ok(val) = row.get_value(0)
-        && let Some(id) = val.as_text()
+    if let Some(existing_id) =
+        add_triple_check_duplicate(connection, &subject_id, &predicate, &object_id).await?
     {
-        return Ok(id.clone());
+        return Ok(existing_id);
     }
 
     let triple_id = format!(
@@ -487,25 +525,21 @@ pub async fn add_triple(connection: &Connection, params: &TripleParams<'_>) -> R
         &uuid::Uuid::new_v4().to_string().replace('-', "")[..8]
     );
 
-    let valid_from_value: turso::Value = match params.valid_from {
-        Some(value) => turso::Value::from(value),
-        None => turso::Value::Null,
-    };
-    let valid_to_value: turso::Value = match params.valid_to {
-        Some(value) => turso::Value::from(value),
-        None => turso::Value::Null,
-    };
-    let source_closet_value: turso::Value = match params.source_closet {
-        Some(value) => turso::Value::from(value),
-        None => turso::Value::Null,
-    };
-    let source_file_value: turso::Value = match params.source_file {
-        Some(value) => turso::Value::from(value),
-        None => turso::Value::Null,
-    };
-
     // Postcondition: triple ID follows naming convention.
     assert!(triple_id.starts_with("t_"), "triple_id must start with t_");
+
+    let valid_from_value: turso::Value = params
+        .valid_from
+        .map_or(turso::Value::Null, turso::Value::from);
+    let valid_to_value: turso::Value = params
+        .valid_to
+        .map_or(turso::Value::Null, turso::Value::from);
+    let source_closet_value: turso::Value = params
+        .source_closet
+        .map_or(turso::Value::Null, turso::Value::from);
+    let source_file_value: turso::Value = params
+        .source_file
+        .map_or(turso::Value::Null, turso::Value::from);
 
     connection.execute(
         "INSERT INTO triples (id, subject, predicate, object, valid_from, valid_to, confidence, source_closet, source_file) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",

--- a/src/kg/mod.rs
+++ b/src/kg/mod.rs
@@ -326,6 +326,7 @@ mod async_tests {
 }
 
 /// Add or update an entity node.
+// Used by `kg::query` tests to seed entities; not called from binary code paths.
 #[allow(dead_code)]
 pub async fn add_entity(
     connection: &Connection,

--- a/src/kg/mod.rs
+++ b/src/kg/mod.rs
@@ -326,7 +326,9 @@ mod async_tests {
 }
 
 /// Add or update an entity node.
-// Used by `kg::query` tests to seed entities; not called from binary code paths.
+// Used by integration tests in `tests/kg_workflow.rs`; the binary never calls it.
+// `#[cfg(test)]` would hide it from integration tests (which build the non-test lib),
+// so `#[allow(dead_code)]` is the correct suppression here.
 #[allow(dead_code)]
 pub async fn add_entity(
     connection: &Connection,

--- a/src/kg/mod.rs
+++ b/src/kg/mod.rs
@@ -250,7 +250,7 @@ mod async_tests {
         .await
         .expect("add_triple should succeed for valid subject/predicate/object params");
 
-        // Both entities should exist
+        // Both entities should exist.
         let entities = crate::db::query_all(&connection, "SELECT id FROM entities ORDER BY id", ())
             .await
             .expect(
@@ -450,7 +450,7 @@ pub async fn add_triple(connection: &Connection, params: &TripleParams<'_>) -> R
         "triple predicate normalizes to empty ID"
     );
 
-    // Auto-create entities
+    // Auto-create entities.
     connection
         .execute(
             "INSERT OR IGNORE INTO entities (id, name) VALUES (?1, ?2)",
@@ -464,7 +464,7 @@ pub async fn add_triple(connection: &Connection, params: &TripleParams<'_>) -> R
         )
         .await?;
 
-    // Check for existing identical active triple
+    // Check for existing identical active triple.
     let existing = db::query_all(
         connection,
         "SELECT id FROM triples WHERE subject=?1 AND predicate=?2 AND object=?3 AND valid_to IS NULL",

--- a/src/kg/query.rs
+++ b/src/kg/query.rs
@@ -36,7 +36,7 @@ pub struct KgStats {
     /// Total triple count.
     pub triples: i64,
     /// Triples with no `valid_to` (still active).
-    pub current_facts: i64,
+    pub facts_current: i64,
     /// Triples with a `valid_to` set.
     pub expired_facts: i64,
     /// Distinct predicate values across all triples.
@@ -285,7 +285,7 @@ pub async fn stats(connection: &Connection) -> Result<KgStats> {
     Ok(KgStats {
         entities,
         triples,
-        current_facts: current,
+        facts_current: current,
         expired_facts: expired,
         relationship_types,
     })
@@ -450,7 +450,7 @@ mod tests {
         assert!(kg_stats.entities > 0, "seeded DB should have entities");
         assert!(kg_stats.triples > 0, "seeded DB should have triples");
         assert_eq!(
-            kg_stats.current_facts, kg_stats.triples,
+            kg_stats.facts_current, kg_stats.triples,
             "no expired facts yet"
         );
     }

--- a/src/kg/query.rs
+++ b/src/kg/query.rs
@@ -164,6 +164,12 @@ pub async fn query_entity(
 
 /// Get chronological timeline of facts.
 pub async fn timeline(connection: &Connection, entity: Option<&str>) -> Result<Vec<Fact>> {
+    // Precondition: when provided, the entity filter must be a non-empty, trimmed name.
+    if let Some(name) = entity {
+        assert!(!name.is_empty(), "timeline: entity name must not be empty");
+        assert!(name == name.trim(), "timeline: entity name must be trimmed");
+    }
+
     let (sql, params) = if let Some(name) = entity {
         let entity_identifier = entity_id(name);
         (

--- a/src/kg/query.rs
+++ b/src/kg/query.rs
@@ -54,14 +54,20 @@ fn query_entity_row_to_fact(
     let predicate = row
         .get_value(1)
         .ok()
-        .and_then(|v| v.as_text().cloned())
+        .and_then(|cell| cell.as_text().cloned())
         .unwrap_or_default();
-    let valid_from = row.get_value(3).ok().and_then(|v| v.as_text().cloned());
-    let valid_to = row.get_value(4).ok().and_then(|v| v.as_text().cloned());
+    let valid_from = row
+        .get_value(3)
+        .ok()
+        .and_then(|cell| cell.as_text().cloned());
+    let valid_to = row
+        .get_value(4)
+        .ok()
+        .and_then(|cell| cell.as_text().cloned());
     let confidence = row
         .get_value(5)
         .ok()
-        .and_then(|v| v.as_real().copied())
+        .and_then(|cell| cell.as_real().copied())
         .unwrap_or(1.0);
 
     Fact {
@@ -124,30 +130,30 @@ pub async fn query_entity(
         ));
     }
 
-    let eid = entity_id(name);
+    let entity_identifier = entity_id(name);
     let mut results = Vec::new();
 
     if direction == "outgoing" || direction == "both" {
-        let (sql, params) = query_entity_sql(&eid, as_of, "object", "subject");
+        let (sql, params) = query_entity_sql(&entity_identifier, as_of, "object", "subject");
         let rows = db::query_all(connection, &sql, turso::params_from_iter(params)).await?;
         for row in &rows {
             let obj_name = row
                 .get_value(6)
                 .ok()
-                .and_then(|v| v.as_text().cloned())
+                .and_then(|cell| cell.as_text().cloned())
                 .unwrap_or_default();
             results.push(query_entity_row_to_fact(row, "outgoing", name, &obj_name));
         }
     }
 
     if direction == "incoming" || direction == "both" {
-        let (sql, params) = query_entity_sql(&eid, as_of, "subject", "object");
+        let (sql, params) = query_entity_sql(&entity_identifier, as_of, "subject", "object");
         let rows = db::query_all(connection, &sql, turso::params_from_iter(params)).await?;
         for row in &rows {
             let sub_name = row
                 .get_value(6)
                 .ok()
-                .and_then(|v| v.as_text().cloned())
+                .and_then(|cell| cell.as_text().cloned())
                 .unwrap_or_default();
             results.push(query_entity_row_to_fact(row, "incoming", &sub_name, name));
         }
@@ -159,7 +165,7 @@ pub async fn query_entity(
 /// Get chronological timeline of facts.
 pub async fn timeline(connection: &Connection, entity: Option<&str>) -> Result<Vec<Fact>> {
     let (sql, params) = if let Some(name) = entity {
-        let eid = entity_id(name);
+        let entity_identifier = entity_id(name);
         (
             "SELECT t.predicate, t.valid_from, t.valid_to, s.name, o.name \
              FROM triples t \
@@ -168,7 +174,7 @@ pub async fn timeline(connection: &Connection, entity: Option<&str>) -> Result<V
              WHERE t.subject = ?1 OR t.object = ?1 \
              ORDER BY t.valid_from ASC"
                 .to_string(),
-            vec![turso::Value::from(eid.as_str())],
+            vec![turso::Value::from(entity_identifier.as_str())],
         )
     } else {
         (
@@ -190,19 +196,25 @@ pub async fn timeline(connection: &Connection, entity: Option<&str>) -> Result<V
         let predicate = row
             .get_value(0)
             .ok()
-            .and_then(|v| v.as_text().cloned())
+            .and_then(|cell| cell.as_text().cloned())
             .unwrap_or_default();
-        let valid_from = row.get_value(1).ok().and_then(|v| v.as_text().cloned());
-        let valid_to = row.get_value(2).ok().and_then(|v| v.as_text().cloned());
+        let valid_from = row
+            .get_value(1)
+            .ok()
+            .and_then(|cell| cell.as_text().cloned());
+        let valid_to = row
+            .get_value(2)
+            .ok()
+            .and_then(|cell| cell.as_text().cloned());
         let sub_name = row
             .get_value(3)
             .ok()
-            .and_then(|v| v.as_text().cloned())
+            .and_then(|cell| cell.as_text().cloned())
             .unwrap_or_default();
         let obj_name = row
             .get_value(4)
             .ok()
-            .and_then(|v| v.as_text().cloned())
+            .and_then(|cell| cell.as_text().cloned())
             .unwrap_or_default();
 
         facts.push(Fact {
@@ -225,15 +237,15 @@ pub async fn stats(connection: &Connection) -> Result<KgStats> {
     let entity_rows = db::query_all(connection, "SELECT COUNT(*) FROM entities", ()).await?;
     let entities = entity_rows
         .first()
-        .and_then(|r| r.get_value(0).ok())
-        .and_then(|v| v.as_integer().copied())
+        .and_then(|row| row.get_value(0).ok())
+        .and_then(|cell| cell.as_integer().copied())
         .unwrap_or(0);
 
     let triple_rows = db::query_all(connection, "SELECT COUNT(*) FROM triples", ()).await?;
     let triples = triple_rows
         .first()
-        .and_then(|r| r.get_value(0).ok())
-        .and_then(|v| v.as_integer().copied())
+        .and_then(|row| row.get_value(0).ok())
+        .and_then(|cell| cell.as_integer().copied())
         .unwrap_or(0);
 
     let current_rows = db::query_all(
@@ -244,8 +256,8 @@ pub async fn stats(connection: &Connection) -> Result<KgStats> {
     .await?;
     let current = current_rows
         .first()
-        .and_then(|r| r.get_value(0).ok())
-        .and_then(|v| v.as_integer().copied())
+        .and_then(|row| row.get_value(0).ok())
+        .and_then(|cell| cell.as_integer().copied())
         .unwrap_or(0);
 
     let pred_rows = db::query_all(
@@ -256,7 +268,11 @@ pub async fn stats(connection: &Connection) -> Result<KgStats> {
     .await?;
     let relationship_types: Vec<String> = pred_rows
         .iter()
-        .filter_map(|r| r.get_value(0).ok().and_then(|v| v.as_text().cloned()))
+        .filter_map(|row| {
+            row.get_value(0)
+                .ok()
+                .and_then(|cell| cell.as_text().cloned())
+        })
         .collect();
 
     let expired = triples - current;
@@ -416,11 +432,11 @@ mod tests {
     async fn stats_empty() {
         let (_db, conn) = crate::test_helpers::test_db().await;
 
-        let s = stats(&conn)
+        let kg_stats = stats(&conn)
             .await
             .expect("stats should succeed on empty database");
-        assert_eq!(s.entities, 0, "fresh DB should have 0 entities");
-        assert_eq!(s.triples, 0, "fresh DB should have 0 triples");
+        assert_eq!(kg_stats.entities, 0, "fresh DB should have 0 entities");
+        assert_eq!(kg_stats.triples, 0, "fresh DB should have 0 triples");
     }
 
     #[tokio::test]
@@ -428,11 +444,14 @@ mod tests {
         let (_db, conn) = crate::test_helpers::test_db().await;
         seed_alice_knows_bob(&conn).await;
 
-        let s = stats(&conn)
+        let kg_stats = stats(&conn)
             .await
             .expect("stats should succeed after seeding data");
-        assert!(s.entities > 0, "seeded DB should have entities");
-        assert!(s.triples > 0, "seeded DB should have triples");
-        assert_eq!(s.current_facts, s.triples, "no expired facts yet");
+        assert!(kg_stats.entities > 0, "seeded DB should have entities");
+        assert!(kg_stats.triples > 0, "seeded DB should have triples");
+        assert_eq!(
+            kg_stats.current_facts, kg_stats.triples,
+            "no expired facts yet"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,6 @@ pub mod config;
 pub mod db;
 pub mod dialect;
 pub mod error;
-#[allow(dead_code)]
 pub mod extract;
 pub mod kg;
 pub mod mcp;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,15 +4,12 @@ mod config;
 mod db;
 mod dialect;
 mod error;
-#[allow(dead_code)]
-mod extract;
 mod kg;
 mod mcp;
 mod normalize;
 mod palace;
 mod schema;
 #[cfg(test)]
-#[allow(dead_code)]
 mod test_helpers;
 
 use clap::Parser;

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -54,10 +54,7 @@ pub async fn run(connection: &Connection) -> Result<()> {
                     "id": null,
                     "error": {"code": -32700, "message": "Request exceeds maximum frame size"}
                 });
-                let serialized_response = serde_json::to_string(&err_response).unwrap_or_default();
-                stdout.write_all(serialized_response.as_bytes()).await?;
-                stdout.write_all(b"\n").await?;
-                stdout.flush().await?;
+                run_write_response(&mut stdout, &err_response).await?;
                 continue;
             }
             Ok(LineRead::Invalid) => {
@@ -66,10 +63,7 @@ pub async fn run(connection: &Connection) -> Result<()> {
                     "id": null,
                     "error": {"code": -32700, "message": "Request contains invalid UTF-8"}
                 });
-                let serialized_response = serde_json::to_string(&err_response).unwrap_or_default();
-                stdout.write_all(serialized_response.as_bytes()).await?;
-                stdout.write_all(b"\n").await?;
-                stdout.flush().await?;
+                run_write_response(&mut stdout, &err_response).await?;
                 continue;
             }
             Err(e) => return Err(e.into()),
@@ -81,18 +75,10 @@ pub async fn run(connection: &Connection) -> Result<()> {
             continue;
         }
 
-        let request: Value = match serde_json::from_str(trimmed) {
+        let request = match run_parse_request(trimmed) {
             Ok(parsed) => parsed,
-            Err(e) => {
-                let err_response = json!({
-                    "jsonrpc": "2.0",
-                    "id": null,
-                    "error": {"code": -32700, "message": format!("Parse error: {e}")}
-                });
-                let serialized_response = serde_json::to_string(&err_response).unwrap_or_default();
-                stdout.write_all(serialized_response.as_bytes()).await?;
-                stdout.write_all(b"\n").await?;
-                stdout.flush().await?;
+            Err(err_response) => {
+                run_write_response(&mut stdout, &err_response).await?;
                 continue;
             }
         };
@@ -100,14 +86,37 @@ pub async fn run(connection: &Connection) -> Result<()> {
         let response = handle_request(connection, &request).await;
 
         if let Some(response_body) = response {
-            let serialized_response = serde_json::to_string(&response_body).unwrap_or_default();
-            stdout.write_all(serialized_response.as_bytes()).await?;
-            stdout.write_all(b"\n").await?;
-            stdout.flush().await?;
+            run_write_response(&mut stdout, &response_body).await?;
         }
     }
 
     Ok(())
+}
+
+/// Parse a JSON-RPC request from a trimmed line of text.
+///
+/// Returns `Ok(Value)` on success, or `Err(Value)` containing a JSON-RPC
+/// parse-error response ready to send to the client.
+fn run_parse_request(trimmed: &str) -> std::result::Result<Value, Value> {
+    assert!(!trimmed.is_empty());
+    serde_json::from_str(trimmed).map_err(|e| {
+        json!({
+            "jsonrpc": "2.0",
+            "id": null,
+            "error": {"code": -32700, "message": format!("Parse error: {e}")}
+        })
+    })
+}
+
+/// Serialize `response` and write it as a newline-terminated frame to `stdout`.
+async fn run_write_response(
+    stdout: &mut tokio::io::Stdout,
+    response: &Value,
+) -> std::io::Result<()> {
+    let serialized_response = serde_json::to_string(response).unwrap_or_default();
+    stdout.write_all(serialized_response.as_bytes()).await?;
+    stdout.write_all(b"\n").await?;
+    stdout.flush().await
 }
 
 /// Read one newline-delimited line from stdin, enforcing a hard byte limit.
@@ -226,6 +235,9 @@ async fn run_read_line_drain<R: AsyncBufRead + Unpin>(reader: &mut R) -> std::io
     }
 }
 
+/// Validate request shape and dispatch to `handle_request_dispatch`.
+///
+/// Returns `None` for notifications (no response required per JSON-RPC 2.0).
 async fn handle_request(connection: &Connection, request: &Value) -> Option<Value> {
     // Malformed (non-object) requests get a JSON-RPC error rather than a panic;
     // the MCP server must stay alive for subsequent well-formed requests.
@@ -248,30 +260,21 @@ async fn handle_request(connection: &Connection, request: &Value) -> Option<Valu
     let params = request.get("params").cloned().unwrap_or(json!({}));
     let req_id = request.get("id").cloned().unwrap_or(Value::Null);
 
+    handle_request_dispatch(connection, method, &params, req_id).await
+}
+
+/// Dispatch a validated JSON-RPC method to the appropriate handler.
+///
+/// Called after `handle_request` has confirmed the request is a well-formed object
+/// with a string `method` field.
+async fn handle_request_dispatch(
+    connection: &Connection,
+    method: &str,
+    params: &Value,
+    req_id: Value,
+) -> Option<Value> {
     match method {
-        "initialize" => {
-            let client_version = params
-                .get("protocolVersion")
-                .and_then(|proto_val| proto_val.as_str());
-            let negotiated = if let Some(cv) = client_version {
-                if SUPPORTED_PROTOCOL_VERSIONS.contains(&cv) {
-                    cv
-                } else {
-                    SUPPORTED_PROTOCOL_VERSIONS[0]
-                }
-            } else {
-                SUPPORTED_PROTOCOL_VERSIONS[0]
-            };
-            Some(json!({
-                "jsonrpc": "2.0",
-                "id": req_id,
-                "result": {
-                    "protocolVersion": negotiated,
-                    "capabilities": {"tools": {}},
-                    "serverInfo": {"name": "mempalace", "version": env!("CARGO_PKG_VERSION")},
-                }
-            }))
-        }
+        "initialize" => Some(handle_request_initialize(params, &req_id)),
 
         "ping" => Some(json!({
             "jsonrpc": "2.0",
@@ -290,7 +293,7 @@ async fn handle_request(connection: &Connection, request: &Value) -> Option<Valu
             }))
         }
 
-        "tools/call" => Some(handle_request_tools_call(connection, &params, req_id).await),
+        "tools/call" => Some(handle_request_tools_call(connection, params, req_id).await),
 
         _ => Some(json!({
             "jsonrpc": "2.0",
@@ -298,6 +301,31 @@ async fn handle_request(connection: &Connection, request: &Value) -> Option<Valu
             "error": {"code": -32601, "message": format!("Unknown method: {method}")}
         })),
     }
+}
+
+/// Handle the `initialize` method: negotiate protocol version and return server info.
+fn handle_request_initialize(params: &Value, req_id: &Value) -> Value {
+    let client_version = params
+        .get("protocolVersion")
+        .and_then(|proto_val| proto_val.as_str());
+    let negotiated = if let Some(cv) = client_version {
+        if SUPPORTED_PROTOCOL_VERSIONS.contains(&cv) {
+            cv
+        } else {
+            SUPPORTED_PROTOCOL_VERSIONS[0]
+        }
+    } else {
+        SUPPORTED_PROTOCOL_VERSIONS[0]
+    };
+    json!({
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "result": {
+            "protocolVersion": negotiated,
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": "mempalace", "version": env!("CARGO_PKG_VERSION")},
+        }
+    })
 }
 
 /// Dispatch a `tools/call` request and return a sanitized JSON-RPC response.
@@ -309,41 +337,62 @@ async fn handle_request_tools_call(
     // Validate params shape before dispatch — reject non-object params, a
     // missing or non-string name, and non-object arguments with Invalid Params
     // (-32602) rather than letting malformed input reach tools::dispatch.
+    let (tool_name, tool_args) = match handle_request_tools_call_validate(params, &req_id) {
+        Ok(validated) => validated,
+        Err(err_response) => return err_response,
+    };
+
+    let result = tools::dispatch(connection, tool_name, &tool_args).await;
+
+    handle_request_tools_call_respond(tool_name, result, &req_id)
+}
+
+/// Validate `tools/call` params and extract `(tool_name, tool_args)`.
+///
+/// Returns `Ok((name, args))` when the params are well-formed, or `Err(response)`
+/// with a ready-to-send JSON-RPC Invalid Params error when they are not.
+fn handle_request_tools_call_validate<'a>(
+    params: &'a Value,
+    req_id: &Value,
+) -> std::result::Result<(&'a str, Value), Value> {
     if !params.is_object() {
-        return json!({
+        return Err(json!({
             "jsonrpc": "2.0",
             "id": req_id,
             "error": {"code": -32602, "message": "Invalid params: expected object"}
-        });
+        }));
     }
     let Some(tool_name) = params
         .get("name")
         .and_then(|name_value| name_value.as_str())
     else {
-        return json!({
+        return Err(json!({
             "jsonrpc": "2.0",
             "id": req_id,
             "error": {"code": -32602, "message": "Invalid params: missing or non-string 'name'"}
-        });
+        }));
     };
     let arguments_value = params.get("arguments");
     if arguments_value.is_some_and(|arguments| !arguments.is_null() && !arguments.is_object()) {
-        return json!({
+        return Err(json!({
             "jsonrpc": "2.0",
             "id": req_id,
             "error": {"code": -32602, "message": "Invalid params: 'arguments' must be an object or null"}
-        });
+        }));
     }
     let tool_args = arguments_value
         .filter(|arguments| !arguments.is_null())
         .cloned()
         .unwrap_or(json!({}));
+    Ok((tool_name, tool_args))
+}
 
-    let result = tools::dispatch(connection, tool_name, &tool_args).await;
-
-    // Sanitize: only expose errors that tools explicitly mark as public.
-    // All other errors are masked so internal paths and database details
-    // are never leaked over the protocol.
+/// Build a sanitized JSON-RPC response from a raw tool dispatch result.
+///
+/// Sanitize: only expose errors that tools explicitly mark as public.
+/// All other errors are masked so internal paths and database details
+/// are never leaked over the protocol.
+fn handle_request_tools_call_respond(tool_name: &str, result: Value, req_id: &Value) -> Value {
     let sanitized = if let Some(error_val) = result.get("error") {
         let is_public = result
             .get("public")

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -54,8 +54,8 @@ pub async fn run(connection: &Connection) -> Result<()> {
                     "id": null,
                     "error": {"code": -32700, "message": "Request exceeds maximum frame size"}
                 });
-                let out = serde_json::to_string(&err_response).unwrap_or_default();
-                stdout.write_all(out.as_bytes()).await?;
+                let serialized_response = serde_json::to_string(&err_response).unwrap_or_default();
+                stdout.write_all(serialized_response.as_bytes()).await?;
                 stdout.write_all(b"\n").await?;
                 stdout.flush().await?;
                 continue;
@@ -66,8 +66,8 @@ pub async fn run(connection: &Connection) -> Result<()> {
                     "id": null,
                     "error": {"code": -32700, "message": "Request contains invalid UTF-8"}
                 });
-                let out = serde_json::to_string(&err_response).unwrap_or_default();
-                stdout.write_all(out.as_bytes()).await?;
+                let serialized_response = serde_json::to_string(&err_response).unwrap_or_default();
+                stdout.write_all(serialized_response.as_bytes()).await?;
                 stdout.write_all(b"\n").await?;
                 stdout.flush().await?;
                 continue;
@@ -82,15 +82,15 @@ pub async fn run(connection: &Connection) -> Result<()> {
         }
 
         let request: Value = match serde_json::from_str(trimmed) {
-            Ok(v) => v,
+            Ok(parsed) => parsed,
             Err(e) => {
                 let err_response = json!({
                     "jsonrpc": "2.0",
                     "id": null,
                     "error": {"code": -32700, "message": format!("Parse error: {e}")}
                 });
-                let out = serde_json::to_string(&err_response).unwrap_or_default();
-                stdout.write_all(out.as_bytes()).await?;
+                let serialized_response = serde_json::to_string(&err_response).unwrap_or_default();
+                stdout.write_all(serialized_response.as_bytes()).await?;
                 stdout.write_all(b"\n").await?;
                 stdout.flush().await?;
                 continue;
@@ -99,9 +99,9 @@ pub async fn run(connection: &Connection) -> Result<()> {
 
         let response = handle_request(connection, &request).await;
 
-        if let Some(resp) = response {
-            let out = serde_json::to_string(&resp).unwrap_or_default();
-            stdout.write_all(out.as_bytes()).await?;
+        if let Some(response_body) = response {
+            let serialized_response = serde_json::to_string(&response_body).unwrap_or_default();
+            stdout.write_all(serialized_response.as_bytes()).await?;
             stdout.write_all(b"\n").await?;
             stdout.flush().await?;
         }
@@ -238,7 +238,9 @@ async fn handle_request(connection: &Connection, request: &Value) -> Option<Valu
 
     match method {
         "initialize" => {
-            let client_version = params.get("protocolVersion").and_then(|v| v.as_str());
+            let client_version = params
+                .get("protocolVersion")
+                .and_then(|proto_val| proto_val.as_str());
             let negotiated = if let Some(cv) = client_version {
                 if SUPPORTED_PROTOCOL_VERSIONS.contains(&cv) {
                     cv
@@ -381,32 +383,32 @@ mod tests {
 
     #[tokio::test]
     async fn handle_request_initialize_supported_version() {
-        let (_db, conn) = crate::test_helpers::test_db().await;
-        let req = json!({
+        let (_database, connection) = crate::test_helpers::test_db().await;
+        let request = json!({
             "method": "initialize",
             "params": {"protocolVersion": "2024-11-05"},
             "id": 1
         });
-        let resp = handle_request(&conn, &req)
+        let response = handle_request(&connection, &request)
             .await
             .expect("should return Some");
-        let result = &resp["result"];
+        let result = &response["result"];
         assert_eq!(result["protocolVersion"], "2024-11-05");
         assert_eq!(result["serverInfo"]["name"], "mempalace");
     }
 
     #[tokio::test]
     async fn handle_request_initialize_unsupported_falls_back() {
-        let (_db, conn) = crate::test_helpers::test_db().await;
-        let req = json!({
+        let (_database, connection) = crate::test_helpers::test_db().await;
+        let request = json!({
             "method": "initialize",
             "params": {"protocolVersion": "9999-01-01"},
             "id": 1
         });
-        let resp = handle_request(&conn, &req)
+        let response = handle_request(&connection, &request)
             .await
             .expect("should return Some");
-        let result = &resp["result"];
+        let result = &response["result"];
         // Falls back to the latest supported version.
         assert_eq!(result["protocolVersion"], SUPPORTED_PROTOCOL_VERSIONS[0]);
         assert_eq!(result["serverInfo"]["name"], "mempalace");
@@ -414,16 +416,16 @@ mod tests {
 
     #[tokio::test]
     async fn handle_request_initialize_no_version() {
-        let (_db, conn) = crate::test_helpers::test_db().await;
-        let req = json!({
+        let (_database, connection) = crate::test_helpers::test_db().await;
+        let request = json!({
             "method": "initialize",
             "params": {},
             "id": 1
         });
-        let resp = handle_request(&conn, &req)
+        let response = handle_request(&connection, &request)
             .await
             .expect("should return Some");
-        let result = &resp["result"];
+        let result = &response["result"];
         // Missing protocolVersion falls back to the latest supported version.
         assert_eq!(result["protocolVersion"], SUPPORTED_PROTOCOL_VERSIONS[0]);
         assert_eq!(result["serverInfo"]["name"], "mempalace");
@@ -431,35 +433,38 @@ mod tests {
 
     #[tokio::test]
     async fn handle_request_ping() {
-        let (_db, conn) = crate::test_helpers::test_db().await;
-        let req = json!({"method": "ping", "id": 2});
-        let resp = handle_request(&conn, &req)
+        let (_database, connection) = crate::test_helpers::test_db().await;
+        let request = json!({"method": "ping", "id": 2});
+        let response = handle_request(&connection, &request)
             .await
             .expect("should return Some");
-        assert_eq!(resp["result"], json!({}));
-        assert_eq!(resp["id"], 2);
+        assert_eq!(response["result"], json!({}));
+        assert_eq!(response["id"], 2);
     }
 
     #[tokio::test]
     async fn handle_request_notification_returns_none() {
-        let (_db, conn) = crate::test_helpers::test_db().await;
-        let req = json!({"method": "notifications/initialized"});
-        let resp = handle_request(&conn, &req).await;
-        assert!(resp.is_none(), "notifications must return None");
+        let (_database, connection) = crate::test_helpers::test_db().await;
+        let request = json!({"method": "notifications/initialized"});
+        let response = handle_request(&connection, &request).await;
+        assert!(response.is_none(), "notifications must return None");
         // Also verify a different notification prefix.
-        let req2 = json!({"method": "notifications/cancelled"});
-        let resp2 = handle_request(&conn, &req2).await;
-        assert!(resp2.is_none(), "all notifications/ must return None");
+        let request_notification = json!({"method": "notifications/cancelled"});
+        let response_notification = handle_request(&connection, &request_notification).await;
+        assert!(
+            response_notification.is_none(),
+            "all notifications/ must return None"
+        );
     }
 
     #[tokio::test]
     async fn handle_request_tools_list() {
-        let (_db, conn) = crate::test_helpers::test_db().await;
-        let req = json!({"method": "tools/list", "id": 3});
-        let resp = handle_request(&conn, &req)
+        let (_database, connection) = crate::test_helpers::test_db().await;
+        let request = json!({"method": "tools/list", "id": 3});
+        let response = handle_request(&connection, &request)
             .await
             .expect("should return Some");
-        let tools = resp["result"]["tools"]
+        let tools = response["result"]["tools"]
             .as_array()
             .expect("tools should be an array");
         assert!(!tools.is_empty(), "tools list must not be empty");
@@ -478,21 +483,21 @@ mod tests {
         }
         // At least one well-known tool must be present.
         assert!(
-            tools.iter().any(|t| t["name"] == "mempalace_status"),
+            tools.iter().any(|tool| tool["name"] == "mempalace_status"),
             "tools list must include 'mempalace_status'"
         );
     }
 
     #[tokio::test]
     async fn handle_request_unknown_method() {
-        let (_db, conn) = crate::test_helpers::test_db().await;
-        let req = json!({"method": "bogus", "id": 4});
-        let resp = handle_request(&conn, &req)
+        let (_database, connection) = crate::test_helpers::test_db().await;
+        let request = json!({"method": "bogus", "id": 4});
+        let response = handle_request(&connection, &request)
             .await
             .expect("should return Some");
-        assert_eq!(resp["error"]["code"], -32601);
+        assert_eq!(response["error"]["code"], -32601);
         assert!(
-            resp["error"]["message"]
+            response["error"]["message"]
                 .as_str()
                 .expect("message should be a string")
                 .contains("bogus"),
@@ -502,14 +507,14 @@ mod tests {
 
     #[tokio::test]
     async fn handle_request_non_object() {
-        let (_db, conn) = crate::test_helpers::test_db().await;
-        let req = json!("string");
-        let resp = handle_request(&conn, &req)
+        let (_database, connection) = crate::test_helpers::test_db().await;
+        let request = json!("string");
+        let response = handle_request(&connection, &request)
             .await
             .expect("should return Some");
-        assert_eq!(resp["error"]["code"], -32600);
+        assert_eq!(response["error"]["code"], -32600);
         assert!(
-            resp["error"]["message"]
+            response["error"]["message"]
                 .as_str()
                 .expect("message should be a string")
                 .contains("Invalid Request"),
@@ -518,14 +523,14 @@ mod tests {
 
     #[tokio::test]
     async fn handle_request_missing_method() {
-        let (_db, conn) = crate::test_helpers::test_db().await;
-        let req = json!({"id": 1});
-        let resp = handle_request(&conn, &req)
+        let (_database, connection) = crate::test_helpers::test_db().await;
+        let request = json!({"id": 1});
+        let response = handle_request(&connection, &request)
             .await
             .expect("should return Some");
-        assert_eq!(resp["error"]["code"], -32600);
+        assert_eq!(response["error"]["code"], -32600);
         assert!(
-            resp["error"]["message"]
+            response["error"]["message"]
                 .as_str()
                 .expect("message should be a string")
                 .contains("method"),
@@ -535,16 +540,16 @@ mod tests {
 
     #[tokio::test]
     async fn handle_request_tools_call_valid() {
-        let (_db, conn) = crate::test_helpers::test_db().await;
-        let req = json!({
+        let (_database, connection) = crate::test_helpers::test_db().await;
+        let request = json!({
             "method": "tools/call",
             "params": {"name": "mempalace_status", "arguments": {}},
             "id": 5
         });
-        let resp = handle_request(&conn, &req)
+        let response = handle_request(&connection, &request)
             .await
             .expect("should return Some");
-        let content = resp["result"]["content"]
+        let content = response["result"]["content"]
             .as_array()
             .expect("content should be an array");
         assert!(!content.is_empty(), "content array must not be empty");
@@ -553,18 +558,18 @@ mod tests {
 
     #[tokio::test]
     async fn handle_request_tools_call_missing_name() {
-        let (_db, conn) = crate::test_helpers::test_db().await;
-        let req = json!({
+        let (_database, connection) = crate::test_helpers::test_db().await;
+        let request = json!({
             "method": "tools/call",
             "params": {"arguments": {}},
             "id": 6
         });
-        let resp = handle_request(&conn, &req)
+        let response = handle_request(&connection, &request)
             .await
             .expect("should return Some");
-        assert_eq!(resp["error"]["code"], -32602);
+        assert_eq!(response["error"]["code"], -32602);
         assert!(
-            resp["error"]["message"]
+            response["error"]["message"]
                 .as_str()
                 .expect("message should be a string")
                 .contains("name"),
@@ -574,18 +579,18 @@ mod tests {
 
     #[tokio::test]
     async fn handle_request_tools_call_invalid_arguments() {
-        let (_db, conn) = crate::test_helpers::test_db().await;
-        let req = json!({
+        let (_database, connection) = crate::test_helpers::test_db().await;
+        let request = json!({
             "method": "tools/call",
             "params": {"name": "mempalace_status", "arguments": "string"},
             "id": 7
         });
-        let resp = handle_request(&conn, &req)
+        let response = handle_request(&connection, &request)
             .await
             .expect("should return Some");
-        assert_eq!(resp["error"]["code"], -32602);
+        assert_eq!(response["error"]["code"], -32602);
         assert!(
-            resp["error"]["message"]
+            response["error"]["message"]
                 .as_str()
                 .expect("message should be a string")
                 .contains("arguments"),
@@ -599,8 +604,8 @@ mod tests {
     async fn read_line_normal() {
         let cursor = Cursor::new(b"hello\n".to_vec());
         let mut reader = BufReader::new(cursor);
-        let mut buf = Vec::new();
-        let result = run_read_line_impl(&mut reader, &mut buf, 1024)
+        let mut buffer = Vec::new();
+        let result = run_read_line_impl(&mut reader, &mut buffer, 1024)
             .await
             .expect("read should succeed");
         let LineRead::Line(line) = result else {
@@ -608,22 +613,22 @@ mod tests {
         };
         assert_eq!(line, "hello");
         // Verify buffer was used for accumulation.
-        assert_eq!(buf.len(), 5, "buffer should contain 'hello' (5 bytes)");
+        assert_eq!(buffer.len(), 5, "buffer should contain 'hello' (5 bytes)");
     }
 
     #[tokio::test]
     async fn read_line_eof() {
         let cursor = Cursor::new(Vec::new());
         let mut reader = BufReader::new(cursor);
-        let mut buf = Vec::new();
-        let result = run_read_line_impl(&mut reader, &mut buf, 1024)
+        let mut buffer = Vec::new();
+        let result = run_read_line_impl(&mut reader, &mut buffer, 1024)
             .await
             .expect("read should succeed");
         assert!(
             matches!(result, LineRead::Eof),
             "expected Eof on empty input"
         );
-        assert!(buf.is_empty(), "buffer should remain empty on EOF");
+        assert!(buffer.is_empty(), "buffer should remain empty on EOF");
     }
 
     #[tokio::test]
@@ -634,8 +639,8 @@ mod tests {
         let input = "a".repeat(limit + 5) + "\n" + "ok\n";
         let cursor = Cursor::new(input.into_bytes());
         let mut reader = BufReader::new(cursor);
-        let mut buf = Vec::new();
-        let result = run_read_line_impl(&mut reader, &mut buf, limit)
+        let mut buffer = Vec::new();
+        let result = run_read_line_impl(&mut reader, &mut buffer, limit)
             .await
             .expect("read should succeed");
         assert!(
@@ -643,8 +648,8 @@ mod tests {
             "expected Overflow for line exceeding limit"
         );
         // After overflow drain, the reader must resync and return the next line.
-        buf.clear();
-        let next = run_read_line_impl(&mut reader, &mut buf, limit)
+        buffer.clear();
+        let next = run_read_line_impl(&mut reader, &mut buffer, limit)
             .await
             .expect("second read should succeed");
         let LineRead::Line(recovered) = next else {
@@ -665,8 +670,8 @@ mod tests {
         assert!(String::from_utf8(input.clone()).is_err());
         let cursor = Cursor::new(std::mem::take(&mut input));
         let mut reader = BufReader::new(cursor);
-        let mut buf = Vec::new();
-        let result = run_read_line_impl(&mut reader, &mut buf, 1024)
+        let mut buffer = Vec::new();
+        let result = run_read_line_impl(&mut reader, &mut buffer, 1024)
             .await
             .expect("read should succeed");
         assert!(
@@ -679,8 +684,8 @@ mod tests {
     async fn read_line_crlf_stripped() {
         let cursor = Cursor::new(b"hello\r\n".to_vec());
         let mut reader = BufReader::new(cursor);
-        let mut buf = Vec::new();
-        let result = run_read_line_impl(&mut reader, &mut buf, 1024)
+        let mut buffer = Vec::new();
+        let result = run_read_line_impl(&mut reader, &mut buffer, 1024)
             .await
             .expect("read should succeed");
         let LineRead::Line(line) = result else {
@@ -688,7 +693,7 @@ mod tests {
         };
         assert_eq!(line, "hello", "\\r\\n should be stripped to just 'hello'");
         // Buffer should have 'hello' without the \r.
-        assert_eq!(buf.len(), 5, "buffer should be 5 bytes after \\r strip");
+        assert_eq!(buffer.len(), 5, "buffer should be 5 bytes after \\r strip");
     }
 
     #[tokio::test]
@@ -696,8 +701,8 @@ mod tests {
         // A stream that ends without a trailing newline must return the accumulated bytes as a line.
         let cursor = Cursor::new(b"no newline at end".to_vec());
         let mut reader = BufReader::new(cursor);
-        let mut buf = Vec::new();
-        let result = run_read_line_impl(&mut reader, &mut buf, 1024)
+        let mut buffer = Vec::new();
+        let result = run_read_line_impl(&mut reader, &mut buffer, 1024)
             .await
             .expect("read should succeed");
         let LineRead::Line(line) = result else {
@@ -707,7 +712,7 @@ mod tests {
             line, "no newline at end",
             "partial line at EOF must be returned"
         );
-        assert_eq!(buf.len(), 17, "buffer must contain all bytes");
+        assert_eq!(buffer.len(), 17, "buffer must contain all bytes");
     }
 
     #[tokio::test]
@@ -717,8 +722,8 @@ mod tests {
         let input = "a".repeat(limit + 10); // No newline — entire input is one oversized line.
         let cursor = Cursor::new(input.into_bytes());
         let mut reader = BufReader::new(cursor);
-        let mut buf = Vec::new();
-        let result = run_read_line_impl(&mut reader, &mut buf, limit)
+        let mut buffer = Vec::new();
+        let result = run_read_line_impl(&mut reader, &mut buffer, limit)
             .await
             .expect("read should succeed");
         assert!(
@@ -726,8 +731,8 @@ mod tests {
             "oversized line without newline must report Overflow"
         );
         // After drain the stream is at EOF; next read must return Eof.
-        buf.clear();
-        let next = run_read_line_impl(&mut reader, &mut buf, limit)
+        buffer.clear();
+        let next = run_read_line_impl(&mut reader, &mut buffer, limit)
             .await
             .expect("second read should succeed");
         assert!(

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -113,7 +113,8 @@ async fn run_write_response(
     stdout: &mut tokio::io::Stdout,
     response: &Value,
 ) -> std::io::Result<()> {
-    let serialized_response = serde_json::to_string(response).unwrap_or_default();
+    let serialized_response = serde_json::to_string(response)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
     stdout.write_all(serialized_response.as_bytes()).await?;
     stdout.write_all(b"\n").await?;
     stdout.flush().await

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -659,6 +659,43 @@ mod tests {
         );
     }
 
+    // -- run_parse_request ---------------------------------------------------
+
+    #[test]
+    fn run_parse_request_valid_json_returns_ok() {
+        // A well-formed JSON object must be returned as a parsed Value.
+        let result = run_parse_request(r#"{"method":"ping","id":1}"#);
+        assert!(result.is_ok(), "valid JSON must return Ok");
+        let value = result.expect("valid JSON must parse");
+        assert_eq!(value["method"], "ping");
+        assert_eq!(value["id"], 1);
+    }
+
+    #[test]
+    fn run_parse_request_invalid_json_returns_error_response() {
+        // Invalid JSON must produce a JSON-RPC -32700 parse-error response.
+        let result = run_parse_request("not_valid{{{json");
+        assert!(result.is_err(), "invalid JSON must return Err");
+        let error_response = result.expect_err("invalid JSON must produce error");
+        assert_eq!(
+            error_response["error"]["code"], -32700,
+            "error code must be -32700 for a parse error"
+        );
+        assert!(
+            error_response["error"]["message"]
+                .as_str()
+                .expect("message must be a string")
+                .contains("Parse error"),
+            "error message must contain 'Parse error'"
+        );
+        // The id field must be null for parse errors (no id extracted).
+        assert_eq!(
+            error_response["id"],
+            serde_json::Value::Null,
+            "id must be null when the request cannot be parsed"
+        );
+    }
+
     // -- run_read_line tests (via run_read_line_impl) ------------------------
 
     #[tokio::test]

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -44,7 +44,7 @@ pub async fn run(connection: &Connection) -> Result<()> {
     // Reusable buffer for line reading — allocated once, cleared each iteration.
     let mut line_buffer: Vec<u8> = Vec::with_capacity(4096);
 
-    // Intentional server loop: runs until stdin closes (Eof signals EOF).
+    // Intentional: server loop runs until stdin closes.
     loop {
         let line = match run_read_line(&mut reader, &mut line_buffer, REQUEST_BYTES_MAX).await {
             Ok(LineRead::Eof) => break, // Client disconnected.
@@ -133,7 +133,13 @@ async fn run_read_line_impl<R: AsyncBufRead + Unpin>(
     assert!(limit > 0);
     buffer.clear();
 
+    let mut read_iterations: usize = 0;
     loop {
+        read_iterations += 1;
+        assert!(
+            read_iterations <= REQUEST_BYTES_MAX,
+            "run_read_line_impl: exceeded REQUEST_BYTES_MAX ({REQUEST_BYTES_MAX}) read iterations"
+        );
         let available = reader.fill_buf().await?;
 
         // EOF: return accumulated buffer or signal end-of-stream.
@@ -191,7 +197,13 @@ async fn run_read_line_impl<R: AsyncBufRead + Unpin>(
 /// Drain bytes from the reader until the next newline or EOF.
 /// Called after detecting an overlong line to resync the stream.
 async fn run_read_line_drain<R: AsyncBufRead + Unpin>(reader: &mut R) -> std::io::Result<LineRead> {
+    let mut drain_iterations: usize = 0;
     loop {
+        drain_iterations += 1;
+        assert!(
+            drain_iterations <= REQUEST_BYTES_MAX,
+            "run_read_line_drain: exceeded REQUEST_BYTES_MAX ({REQUEST_BYTES_MAX}) drain iterations"
+        );
         let available = reader.fill_buf().await?;
         if available.is_empty() {
             // EOF during drain — still report overflow so the error response is sent.

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -145,7 +145,10 @@ async fn run_read_line_impl<R: AsyncBufRead + Unpin>(
     let mut read_iterations: usize = 0;
     loop {
         read_iterations += 1;
-        assert!(
+        // debug_assert: iteration count is a proxy for bytes read; a 1-byte-per-chunk
+        // client could legitimately reach REQUEST_BYTES_MAX+1 iterations without being
+        // a logic error, so this fires only in debug builds as a sanity ceiling.
+        debug_assert!(
             read_iterations <= REQUEST_BYTES_MAX,
             "run_read_line_impl: exceeded REQUEST_BYTES_MAX ({REQUEST_BYTES_MAX}) read iterations"
         );
@@ -209,7 +212,9 @@ async fn run_read_line_drain<R: AsyncBufRead + Unpin>(reader: &mut R) -> std::io
     let mut drain_iterations: usize = 0;
     loop {
         drain_iterations += 1;
-        assert!(
+        // debug_assert: same reasoning as run_read_line_impl — iteration count is not
+        // a byte count; a slow client could legitimately exceed this in production.
+        debug_assert!(
             drain_iterations <= REQUEST_BYTES_MAX,
             "run_read_line_drain: exceeded REQUEST_BYTES_MAX ({REQUEST_BYTES_MAX}) drain iterations"
         );
@@ -399,8 +404,9 @@ fn handle_request_tools_call_respond(tool_name: &str, result: Value, req_id: &Va
             .and_then(Value::as_bool)
             .unwrap_or(false);
         // Extract the full error string before deciding what to expose.
-        // Truncate only for logging so we don't shorten public error messages.
-        let full_error = error_val.as_str().unwrap_or("unknown");
+        // Owned String so the borrow on `result` via `error_val` ends here,
+        // allowing `result` to be moved in the is_public arm below.
+        let full_error: String = error_val.as_str().unwrap_or("unknown").to_owned();
         let truncated: String = full_error.chars().take(100).collect();
         // Sanitize log fields: replace control characters so a hostile client
         // cannot inject newlines or terminal escape sequences into stderr.
@@ -414,7 +420,9 @@ fn handle_request_tools_call_respond(tool_name: &str, result: Value, req_id: &Va
             .collect();
         eprintln!("tool error: tool={tool_name_safe} error={error_safe}");
         if is_public {
-            json!({"error": full_error})
+            // Return the full result so sibling fields (e.g. "existing_drawer_id")
+            // are preserved alongside the "error" key.
+            result
         } else {
             json!({"error": "Internal tool error"})
         }

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -22,7 +22,7 @@ const SUPPORTED_PROTOCOL_VERSIONS: &[&str] =
 /// Hard cap on a single newline-delimited request frame. A client-controlled
 /// line is buffered entirely before JSON parsing, so this bound prevents OOM
 /// before any validation runs. 1 MiB comfortably fits any real tool payload.
-const MAX_REQUEST_BYTES: usize = 1024 * 1024; // 1 MiB
+const REQUEST_BYTES_MAX: usize = 1024 * 1024; // 1 MiB
 
 /// Outcome of reading a single newline-delimited frame from the buffered reader.
 enum LineRead {
@@ -46,7 +46,7 @@ pub async fn run(connection: &Connection) -> Result<()> {
 
     // Intentional server loop: runs until stdin closes (Eof signals EOF).
     loop {
-        let line = match run_read_line(&mut reader, &mut line_buffer, MAX_REQUEST_BYTES).await {
+        let line = match run_read_line(&mut reader, &mut line_buffer, REQUEST_BYTES_MAX).await {
             Ok(LineRead::Eof) => break, // Client disconnected.
             Ok(LineRead::Overflow) => {
                 let err_response = json!({

--- a/src/mcp/protocol.rs
+++ b/src/mcp/protocol.rs
@@ -27,10 +27,9 @@ Read AAAK naturally — expand codes mentally, treat *markers* as emotional cont
 When WRITING AAAK: use entity codes, mark emotions, keep structure tight.";
 
 /// Generate the tools/list response payload.
-// 22 tool schemas in a single JSON literal — splitting would hurt readability
-// with no structural benefit since each tool is a self-contained object.
-// Static JSON literal guaranteed to be an array; .as_array() cannot return None.
+// TigerStyle exemption: declarative data, not logic.
 #[allow(clippy::too_many_lines)]
+// Static JSON literal is guaranteed to be an array; `.as_array()` cannot return `None`.
 #[allow(clippy::expect_used)]
 pub fn tool_definitions() -> Vec<serde_json::Value> {
     serde_json::json!([

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -70,7 +70,9 @@ pub async fn dispatch(connection: &Connection, name: &str, args: &Value) -> Valu
 }
 
 fn str_arg<'a>(args: &'a Value, key: &str) -> &'a str {
-    args.get(key).and_then(|v| v.as_str()).unwrap_or("")
+    args.get(key)
+        .and_then(|arg_val| arg_val.as_str())
+        .unwrap_or("")
 }
 
 /// Extract a positive integer argument, coercing floats and strings.
@@ -80,11 +82,12 @@ fn str_arg<'a>(args: &'a Value, key: &str) -> &'a str {
 /// of what the client sends. Only accepts finite, whole, positive integers (>0).
 fn int_arg(args: &Value, key: &str, default: i64) -> i64 {
     args.get(key)
-        .and_then(|v| {
-            v.as_i64()
+        .and_then(|arg_val| {
+            arg_val
+                .as_i64()
                 .filter(|&n| n > 0)
                 .or_else(|| {
-                    v.as_f64().and_then(|f| {
+                    arg_val.as_f64().and_then(|f| {
                         if f.is_finite() && f > 0.0 && f <= MAX_EXACT_INT_F64 && f.fract() == 0.0 {
                             // Safe: MAX_EXACT_INT_F64 (2^53-1) < i64::MAX, so the value fits exactly
                             #[allow(clippy::cast_possible_truncation)]
@@ -95,9 +98,9 @@ fn int_arg(args: &Value, key: &str, default: i64) -> i64 {
                     })
                 })
                 .or_else(|| {
-                    v.as_str().and_then(|s| {
-                        s.parse::<i64>().ok().filter(|&n| n > 0).or_else(|| {
-                            s.parse::<f64>().ok().and_then(|f| {
+                    arg_val.as_str().and_then(|str_val| {
+                        str_val.parse::<i64>().ok().filter(|&n| n > 0).or_else(|| {
+                            str_val.parse::<f64>().ok().and_then(|f| {
                                 if f.is_finite()
                                     && f > 0.0
                                     && f <= MAX_EXACT_INT_F64
@@ -125,28 +128,36 @@ fn int_arg(args: &Value, key: &str, default: i64) -> i64 {
 /// empty, too long, contains path-traversal sequences, null bytes, an invalid
 /// first character, or characters outside `[a-zA-Z0-9_ .'-]`.
 fn sanitize_name(value: &str, field_name: &str) -> Result<String, Value> {
-    let v = value.trim();
-    if v.is_empty() {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
         return Err(
             json!({"success": false, "error": format!("{field_name} must be a non-empty string"), "public": true}),
         );
     }
-    if v.len() > 128 {
+    if trimmed.len() > 128 {
         return Err(
             json!({"success": false, "error": format!("{field_name} exceeds maximum length of 128 characters"), "public": true}),
         );
     }
-    if v.contains("..") || v.contains('/') || v.contains('\\') || v.contains('\x00') {
+    if trimmed.contains("..")
+        || trimmed.contains('/')
+        || trimmed.contains('\\')
+        || trimmed.contains('\x00')
+    {
         return Err(
             json!({"success": false, "error": format!("{field_name} contains invalid characters"), "public": true}),
         );
     }
-    if !v.chars().next().is_some_and(|c| c.is_ascii_alphanumeric()) {
+    if !trimmed
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_ascii_alphanumeric())
+    {
         return Err(
             json!({"success": false, "error": format!("{field_name} must start with an alphanumeric character"), "public": true}),
         );
     }
-    if !v
+    if !trimmed
         .chars()
         .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | ' ' | '.' | '\'' | '-'))
     {
@@ -154,7 +165,7 @@ fn sanitize_name(value: &str, field_name: &str) -> Result<String, Value> {
             json!({"success": false, "error": format!("{field_name} contains invalid characters"), "public": true}),
         );
     }
-    let result = v.to_string();
+    let result = trimmed.to_string();
 
     // Postconditions: result is non-empty, trimmed, and has no path-traversal chars.
     debug_assert!(!result.is_empty());
@@ -354,7 +365,7 @@ async fn wal_log(operation: &str, params: Value) {
                     eprintln!("WAL write failed: {e}");
                 }
             }
-            Err(e) => eprintln!("WAL write failed: {e}"),
+            Err(error) => eprintln!("WAL write failed: {error}"),
         }
     })
     .await;
@@ -369,8 +380,8 @@ async fn tool_status(connection: &Connection) -> Value {
     .await;
 
     let rows = match rows {
-        Ok(r) => r,
-        Err(e) => return json!({"error": e.to_string()}),
+        Ok(rows) => rows,
+        Err(error) => return json!({"error": error.to_string()}),
     };
 
     let mut wings: HashMap<String, i64> = HashMap::new();
@@ -413,14 +424,14 @@ async fn tool_list_wings(connection: &Connection) -> Value {
             }
             json!({"wings": wings})
         }
-        Err(e) => json!({"error": e.to_string()}),
+        Err(error) => json!({"error": error.to_string()}),
     }
 }
 
 async fn tool_list_rooms(connection: &Connection, args: &Value) -> Value {
     let wing = match sanitize_opt_name(str_arg(args, "wing"), "wing") {
-        Ok(v) => v,
-        Err(e) => return e,
+        Ok(value) => value,
+        Err(error) => return error,
     };
 
     let rows = if let Some(ref w) = wing {
@@ -449,7 +460,7 @@ async fn tool_list_rooms(connection: &Connection, args: &Value) -> Value {
             }
             json!({"wing": wing.as_deref().unwrap_or("all"), "rooms": rooms})
         }
-        Err(e) => json!({"error": e.to_string()}),
+        Err(error) => json!({"error": error.to_string()}),
     }
 }
 
@@ -472,7 +483,7 @@ async fn tool_get_taxonomy(connection: &Connection) -> Value {
             }
             json!({"taxonomy": taxonomy})
         }
-        Err(e) => json!({"error": e.to_string()}),
+        Err(error) => json!({"error": error.to_string()}),
     }
 }
 
@@ -484,12 +495,12 @@ async fn tool_search(connection: &Connection, args: &Value) -> Value {
     let limit = usize::try_from(int_arg(args, "limit", 5).clamp(1, 100)).unwrap_or(5);
     let context_received = !str_arg(args, "context").trim().is_empty();
     let wing = match sanitize_opt_name(str_arg(args, "wing"), "wing") {
-        Ok(v) => v,
-        Err(e) => return e,
+        Ok(value) => value,
+        Err(error) => return error,
     };
     let room = match sanitize_opt_name(str_arg(args, "room"), "room") {
-        Ok(v) => v,
-        Err(e) => return e,
+        Ok(value) => value,
+        Err(error) => return error,
     };
 
     // Mitigate system prompt contamination before the search (mempalace-py issue #333).
@@ -507,22 +518,22 @@ async fn tool_search(connection: &Connection, args: &Value) -> Value {
         Ok(results) => {
             let items: Vec<Value> = results
                 .iter()
-                .map(|r| {
+                .map(|result| {
                     json!({
-                        "wing": r.wing,
-                        "room": r.room,
-                        "content": r.text,
-                        "source_file": r.source_file,
-                        "created_at": r.created_at,
-                        "similarity": r.relevance,
+                        "wing": result.wing,
+                        "room": result.room,
+                        "content": result.text,
+                        "source_file": result.source_file,
+                        "created_at": result.created_at,
+                        "similarity": result.relevance,
                     })
                 })
                 .collect();
             let count = items.len();
-            let mut out = json!({"results": items, "count": count});
+            let mut output = json!({"results": items, "count": count});
             if sanitized.was_sanitized {
-                out["query_sanitized"] = json!(true);
-                out["sanitizer"] = json!({
+                output["query_sanitized"] = json!(true);
+                output["sanitizer"] = json!({
                     "method": sanitized.method,
                     "original_length": sanitized.original_length,
                     "clean_length": sanitized.clean_length,
@@ -530,11 +541,11 @@ async fn tool_search(connection: &Connection, args: &Value) -> Value {
                 });
             }
             if context_received {
-                out["context_received"] = json!(true);
+                output["context_received"] = json!(true);
             }
-            out
+            output
         }
-        Err(e) => json!({"error": e.to_string()}),
+        Err(error) => json!({"error": error.to_string()}),
     }
 }
 
@@ -545,16 +556,16 @@ async fn tool_check_duplicate(connection: &Connection, args: &Value) -> Value {
         Ok(results) => {
             let matches: Vec<Value> = results
                 .iter()
-                .filter(|r| r.relevance > 3.0) // high word overlap
-                .map(|r| {
-                    let preview = if r.text.chars().count() > 200 {
-                        format!("{}...", r.text.chars().take(200).collect::<String>())
+                .filter(|result| result.relevance > 3.0) // high word overlap
+                .map(|result| {
+                    let preview = if result.text.chars().count() > 200 {
+                        format!("{}...", result.text.chars().take(200).collect::<String>())
                     } else {
-                        r.text.clone()
+                        result.text.clone()
                     };
                     json!({
-                        "wing": r.wing,
-                        "room": r.room,
+                        "wing": result.wing,
+                        "room": result.room,
                         "content": preview,
                     })
                 })
@@ -564,7 +575,7 @@ async fn tool_check_duplicate(connection: &Connection, args: &Value) -> Value {
                 "matches": matches,
             })
         }
-        Err(e) => json!({"error": e.to_string()}),
+        Err(error) => json!({"error": error.to_string()}),
     }
 }
 
@@ -574,30 +585,34 @@ async fn tool_add_drawer(connection: &Connection, args: &Value) -> Value {
     let content = str_arg(args, "content");
     let source_file = str_arg(args, "source_file");
     let added_by = {
-        let a = str_arg(args, "added_by");
-        if a.is_empty() { "mcp" } else { a }
+        let added_by_raw = str_arg(args, "added_by");
+        if added_by_raw.is_empty() {
+            "mcp"
+        } else {
+            added_by_raw
+        }
     };
 
     let wing = match sanitize_name(wing, "wing") {
-        Ok(v) => v,
-        Err(e) => return e,
+        Ok(value) => value,
+        Err(error) => return error,
     };
     let room = match sanitize_name(room, "room") {
-        Ok(v) => v,
-        Err(e) => return e,
+        Ok(value) => value,
+        Err(error) => return error,
     };
     let content = match sanitize_content(content) {
-        Ok(v) => v,
-        Err(e) => return e,
+        Ok(value) => value,
+        Err(error) => return error,
     };
 
     // Deterministic ID: sha256(wing+room+content) so the same content in
     // the same wing/room always produces the same ID, making the call idempotent.
     let hash = sha2::Sha256::digest(format!("{wing}\u{1f}{room}\u{1f}{content}").as_bytes());
-    let hex: String = hash.iter().fold(String::new(), |mut s, b| {
+    let hex: String = hash.iter().fold(String::new(), |mut hex_string, byte| {
         use std::fmt::Write as _;
-        let _ = write!(s, "{b:02x}");
-        s
+        let _ = write!(hex_string, "{byte:02x}");
+        hex_string
     });
     let id = format!("drawer_{wing}_{room}_{}", &hex[..24]);
     // Postcondition: deterministic ID follows naming convention.
@@ -661,14 +676,14 @@ async fn tool_add_drawer_insert(
             "wing": wing,
             "room": room,
         }),
-        Err(e) => json!({"success": false, "error": e.to_string()}),
+        Err(error) => json!({"success": false, "error": error.to_string()}),
     }
 }
 
 async fn tool_delete_drawer(connection: &Connection, args: &Value) -> Value {
     let drawer_id = match sanitize_name(str_arg(args, "drawer_id"), "drawer_id") {
-        Ok(v) => v,
-        Err(e) => return e,
+        Ok(value) => value,
+        Err(error) => return error,
     };
     if !drawer_id.starts_with("drawer_") {
         return json!({"success": false, "error": "drawer_id has invalid format", "public": true});
@@ -690,15 +705,15 @@ async fn tool_delete_drawer(connection: &Connection, args: &Value) -> Value {
                 .await;
             json!({"success": true, "drawer_id": drawer_id})
         }
-        Err(e) => json!({"success": false, "error": e.to_string()}),
+        Err(error) => json!({"success": false, "error": error.to_string()}),
     }
 }
 
 /// Fetch a single drawer by ID, returning its full content and metadata.
 async fn tool_get_drawer(connection: &Connection, args: &Value) -> Value {
     let drawer_id = match sanitize_name(str_arg(args, "drawer_id"), "drawer_id") {
-        Ok(v) => v,
-        Err(e) => return e,
+        Ok(value) => value,
+        Err(error) => return error,
     };
     if !drawer_id.starts_with("drawer_") {
         return json!({"error": "drawer_id has invalid format", "public": true});
@@ -731,7 +746,7 @@ async fn tool_get_drawer(connection: &Connection, args: &Value) -> Value {
                 "filed_at": filed_at,
             })
         }
-        Err(e) => json!({"error": e.to_string()}),
+        Err(error) => json!({"error": error.to_string()}),
     }
 }
 
@@ -741,12 +756,12 @@ async fn tool_list_drawers(connection: &Connection, args: &Value) -> Value {
     let limit = int_arg(args, "limit", 20).clamp(1, MAX_LIMIT);
     let offset = int_arg(args, "offset", 0).max(0);
     let wing = match sanitize_opt_name(str_arg(args, "wing"), "wing") {
-        Ok(v) => v,
-        Err(e) => return e,
+        Ok(value) => value,
+        Err(error) => return error,
     };
     let room = match sanitize_opt_name(str_arg(args, "room"), "room") {
-        Ok(v) => v,
-        Err(e) => return e,
+        Ok(value) => value,
+        Err(error) => return error,
     };
 
     match tool_list_drawers_query(connection, wing.as_ref(), room.as_ref(), limit, offset).await {
@@ -779,7 +794,7 @@ async fn tool_list_drawers(connection: &Connection, args: &Value) -> Value {
                 "limit": limit,
             })
         }
-        Err(e) => json!({"error": e.to_string()}),
+        Err(error) => json!({"error": error.to_string()}),
     }
 }
 
@@ -796,14 +811,14 @@ async fn tool_list_drawers_query(
     offset: i64,
 ) -> crate::error::Result<Vec<turso::Row>> {
     match (wing, room) {
-        (Some(w), Some(r)) => {
-            query_all(connection, "SELECT id, content, wing, room FROM drawers WHERE wing = ?1 AND room = ?2 AND (ingest_mode IS NULL OR ingest_mode != 'diary') ORDER BY filed_at DESC, id DESC LIMIT ?3 OFFSET ?4", (w.as_str(), r.as_str(), limit, offset)).await
+        (Some(wing_value), Some(room_value)) => {
+            query_all(connection, "SELECT id, content, wing, room FROM drawers WHERE wing = ?1 AND room = ?2 AND (ingest_mode IS NULL OR ingest_mode != 'diary') ORDER BY filed_at DESC, id DESC LIMIT ?3 OFFSET ?4", (wing_value.as_str(), room_value.as_str(), limit, offset)).await
         }
-        (Some(w), None) => {
-            query_all(connection, "SELECT id, content, wing, room FROM drawers WHERE wing = ?1 AND (ingest_mode IS NULL OR ingest_mode != 'diary') ORDER BY filed_at DESC, id DESC LIMIT ?2 OFFSET ?3", (w.as_str(), limit, offset)).await
+        (Some(wing_value), None) => {
+            query_all(connection, "SELECT id, content, wing, room FROM drawers WHERE wing = ?1 AND (ingest_mode IS NULL OR ingest_mode != 'diary') ORDER BY filed_at DESC, id DESC LIMIT ?2 OFFSET ?3", (wing_value.as_str(), limit, offset)).await
         }
-        (None, Some(r)) => {
-            query_all(connection, "SELECT id, content, wing, room FROM drawers WHERE room = ?1 AND (ingest_mode IS NULL OR ingest_mode != 'diary') ORDER BY filed_at DESC, id DESC LIMIT ?2 OFFSET ?3", (r.as_str(), limit, offset)).await
+        (None, Some(room_value)) => {
+            query_all(connection, "SELECT id, content, wing, room FROM drawers WHERE room = ?1 AND (ingest_mode IS NULL OR ingest_mode != 'diary') ORDER BY filed_at DESC, id DESC LIMIT ?2 OFFSET ?3", (room_value.as_str(), limit, offset)).await
         }
         (None, None) => {
             query_all(connection, "SELECT id, content, wing, room FROM drawers WHERE (ingest_mode IS NULL OR ingest_mode != 'diary') ORDER BY filed_at DESC, id DESC LIMIT ?1 OFFSET ?2", (limit, offset)).await
@@ -822,8 +837,8 @@ async fn tool_list_drawers_query(
 #[allow(clippy::too_many_lines)]
 async fn tool_update_drawer(connection: &Connection, args: &Value) -> Value {
     let drawer_id = match sanitize_name(str_arg(args, "drawer_id"), "drawer_id") {
-        Ok(v) => v,
-        Err(e) => return e,
+        Ok(value) => value,
+        Err(error) => return error,
     };
     // Diary entries use UUID IDs; they must not be mutated via this handler.
     if !drawer_id.starts_with("drawer_") {
@@ -831,23 +846,23 @@ async fn tool_update_drawer(connection: &Connection, args: &Value) -> Value {
     }
 
     let new_content = {
-        let s = str_arg(args, "content");
-        if s.is_empty() {
+        let content_raw = str_arg(args, "content");
+        if content_raw.is_empty() {
             None
         } else {
-            match sanitize_content(s) {
-                Ok(v) => Some(v),
-                Err(e) => return e,
+            match sanitize_content(content_raw) {
+                Ok(value) => Some(value),
+                Err(error) => return error,
             }
         }
     };
     let new_wing = match sanitize_opt_name(str_arg(args, "wing"), "wing") {
-        Ok(v) => v,
-        Err(e) => return e,
+        Ok(value) => value,
+        Err(error) => return error,
     };
     let new_room = match sanitize_opt_name(str_arg(args, "room"), "room") {
-        Ok(v) => v,
-        Err(e) => return e,
+        Ok(value) => value,
+        Err(error) => return error,
     };
 
     // No-op: nothing to change
@@ -864,8 +879,8 @@ async fn tool_update_drawer(connection: &Connection, args: &Value) -> Value {
     .await;
 
     let rows = match rows {
-        Ok(r) => r,
-        Err(e) => return json!({"success": false, "error": e.to_string()}),
+        Ok(rows) => rows,
+        Err(error) => return json!({"success": false, "error": error.to_string()}),
     };
 
     if rows.is_empty() {
@@ -885,10 +900,10 @@ async fn tool_update_drawer(connection: &Connection, args: &Value) -> Value {
     let hash = sha2::Sha256::digest(
         format!("{final_wing}\u{1f}{final_room}\u{1f}{final_content}").as_bytes(),
     );
-    let hex: String = hash.iter().fold(String::new(), |mut s, b| {
+    let hex: String = hash.iter().fold(String::new(), |mut hex_string, byte| {
         use std::fmt::Write as _;
-        let _ = write!(s, "{b:02x}");
-        s
+        let _ = write!(hex_string, "{byte:02x}");
+        hex_string
     });
     let new_id = format!("drawer_{final_wing}_{final_room}_{}", &hex[..24]);
 
@@ -924,7 +939,7 @@ async fn tool_update_drawer(connection: &Connection, args: &Value) -> Value {
                     "public": true,
                 });
             }
-            Err(e) => return json!({"success": false, "error": e.to_string()}),
+            Err(error) => return json!({"success": false, "error": error.to_string()}),
             Ok(_) => {}
         }
     }
@@ -996,20 +1011,24 @@ async fn tool_update_drawer(connection: &Connection, args: &Value) -> Value {
 
 async fn tool_kg_query(connection: &Connection, args: &Value) -> Value {
     let entity = match sanitize_kg_value(str_arg(args, "entity"), "entity") {
-        Ok(v) => v,
-        Err(e) => return e,
+        Ok(value) => value,
+        Err(error) => return error,
     };
     let as_of = {
-        let a = str_arg(args, "as_of");
-        if a.is_empty() {
+        let as_of_raw = str_arg(args, "as_of");
+        if as_of_raw.is_empty() {
             None
         } else {
-            Some(a.to_string())
+            Some(as_of_raw.to_string())
         }
     };
     let direction = {
-        let d = str_arg(args, "direction");
-        if d.is_empty() { "both" } else { d }
+        let direction_raw = str_arg(args, "direction");
+        if direction_raw.is_empty() {
+            "both"
+        } else {
+            direction_raw
+        }
     };
     if !matches!(direction, "outgoing" | "incoming" | "both") {
         return json!({"error": "direction must be 'outgoing', 'incoming', or 'both'", "public": true});
@@ -1020,7 +1039,7 @@ async fn tool_kg_query(connection: &Connection, args: &Value) -> Value {
             let count = facts.len();
             json!({"entity": entity, "as_of": as_of, "facts": facts, "count": count})
         }
-        Err(e) => json!({"error": e.to_string()}),
+        Err(error) => json!({"error": error.to_string()}),
     }
 }
 
@@ -1029,33 +1048,33 @@ async fn tool_kg_add(connection: &Connection, args: &Value) -> Value {
     let predicate = str_arg(args, "predicate");
     let object = str_arg(args, "object");
     let valid_from = {
-        let v = str_arg(args, "valid_from");
-        if v.is_empty() {
+        let valid_from_raw = str_arg(args, "valid_from");
+        if valid_from_raw.is_empty() {
             None
         } else {
-            Some(v.to_string())
+            Some(valid_from_raw.to_string())
         }
     };
     let source_closet = {
-        let s = str_arg(args, "source_closet");
-        if s.is_empty() {
+        let source_closet_raw = str_arg(args, "source_closet");
+        if source_closet_raw.is_empty() {
             None
         } else {
-            Some(s.to_string())
+            Some(source_closet_raw.to_string())
         }
     };
 
     let subject = match sanitize_kg_value(subject, "subject") {
-        Ok(v) => v,
-        Err(e) => return e,
+        Ok(value) => value,
+        Err(error) => return error,
     };
     let predicate = match sanitize_name(predicate, "predicate") {
-        Ok(v) => v,
-        Err(e) => return e,
+        Ok(value) => value,
+        Err(error) => return error,
     };
     let object = match sanitize_kg_value(object, "object") {
-        Ok(v) => v,
-        Err(e) => return e,
+        Ok(value) => value,
+        Err(error) => return error,
     };
 
     wal_log(
@@ -1090,7 +1109,7 @@ async fn tool_kg_add(connection: &Connection, args: &Value) -> Value {
             "triple_id": triple_id,
             "fact": format!("{subject} → {predicate} → {object}"),
         }),
-        Err(e) => json!({"success": false, "error": e.to_string()}),
+        Err(error) => json!({"success": false, "error": error.to_string()}),
     }
 }
 
@@ -1099,25 +1118,25 @@ async fn tool_kg_invalidate(connection: &Connection, args: &Value) -> Value {
     let predicate = str_arg(args, "predicate");
     let object = str_arg(args, "object");
     let ended = {
-        let e = str_arg(args, "ended");
-        if e.is_empty() {
+        let ended_raw = str_arg(args, "ended");
+        if ended_raw.is_empty() {
             None
         } else {
-            Some(e.to_string())
+            Some(ended_raw.to_string())
         }
     };
 
     let subject = match sanitize_kg_value(subject, "subject") {
-        Ok(v) => v,
-        Err(e) => return e,
+        Ok(value) => value,
+        Err(error) => return error,
     };
     let predicate = match sanitize_name(predicate, "predicate") {
-        Ok(v) => v,
-        Err(e) => return e,
+        Ok(value) => value,
+        Err(error) => return error,
     };
     let object = match sanitize_kg_value(object, "object") {
-        Ok(v) => v,
-        Err(e) => return e,
+        Ok(value) => value,
+        Err(error) => return error,
     };
 
     // Perform the mutation first so the WAL records persisted_ended — the value
@@ -1136,7 +1155,7 @@ async fn tool_kg_invalidate(connection: &Connection, args: &Value) -> Value {
                 "ended": persisted_ended,
             })
         }
-        Err(e) => json!({"success": false, "error": e.to_string()}),
+        Err(error) => json!({"success": false, "error": error.to_string()}),
     }
 }
 
@@ -1147,8 +1166,8 @@ async fn tool_kg_timeline(connection: &Connection, args: &Value) -> Value {
             None
         } else {
             match sanitize_kg_value(raw_entity, "entity") {
-                Ok(v) => Some(v),
-                Err(e) => return e,
+                Ok(sanitized_val) => Some(sanitized_val),
+                Err(error) => return error,
             }
         }
     };
@@ -1162,83 +1181,83 @@ async fn tool_kg_timeline(connection: &Connection, args: &Value) -> Value {
                 "count": count,
             })
         }
-        Err(e) => json!({"error": e.to_string()}),
+        Err(error) => json!({"error": error.to_string()}),
     }
 }
 
 async fn tool_kg_stats(connection: &Connection) -> Value {
     match kg::query::stats(connection).await {
         Ok(stats) => json!(stats),
-        Err(e) => json!({"error": e.to_string()}),
+        Err(error) => json!({"error": error.to_string()}),
     }
 }
 
 async fn tool_traverse(connection: &Connection, args: &Value) -> Value {
     let start_room = match sanitize_name(str_arg(args, "start_room"), "start_room") {
-        Ok(v) => v,
-        Err(e) => return e,
+        Ok(value) => value,
+        Err(error) => return error,
     };
     let max_hops = usize::try_from(int_arg(args, "max_hops", 2).clamp(1, 10)).unwrap_or(2);
 
     match graph::traverse(connection, &start_room, max_hops).await {
         Ok((results, truncated)) => json!({"results": results, "truncated": truncated}),
-        Err(e) => json!({"error": e.to_string()}),
+        Err(error) => json!({"error": error.to_string()}),
     }
 }
 
 async fn tool_find_tunnels(connection: &Connection, args: &Value) -> Value {
     let wing_a = match sanitize_opt_name(str_arg(args, "wing_a"), "wing_a") {
-        Ok(v) => v,
-        Err(e) => return e,
+        Ok(value) => value,
+        Err(error) => return error,
     };
     let wing_b = match sanitize_opt_name(str_arg(args, "wing_b"), "wing_b") {
-        Ok(v) => v,
-        Err(e) => return e,
+        Ok(value) => value,
+        Err(error) => return error,
     };
 
     match graph::find_tunnels(connection, wing_a.as_deref(), wing_b.as_deref()).await {
         Ok((tunnels, truncated)) => json!({"tunnels": tunnels, "truncated": truncated}),
-        Err(e) => json!({"error": e.to_string()}),
+        Err(error) => json!({"error": error.to_string()}),
     }
 }
 
 async fn tool_graph_stats(connection: &Connection) -> Value {
     match graph::graph_stats(connection).await {
         Ok(stats) => json!(stats),
-        Err(e) => json!({"error": e.to_string()}),
+        Err(error) => json!({"error": error.to_string()}),
     }
 }
 
 async fn tool_create_tunnel(connection: &Connection, args: &Value) -> Value {
     let source_wing = match sanitize_name(str_arg(args, "source_wing"), "source_wing") {
-        Ok(v) => v,
-        Err(e) => return e,
+        Ok(value) => value,
+        Err(error) => return error,
     };
     let source_room = match sanitize_name(str_arg(args, "source_room"), "source_room") {
-        Ok(v) => v,
-        Err(e) => return e,
+        Ok(value) => value,
+        Err(error) => return error,
     };
     let target_wing = match sanitize_name(str_arg(args, "target_wing"), "target_wing") {
-        Ok(v) => v,
-        Err(e) => return e,
+        Ok(value) => value,
+        Err(error) => return error,
     };
     let target_room = match sanitize_name(str_arg(args, "target_room"), "target_room") {
-        Ok(v) => v,
-        Err(e) => return e,
+        Ok(value) => value,
+        Err(error) => return error,
     };
     let label = match sanitize_label(str_arg(args, "label")) {
-        Ok(v) => v,
-        Err(e) => return e,
+        Ok(value) => value,
+        Err(error) => return error,
     };
     let source_drawer_id =
         match sanitize_opt_name(str_arg(args, "source_drawer_id"), "source_drawer_id") {
-            Ok(v) => v,
-            Err(e) => return e,
+            Ok(value) => value,
+            Err(error) => return error,
         };
     let target_drawer_id =
         match sanitize_opt_name(str_arg(args, "target_drawer_id"), "target_drawer_id") {
-            Ok(v) => v,
-            Err(e) => return e,
+            Ok(value) => value,
+            Err(error) => return error,
         };
 
     match graph::create_tunnel(
@@ -1272,19 +1291,19 @@ async fn tool_create_tunnel(connection: &Connection, args: &Value) -> Value {
             .await;
             json!(tunnel)
         }
-        Err(e) => json!({"error": e.to_string()}),
+        Err(error) => json!({"error": error.to_string()}),
     }
 }
 
 async fn tool_list_tunnels(connection: &Connection, args: &Value) -> Value {
     let wing = match sanitize_opt_name(str_arg(args, "wing"), "wing") {
-        Ok(v) => v,
-        Err(e) => return e,
+        Ok(value) => value,
+        Err(error) => return error,
     };
 
     match graph::list_tunnels(connection, wing.as_deref()).await {
         Ok(tunnels) => json!({"tunnels": tunnels, "count": tunnels.len()}),
-        Err(e) => json!({"error": e.to_string()}),
+        Err(error) => json!({"error": error.to_string()}),
     }
 }
 
@@ -1304,23 +1323,23 @@ async fn tool_delete_tunnel(connection: &Connection, args: &Value) -> Value {
 
     match graph::delete_tunnel(connection, tunnel_id).await {
         Ok(deleted) => json!({"deleted": deleted, "tunnel_id": tunnel_id}),
-        Err(e) => json!({"error": e.to_string()}),
+        Err(error) => json!({"error": error.to_string()}),
     }
 }
 
 async fn tool_follow_tunnels(connection: &Connection, args: &Value) -> Value {
     let wing = match sanitize_name(str_arg(args, "wing"), "wing") {
-        Ok(v) => v,
-        Err(e) => return e,
+        Ok(value) => value,
+        Err(error) => return error,
     };
     let room = match sanitize_name(str_arg(args, "room"), "room") {
-        Ok(v) => v,
-        Err(e) => return e,
+        Ok(value) => value,
+        Err(error) => return error,
     };
 
     match graph::follow_tunnels(connection, &wing, &room).await {
         Ok(connections) => json!({"wing": wing, "room": room, "connections": connections}),
-        Err(e) => json!({"error": e.to_string()}),
+        Err(error) => json!({"error": error.to_string()}),
     }
 }
 
@@ -1328,24 +1347,24 @@ async fn tool_diary_write(connection: &Connection, args: &Value) -> Value {
     let agent_name = str_arg(args, "agent_name");
     let entry = str_arg(args, "entry");
     let topic = {
-        let t = str_arg(args, "topic");
-        if t.is_empty() {
+        let topic_raw = str_arg(args, "topic");
+        if topic_raw.is_empty() {
             "general".to_string()
         } else {
-            match sanitize_name(t, "topic") {
-                Ok(v) => v,
-                Err(e) => return e,
+            match sanitize_name(topic_raw, "topic") {
+                Ok(value) => value,
+                Err(error) => return error,
             }
         }
     };
 
     let agent_name = match sanitize_name(agent_name, "agent_name") {
-        Ok(v) => v,
-        Err(e) => return e,
+        Ok(value) => value,
+        Err(error) => return error,
     };
     let entry = match sanitize_content(entry) {
-        Ok(v) => v,
-        Err(e) => return e,
+        Ok(value) => value,
+        Err(error) => return error,
     };
 
     let wing = format!("wing_{}", agent_name.to_lowercase().replace(' ', "_"));
@@ -1381,7 +1400,7 @@ async fn tool_diary_write(connection: &Connection, args: &Value) -> Value {
                 "timestamp": now.to_rfc3339(),
             })
         }
-        Err(e) => json!({"success": false, "error": e.to_string()}),
+        Err(error) => json!({"success": false, "error": error.to_string()}),
     }
 }
 
@@ -1390,8 +1409,8 @@ async fn tool_diary_read(connection: &Connection, args: &Value) -> Value {
     let last_n = int_arg(args, "last_n", 10).clamp(1, 100);
 
     let agent_name = match sanitize_name(agent_name, "agent_name") {
-        Ok(v) => v,
-        Err(e) => return e,
+        Ok(value) => value,
+        Err(error) => return error,
     };
 
     let wing = format!("wing_{}", agent_name.to_lowercase().replace(' ', "_"));
@@ -1428,7 +1447,7 @@ async fn tool_diary_read(connection: &Connection, args: &Value) -> Value {
                 "showing": total,
             })
         }
-        Err(e) => json!({"error": e.to_string()}),
+        Err(error) => json!({"error": error.to_string()}),
     }
 }
 
@@ -1538,24 +1557,24 @@ mod tests {
     async fn add_drawer_missing_required_fields_returns_error() {
         with_isolated_env(|connection| async move {
             // Missing content
-            let r = tool_add_drawer(&connection, &json!({"wing": "w", "room": "r"})).await;
-            assert_eq!(r["success"], false);
+            let result = tool_add_drawer(&connection, &json!({"wing": "w", "room": "r"})).await;
+            assert_eq!(result["success"], false);
 
             // Missing wing
-            let r = tool_add_drawer(
+            let result = tool_add_drawer(
                 &connection,
                 &json!({"room": "r", "content": "some text here for testing"}),
             )
             .await;
-            assert_eq!(r["success"], false);
+            assert_eq!(result["success"], false);
 
             // Missing room
-            let r = tool_add_drawer(
+            let result = tool_add_drawer(
                 &connection,
                 &json!({"wing": "w", "content": "some text here for testing"}),
             )
             .await;
-            assert_eq!(r["success"], false);
+            assert_eq!(result["success"], false);
         })
         .await;
     }
@@ -2021,8 +2040,8 @@ mod tests {
 
             let result = tool_list_drawers(&connection, &json!({"wing": "alpha"})).await;
             assert_eq!(result["count"], 1);
-            let d = &result["drawers"][0];
-            assert_eq!(d["wing"], "alpha");
+            let drawer = &result["drawers"][0];
+            assert_eq!(drawer["wing"], "alpha");
         })
         .await;
     }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -551,7 +551,7 @@ async fn tool_search(connection: &Connection, args: &Value) -> Value {
 
 async fn tool_check_duplicate(connection: &Connection, args: &Value) -> Value {
     let content = str_arg(args, "content");
-    // Simple keyword overlap check since we don't have vector similarity
+    // Simple keyword overlap check since we don't have vector similarity.
     match search::search_memories(connection, content, None, None, 5).await {
         Ok(results) => {
             let matches: Vec<Value> = results
@@ -696,7 +696,7 @@ async fn tool_delete_drawer(connection: &Connection, args: &Value) -> Value {
         .await
     {
         Ok(_) => {
-            // Also clean up inverted index
+            // Also clean up inverted index.
             let _ = connection
                 .execute(
                     "DELETE FROM drawer_words WHERE drawer_id = ?",
@@ -865,12 +865,12 @@ async fn tool_update_drawer(connection: &Connection, args: &Value) -> Value {
         Err(error) => return error,
     };
 
-    // No-op: nothing to change
+    // No-op: nothing to change.
     if content_new.is_none() && wing_new.is_none() && room_new.is_none() {
         return json!({"success": true, "drawer_id": drawer_id, "noop": true});
     }
 
-    // Fetch existing drawer
+    // Fetch existing drawer.
     let rows = query_all(
         connection,
         "SELECT wing, room, content FROM drawers WHERE id = ?",
@@ -1382,7 +1382,7 @@ async fn tool_diary_write(connection: &Connection, args: &Value) -> Value {
     )
     .await;
 
-    // Use direct SQL to also set extract_mode (topic) which DrawerParams doesn't support
+    // Use direct SQL to also set extract_mode (topic) which DrawerParams doesn't support.
     match connection
         .execute(
             "INSERT OR IGNORE INTO drawers (id, wing, room, content, source_file, chunk_index, added_by, ingest_mode, extract_mode) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
@@ -1556,11 +1556,11 @@ mod tests {
     #[tokio::test]
     async fn add_drawer_missing_required_fields_returns_error() {
         with_isolated_env(|connection| async move {
-            // Missing content
+            // Missing content.
             let result = tool_add_drawer(&connection, &json!({"wing": "w", "room": "r"})).await;
             assert_eq!(result["success"], false);
 
-            // Missing wing
+            // Missing wing.
             let result = tool_add_drawer(
                 &connection,
                 &json!({"room": "r", "content": "some text here for testing"}),
@@ -1568,7 +1568,7 @@ mod tests {
             .await;
             assert_eq!(result["success"], false);
 
-            // Missing room
+            // Missing room.
             let result = tool_add_drawer(
                 &connection,
                 &json!({"wing": "w", "content": "some text here for testing"}),
@@ -1861,7 +1861,7 @@ mod tests {
 
             let result = tool_search(&connection, &json!({"query": "rust", "wing": "tech"})).await;
             assert!(result.get("error").is_none(), "search must not error");
-            // All returned results should be from the "tech" wing
+            // All returned results should be from the "tech" wing.
             let results = result["results"].as_array().expect("results must be array");
             for r in results {
                 assert_eq!(r["wing"], "tech");
@@ -1902,14 +1902,14 @@ mod tests {
             )
             .await;
 
-            // Check with very similar content — duplicate detection uses word overlap
+            // Check with very similar content — duplicate detection uses word overlap.
             let result = tool_check_duplicate(
                 &connection,
                 &json!({"content": "rust programming language memory safety ownership borrowing lifetimes"}),
             )
             .await;
             assert!(result.get("error").is_none(), "must not error");
-            // is_duplicate is present regardless
+            // is_duplicate is present regardless.
             assert!(
                 result.get("is_duplicate").is_some(),
                 "is_duplicate key must exist"
@@ -2013,12 +2013,12 @@ mod tests {
             seed_drawer(&connection, "w", "r", "second content for pagination test").await;
             seed_drawer(&connection, "w", "r", "third content for pagination test").await;
 
-            // Limit to 2
+            // Limit to 2.
             let result = tool_list_drawers(&connection, &json!({"limit": 2})).await;
             assert_eq!(result["count"], 2);
             assert_eq!(result["limit"], 2);
 
-            // Offset to get the third
+            // Offset to get the third.
             let result2 = tool_list_drawers(&connection, &json!({"limit": 2, "offset": 2})).await;
             assert_eq!(result2["count"], 1);
             assert_eq!(result2["offset"], 2);
@@ -2063,7 +2063,7 @@ mod tests {
             )
             .await;
             assert_eq!(result["success"], true);
-            // ID changes because content changed (deterministic ID includes content)
+            // ID changes because content changed (deterministic ID includes content).
             assert_ne!(
                 result["drawer_id"].as_str().expect("new id"),
                 old_id,
@@ -2104,7 +2104,7 @@ mod tests {
                 .as_str()
                 .expect("drawer_id must be string");
 
-            // Send update with no actual changes
+            // Send update with no actual changes.
             let result = tool_update_drawer(&connection, &json!({"drawer_id": drawer_id})).await;
             assert_eq!(result["success"], true);
             assert_eq!(result["noop"], true);
@@ -2138,7 +2138,7 @@ mod tests {
     #[tokio::test]
     async fn kg_add_missing_field_returns_error() {
         with_isolated_env(|connection| async move {
-            // Missing object
+            // Missing object.
             let result =
                 tool_kg_add(&connection, &json!({"subject": "Rust", "predicate": "is"})).await;
             assert_eq!(result["success"], false);
@@ -2152,7 +2152,7 @@ mod tests {
     #[tokio::test]
     async fn kg_query_entity() {
         with_isolated_env(|connection| async move {
-            // Add a triple first
+            // Add a triple first.
             tool_kg_add(
                 &connection,
                 &json!({"subject": "Rust", "predicate": "compilesTo", "object": "binary"}),
@@ -2400,7 +2400,7 @@ mod tests {
     #[tokio::test]
     async fn delete_tunnel_nonexistent_returns_false() {
         with_isolated_env(|connection| async move {
-            // Valid 16-char hex that doesn't exist
+            // Valid 16-char hex that doesn't exist.
             let result =
                 tool_delete_tunnel(&connection, &json!({"tunnel_id": "0000000000000000"})).await;
             assert!(result.get("error").is_none(), "must not error");
@@ -2436,7 +2436,7 @@ mod tests {
                 tool_follow_tunnels(&connection, &json!({"wing": "alpha", "room": "code"})).await;
             assert!(result.get("error").is_none(), "must not error");
             assert_eq!(result["wing"], "alpha");
-            // Should find at least one connection from the seeded tunnel
+            // Should find at least one connection from the seeded tunnel.
             let conns = result["connections"]
                 .as_array()
                 .expect("connections must be array");
@@ -2463,7 +2463,7 @@ mod tests {
     #[tokio::test]
     async fn traverse_with_shared_room() {
         with_isolated_env(|connection| async move {
-            // Two wings sharing the same room name creates a graph edge
+            // Two wings sharing the same room name creates a graph edge.
             seed_drawer(
                 &connection,
                 "alpha",
@@ -2505,7 +2505,7 @@ mod tests {
     #[tokio::test]
     async fn find_tunnels_between_wings() {
         with_isolated_env(|connection| async move {
-            // Create drawers in two wings sharing a room name
+            // Create drawers in two wings sharing a room name.
             seed_drawer(&connection, "alpha", "shared", "alpha shared content here").await;
             seed_drawer(&connection, "beta", "shared", "beta shared content here").await;
 
@@ -2691,7 +2691,7 @@ mod tests {
     async fn dispatch_routes_to_correct_tool() {
         with_isolated_env(|connection| async move {
             let result = dispatch(&connection, "mempalace_status", &json!({})).await;
-            // tool_status returns total_drawers, proving it was routed correctly
+            // tool_status returns total_drawers, proving it was routed correctly.
             assert!(
                 result.get("total_drawers").is_some(),
                 "must route to tool_status"

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -247,7 +247,7 @@ fn sanitize_label(value: &str) -> Result<String, Value> {
             json!({"success": false, "error": "label must be a non-empty string", "public": true}),
         );
     }
-    if trimmed.len() > LABEL_LEN_MAX {
+    if trimmed.chars().count() > LABEL_LEN_MAX {
         return Err(
             json!({"success": false, "error": format!("label exceeds maximum length of {LABEL_LEN_MAX} characters"), "public": true}),
         );
@@ -263,7 +263,7 @@ fn sanitize_label(value: &str) -> Result<String, Value> {
     debug_assert!(!result.is_empty());
     debug_assert!(result == result.trim());
     debug_assert!(!result.contains('\0'));
-    debug_assert!(result.len() <= LABEL_LEN_MAX);
+    debug_assert!(result.chars().count() <= LABEL_LEN_MAX);
 
     Ok(result)
 }
@@ -1006,19 +1006,6 @@ async fn tool_update_drawer(connection: &Connection, args: &Value) -> Value {
     // Recompute the deterministic ID to keep it consistent with tool_add_drawer.
     // wing/room/content are all baked into the ID, so any change means a new ID.
     let id_new = tool_update_drawer_recompute_id(final_wing, final_room, final_content);
-    wal_log(
-        "update_drawer",
-        json!({
-            "drawer_id": parsed.drawer_id,
-            "new_drawer_id": id_new,
-            "old_wing": wing_old,
-            "old_room": room_old,
-            "new_wing": final_wing,
-            "new_room": final_room,
-            "content_changed": parsed.content_new.is_some(),
-        }),
-    )
-    .await;
 
     // If the recomputed ID already exists (and differs), the new wing+room+content
     // is a duplicate of another drawer — reject to prevent silent duplication.
@@ -1040,6 +1027,23 @@ async fn tool_update_drawer(connection: &Connection, args: &Value) -> Value {
     {
         return error;
     }
+
+    // WAL entry is written only after both validation and the transaction commit
+    // succeed — a bogus log entry would be written if wal_log ran before either check.
+    wal_log(
+        "update_drawer",
+        json!({
+            "drawer_id": parsed.drawer_id,
+            "new_drawer_id": id_new,
+            "old_wing": wing_old,
+            "old_room": room_old,
+            "new_wing": final_wing,
+            "new_room": final_room,
+            "content_changed": parsed.content_new.is_some(),
+        }),
+    )
+    .await;
+
     json!({
         "success": true,
         "drawer_id": id_new,

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -16,12 +16,12 @@ use super::protocol::{AAAK_SPEC, PALACE_PROTOCOL};
 
 /// Largest integer exactly representable as an f64 (2^53 − 1).
 /// Values above this lose precision when stored in f64, so we reject them.
-const MAX_EXACT_INT_F64: f64 = 9_007_199_254_740_991.0;
+const EXACT_INT_F64_MAX: f64 = 9_007_199_254_740_991.0;
 
 /// Maximum byte length for a tunnel label.  Labels are free-form strings stored
 /// in `SQLite`; without a cap an unbounded value could waste DB space or overflow
 /// index rows.  255 characters is generous for a short descriptive label.
-const MAX_LABEL_LEN: usize = 255;
+const LABEL_LEN_MAX: usize = 255;
 
 /// Exact character length of a tunnel ID.  Tunnel IDs are the first 16 hex
 /// characters of a SHA256 digest (see `canonical_tunnel_id` in graph.rs).
@@ -88,8 +88,8 @@ fn int_arg(args: &Value, key: &str, default: i64) -> i64 {
                 .filter(|&n| n > 0)
                 .or_else(|| {
                     arg_val.as_f64().and_then(|f| {
-                        if f.is_finite() && f > 0.0 && f <= MAX_EXACT_INT_F64 && f.fract() == 0.0 {
-                            // Safe: MAX_EXACT_INT_F64 (2^53-1) < i64::MAX, so the value fits exactly
+                        if f.is_finite() && f > 0.0 && f <= EXACT_INT_F64_MAX && f.fract() == 0.0 {
+                            // Safe: EXACT_INT_F64_MAX (2^53-1) < i64::MAX, so the value fits exactly
                             #[allow(clippy::cast_possible_truncation)]
                             Some(f as i64)
                         } else {
@@ -103,10 +103,10 @@ fn int_arg(args: &Value, key: &str, default: i64) -> i64 {
                             str_val.parse::<f64>().ok().and_then(|f| {
                                 if f.is_finite()
                                     && f > 0.0
-                                    && f <= MAX_EXACT_INT_F64
+                                    && f <= EXACT_INT_F64_MAX
                                     && f.fract() == 0.0
                                 {
-                                    // Safe: MAX_EXACT_INT_F64 (2^53-1) < i64::MAX, so the value fits exactly
+                                    // Safe: EXACT_INT_F64_MAX (2^53-1) < i64::MAX, so the value fits exactly
                                     #[allow(clippy::cast_possible_truncation)]
                                     Some(f as i64)
                                 } else {
@@ -245,9 +245,9 @@ fn sanitize_label(value: &str) -> Result<String, Value> {
             json!({"success": false, "error": "label must be a non-empty string", "public": true}),
         );
     }
-    if trimmed.len() > MAX_LABEL_LEN {
+    if trimmed.len() > LABEL_LEN_MAX {
         return Err(
-            json!({"success": false, "error": format!("label exceeds maximum length of {MAX_LABEL_LEN} characters"), "public": true}),
+            json!({"success": false, "error": format!("label exceeds maximum length of {LABEL_LEN_MAX} characters"), "public": true}),
         );
     }
     if trimmed.contains('\0') {
@@ -261,7 +261,7 @@ fn sanitize_label(value: &str) -> Result<String, Value> {
     debug_assert!(!result.is_empty());
     debug_assert!(result == result.trim());
     debug_assert!(!result.contains('\0'));
-    debug_assert!(result.len() <= MAX_LABEL_LEN);
+    debug_assert!(result.len() <= LABEL_LEN_MAX);
 
     Ok(result)
 }
@@ -752,8 +752,8 @@ async fn tool_get_drawer(connection: &Connection, args: &Value) -> Value {
 
 /// List drawers with optional wing/room filtering and cursor-style pagination.
 async fn tool_list_drawers(connection: &Connection, args: &Value) -> Value {
-    const MAX_LIMIT: i64 = 100;
-    let limit = int_arg(args, "limit", 20).clamp(1, MAX_LIMIT);
+    const LIMIT_MAX: i64 = 100;
+    let limit = int_arg(args, "limit", 20).clamp(1, LIMIT_MAX);
     let offset = int_arg(args, "offset", 0).max(0);
     let wing = match sanitize_opt_name(str_arg(args, "wing"), "wing") {
         Ok(value) => value,
@@ -845,7 +845,7 @@ async fn tool_update_drawer(connection: &Connection, args: &Value) -> Value {
         return json!({"success": false, "error": "drawer_id has invalid format", "public": true});
     }
 
-    let new_content = {
+    let content_new = {
         let content_raw = str_arg(args, "content");
         if content_raw.is_empty() {
             None
@@ -856,17 +856,17 @@ async fn tool_update_drawer(connection: &Connection, args: &Value) -> Value {
             }
         }
     };
-    let new_wing = match sanitize_opt_name(str_arg(args, "wing"), "wing") {
+    let wing_new = match sanitize_opt_name(str_arg(args, "wing"), "wing") {
         Ok(value) => value,
         Err(error) => return error,
     };
-    let new_room = match sanitize_opt_name(str_arg(args, "room"), "room") {
+    let room_new = match sanitize_opt_name(str_arg(args, "room"), "room") {
         Ok(value) => value,
         Err(error) => return error,
     };
 
     // No-op: nothing to change
-    if new_content.is_none() && new_wing.is_none() && new_room.is_none() {
+    if content_new.is_none() && wing_new.is_none() && room_new.is_none() {
         return json!({"success": true, "drawer_id": drawer_id, "noop": true});
     }
 
@@ -887,13 +887,13 @@ async fn tool_update_drawer(connection: &Connection, args: &Value) -> Value {
         return json!({"success": false, "error": format!("Drawer not found: {drawer_id}"), "public": true});
     }
 
-    let old_wing: String = rows[0].get(0).unwrap_or_default();
-    let old_room: String = rows[0].get(1).unwrap_or_default();
-    let old_content: String = rows[0].get(2).unwrap_or_default();
+    let wing_old: String = rows[0].get(0).unwrap_or_default();
+    let room_old: String = rows[0].get(1).unwrap_or_default();
+    let content_old: String = rows[0].get(2).unwrap_or_default();
 
-    let final_wing = new_wing.as_deref().unwrap_or(&old_wing);
-    let final_room = new_room.as_deref().unwrap_or(&old_room);
-    let final_content = new_content.as_deref().unwrap_or(&old_content);
+    let final_wing = wing_new.as_deref().unwrap_or(&wing_old);
+    let final_room = room_new.as_deref().unwrap_or(&room_old);
+    let final_content = content_new.as_deref().unwrap_or(&content_old);
 
     // Recompute the deterministic ID to keep it consistent with tool_add_drawer.
     // wing/room/content are all baked into the ID, so any change means a new ID.
@@ -905,29 +905,29 @@ async fn tool_update_drawer(connection: &Connection, args: &Value) -> Value {
         let _ = write!(hex_string, "{byte:02x}");
         hex_string
     });
-    let new_id = format!("drawer_{final_wing}_{final_room}_{}", &hex[..24]);
+    let id_new = format!("drawer_{final_wing}_{final_room}_{}", &hex[..24]);
 
     wal_log(
         "update_drawer",
         json!({
             "drawer_id": drawer_id,
-            "new_drawer_id": new_id,
-            "old_wing": old_wing,
-            "old_room": old_room,
+            "new_drawer_id": id_new,
+            "old_wing": wing_old,
+            "old_room": room_old,
             "new_wing": final_wing,
             "new_room": final_room,
-            "content_changed": new_content.is_some(),
+            "content_changed": content_new.is_some(),
         }),
     )
     .await;
 
     // If the recomputed ID already exists (and differs), the new wing+room+content
     // is a duplicate of another drawer — reject to prevent silent duplication.
-    if new_id != drawer_id {
+    if id_new != drawer_id {
         let existing = query_all(
             connection,
             "SELECT id FROM drawers WHERE id = ?",
-            [new_id.as_str()],
+            [id_new.as_str()],
         )
         .await;
         match existing {
@@ -935,7 +935,7 @@ async fn tool_update_drawer(connection: &Connection, args: &Value) -> Value {
                 return json!({
                     "success": false,
                     "error": "A drawer with this wing/room/content already exists",
-                    "existing_drawer_id": new_id,
+                    "existing_drawer_id": id_new,
                     "public": true,
                 });
             }
@@ -954,7 +954,7 @@ async fn tool_update_drawer(connection: &Connection, args: &Value) -> Value {
         .execute(
             "UPDATE drawers SET id = ?1, wing = ?2, room = ?3, content = ?4 WHERE id = ?5",
             turso::params![
-                new_id.as_str(),
+                id_new.as_str(),
                 final_wing,
                 final_room,
                 final_content,
@@ -979,19 +979,19 @@ async fn tool_update_drawer(connection: &Connection, args: &Value) -> Value {
         return json!({"success": false, "error": e.to_string()});
     }
 
-    if new_id != drawer_id {
+    if id_new != drawer_id {
         // drawer_words rows for the old ID were deleted above; if the new
         // ID already had entries (shouldn't happen — we checked above),
         // clean those too.
         let _ = connection
             .execute(
                 "DELETE FROM drawer_words WHERE drawer_id = ?",
-                [new_id.as_str()],
+                [id_new.as_str()],
             )
             .await;
     }
 
-    if let Err(e) = drawer::index_words(connection, &new_id, final_content).await {
+    if let Err(e) = drawer::index_words(connection, &id_new, final_content).await {
         let _ = connection.execute("ROLLBACK", ()).await;
         return json!({"success": false, "error": e.to_string()});
     }
@@ -1003,7 +1003,7 @@ async fn tool_update_drawer(connection: &Connection, args: &Value) -> Value {
 
     json!({
         "success": true,
-        "drawer_id": new_id,
+        "drawer_id": id_new,
         "wing": final_wing,
         "room": final_room,
     })
@@ -1197,9 +1197,9 @@ async fn tool_traverse(connection: &Connection, args: &Value) -> Value {
         Ok(value) => value,
         Err(error) => return error,
     };
-    let max_hops = usize::try_from(int_arg(args, "max_hops", 2).clamp(1, 10)).unwrap_or(2);
+    let hops_max = usize::try_from(int_arg(args, "max_hops", 2).clamp(1, 10)).unwrap_or(2);
 
-    match graph::traverse(connection, &start_room, max_hops).await {
+    match graph::traverse(connection, &start_room, hops_max).await {
         Ok((results, truncated)) => json!({"results": results, "truncated": truncated}),
         Err(error) => json!({"error": error.to_string()}),
     }
@@ -2528,8 +2528,8 @@ mod tests {
         with_isolated_env(|connection| async move {
             let result = tool_graph_stats(&connection).await;
             assert!(result.get("error").is_none(), "must not error");
-            assert_eq!(result["total_rooms"], 0);
-            assert_eq!(result["total_edges"], 0);
+            assert_eq!(result["rooms_total"], 0);
+            assert_eq!(result["edges_total"], 0);
         })
         .await;
     }
@@ -2543,7 +2543,7 @@ mod tests {
             let result = tool_graph_stats(&connection).await;
             assert!(result.get("error").is_none(), "must not error");
             assert!(
-                result["total_rooms"].as_i64().expect("total_rooms") >= 1,
+                result["rooms_total"].as_i64().expect("rooms_total") >= 1,
                 "must count at least one room"
             );
         })

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -862,10 +862,7 @@ fn tool_update_drawer_validate_args(args: &Value) -> Result<UpdateDrawerArgs, Va
         if content_raw.is_empty() {
             None
         } else {
-            match sanitize_content(content_raw) {
-                Ok(value) => Some(value),
-                Err(error) => return Err(error),
-            }
+            Some(sanitize_content(content_raw)?)
         }
     };
     let wing_new = sanitize_opt_name(str_arg(args, "wing"), "wing")?;

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -857,16 +857,33 @@ fn tool_update_drawer_validate_args(args: &Value) -> Result<UpdateDrawerArgs, Va
             json!({"success": false, "error": "drawer_id has invalid format", "public": true}),
         );
     }
-    let content_new = {
-        let content_raw = str_arg(args, "content");
-        if content_raw.is_empty() {
-            None
-        } else {
-            Some(sanitize_content(content_raw)?)
+    let content_new = match args.get("content") {
+        None | Some(Value::Null) => None,
+        Some(Value::String(content_raw)) => Some(sanitize_content(content_raw)?),
+        Some(_) => {
+            return Err(
+                json!({"success": false, "error": "content must be a string", "public": true}),
+            );
         }
     };
-    let wing_new = sanitize_opt_name(str_arg(args, "wing"), "wing")?;
-    let room_new = sanitize_opt_name(str_arg(args, "room"), "room")?;
+    let wing_new = match args.get("wing") {
+        None | Some(Value::Null) => None,
+        Some(Value::String(wing_raw)) => sanitize_opt_name(wing_raw, "wing")?,
+        Some(_) => {
+            return Err(
+                json!({"success": false, "error": "wing must be a string", "public": true}),
+            );
+        }
+    };
+    let room_new = match args.get("room") {
+        None | Some(Value::Null) => None,
+        Some(Value::String(room_raw)) => sanitize_opt_name(room_raw, "room")?,
+        Some(_) => {
+            return Err(
+                json!({"success": false, "error": "room must be a string", "public": true}),
+            );
+        }
+    };
     // No-op: nothing to change.  Return as Err so the caller can return early.
     if content_new.is_none() && wing_new.is_none() && room_new.is_none() {
         return Err(json!({"success": true, "drawer_id": drawer_id, "noop": true}));
@@ -2166,6 +2183,66 @@ mod tests {
             let result = tool_update_drawer(&connection, &json!({"drawer_id": drawer_id})).await;
             assert_eq!(result["success"], true);
             assert_eq!(result["noop"], true);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn update_drawer_wrong_type_fields_return_error() {
+        with_isolated_env(|connection| async move {
+            let seeded = seed_drawer(&connection, "proj", "code", "typed field test").await;
+            let drawer_id = seeded["drawer_id"]
+                .as_str()
+                .expect("drawer_id must be string");
+
+            // Non-string content must be rejected, not silently treated as absent.
+            let result_content = tool_update_drawer(
+                &connection,
+                &json!({"drawer_id": drawer_id, "content": 123}),
+            )
+            .await;
+            assert_eq!(
+                result_content["success"], false,
+                "integer content must be rejected"
+            );
+            assert!(
+                result_content["error"]
+                    .as_str()
+                    .expect("error must be a string")
+                    .contains("content"),
+                "error must mention the offending field"
+            );
+
+            // Non-string wing must be rejected.
+            let result_wing =
+                tool_update_drawer(&connection, &json!({"drawer_id": drawer_id, "wing": 42})).await;
+            assert_eq!(
+                result_wing["success"], false,
+                "integer wing must be rejected"
+            );
+            assert!(
+                result_wing["error"]
+                    .as_str()
+                    .expect("error must be a string")
+                    .contains("wing"),
+                "error must mention the offending field"
+            );
+
+            // Non-string room must be rejected.
+            let result_room =
+                tool_update_drawer(&connection, &json!({"drawer_id": drawer_id, "room": true}))
+                    .await;
+            assert_eq!(
+                result_room["success"], false,
+                "boolean room must be rejected"
+            );
+            assert!(
+                result_room["error"]
+                    .as_str()
+                    .expect("error must be a string")
+                    .contains("room"),
+                "error must mention the offending field"
+            );
         })
         .await;
     }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -2916,4 +2916,136 @@ mod tests {
         })
         .await;
     }
+
+    // --- sanitize_name ---
+
+    #[test]
+    fn sanitize_name_rejects_too_long_string() {
+        // A string longer than 128 characters must be rejected with a public error.
+        let long = "a".repeat(129);
+        let result = sanitize_name(&long, "field");
+        assert!(result.is_err(), "string > 128 chars must be rejected");
+        let error_json = result.expect_err("long string must fail");
+        assert!(
+            error_json["error"]
+                .as_str()
+                .expect("error must be string")
+                .contains("128"),
+            "error must mention the 128-char limit"
+        );
+        assert!(
+            error_json["public"].as_bool().unwrap_or(false),
+            "error must be public"
+        );
+    }
+
+    #[test]
+    fn sanitize_name_rejects_path_traversal_and_null() {
+        // Path-traversal sequences and null bytes are always invalid.
+        for input in &["a..b", "a/b", "a\\b", "a\x00b"] {
+            let result = sanitize_name(input, "field");
+            assert!(result.is_err(), "'{input}' must be rejected");
+            assert!(
+                result.expect_err("path traversal must fail")["public"]
+                    .as_bool()
+                    .unwrap_or(false),
+                "error must be public for '{input}'"
+            );
+        }
+    }
+
+    #[test]
+    fn sanitize_name_rejects_non_alphanumeric_first_char() {
+        // Names must start with an ASCII alphanumeric character.
+        // Note: leading spaces are stripped by trim(), so they are not tested here.
+        for input in &["_leading", "-leading", ".leading"] {
+            let result = sanitize_name(input, "field");
+            assert!(
+                result.is_err(),
+                "name starting with non-alphanumeric '{input}' must be rejected"
+            );
+            assert!(
+                result.expect_err("invalid start must fail")["public"]
+                    .as_bool()
+                    .unwrap_or(false),
+                "error must be public for '{input}'"
+            );
+        }
+    }
+
+    #[test]
+    fn sanitize_name_rejects_invalid_chars() {
+        // Characters outside [a-zA-Z0-9_ .'-] must be rejected.
+        for input in &["foo@bar", "foo!bar", "foo#bar", "foo$bar"] {
+            let result = sanitize_name(input, "field");
+            assert!(
+                result.is_err(),
+                "name with invalid character '{input}' must be rejected"
+            );
+            assert!(
+                result.expect_err("invalid char must fail")["public"]
+                    .as_bool()
+                    .unwrap_or(false),
+                "error must be public for '{input}'"
+            );
+        }
+    }
+
+    // --- sanitize_label ---
+
+    #[test]
+    fn sanitize_label_rejects_too_long_string() {
+        // A label longer than LABEL_LEN_MAX (255) bytes must be rejected.
+        let long = "a".repeat(LABEL_LEN_MAX + 1);
+        let result = sanitize_label(&long);
+        assert!(result.is_err(), "label > LABEL_LEN_MAX must be rejected");
+        assert!(
+            result.expect_err("long label must fail")["public"]
+                .as_bool()
+                .unwrap_or(false),
+            "error must be public"
+        );
+    }
+
+    #[test]
+    fn sanitize_label_rejects_null_bytes() {
+        // A label containing a null byte must be rejected.
+        let result = sanitize_label("valid\x00but_null");
+        assert!(result.is_err(), "label with null byte must be rejected");
+        assert!(
+            result.expect_err("null byte must fail")["public"]
+                .as_bool()
+                .unwrap_or(false),
+            "error must be public"
+        );
+    }
+
+    // --- sanitize_content ---
+
+    #[test]
+    fn sanitize_content_rejects_null_bytes() {
+        // Content containing a null byte must be rejected.
+        let result = sanitize_content("valid content\x00with null");
+        assert!(result.is_err(), "content with null byte must be rejected");
+        assert!(
+            result.expect_err("null byte content must fail")["public"]
+                .as_bool()
+                .unwrap_or(false),
+            "error must be public"
+        );
+    }
+
+    #[test]
+    fn sanitize_content_rejects_over_100k_chars() {
+        // Content exceeding 100,000 characters must be rejected.
+        let long = "a".repeat(100_001);
+        let result = sanitize_content(&long);
+        assert!(result.is_err(), "content > 100k chars must be rejected");
+        assert!(
+            result.expect_err("over-100k content must fail")["public"]
+                .as_bool()
+                .unwrap_or(false),
+            "error must be public"
+        );
+    }
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -69,6 +69,8 @@ pub async fn dispatch(connection: &Connection, name: &str, args: &Value) -> Valu
     }
 }
 
+/// Extract a string argument from the tool args JSON object.
+/// Returns an empty string when the key is absent or the value is not a string.
 fn str_arg<'a>(args: &'a Value, key: &str) -> &'a str {
     args.get(key)
         .and_then(|arg_val| arg_val.as_str())
@@ -371,6 +373,7 @@ async fn wal_log(operation: &str, params: Value) {
     .await;
 }
 
+/// Return a summary of all wings, rooms, and total drawer count.
 async fn tool_status(connection: &Connection) -> Value {
     let rows = query_all(
         connection,
@@ -406,6 +409,7 @@ async fn tool_status(connection: &Connection) -> Value {
     })
 }
 
+/// Return all wings with their drawer counts.
 async fn tool_list_wings(connection: &Connection) -> Value {
     let rows = query_all(
         connection,
@@ -428,6 +432,7 @@ async fn tool_list_wings(connection: &Connection) -> Value {
     }
 }
 
+/// Return rooms and their drawer counts, optionally filtered by wing.
 async fn tool_list_rooms(connection: &Connection, args: &Value) -> Value {
     let wing = match sanitize_opt_name(str_arg(args, "wing"), "wing") {
         Ok(value) => value,
@@ -464,6 +469,7 @@ async fn tool_list_rooms(connection: &Connection, args: &Value) -> Value {
     }
 }
 
+/// Return the full wing → room → drawer-count taxonomy tree.
 async fn tool_get_taxonomy(connection: &Connection) -> Value {
     let rows = query_all(
         connection,
@@ -487,6 +493,7 @@ async fn tool_get_taxonomy(connection: &Connection) -> Value {
     }
 }
 
+/// Full-text search the palace, returning ranked drawer results.
 async fn tool_search(connection: &Connection, args: &Value) -> Value {
     let raw_query = str_arg(args, "query").trim();
     if raw_query.is_empty() {
@@ -549,6 +556,7 @@ async fn tool_search(connection: &Connection, args: &Value) -> Value {
     }
 }
 
+/// Check whether content is a near-duplicate of an existing drawer.
 async fn tool_check_duplicate(connection: &Connection, args: &Value) -> Value {
     let content = str_arg(args, "content");
     // Simple keyword overlap check since we don't have vector similarity.
@@ -579,6 +587,7 @@ async fn tool_check_duplicate(connection: &Connection, args: &Value) -> Value {
     }
 }
 
+/// Insert a new drawer into the palace, computing a deterministic SHA256-based ID.
 async fn tool_add_drawer(connection: &Connection, args: &Value) -> Value {
     let wing = str_arg(args, "wing");
     let room = str_arg(args, "room");
@@ -680,6 +689,7 @@ async fn tool_add_drawer_insert(
     }
 }
 
+/// Delete a drawer and its inverted-index entries by ID.
 async fn tool_delete_drawer(connection: &Connection, args: &Value) -> Value {
     let drawer_id = match sanitize_name(str_arg(args, "drawer_id"), "drawer_id") {
         Ok(value) => value,
@@ -826,25 +836,27 @@ async fn tool_list_drawers_query(
     }
 }
 
-/// Update an existing drawer's content and/or location (wing/room).
+/// Parsed and validated arguments for `tool_update_drawer`.
+struct UpdateDrawerArgs {
+    drawer_id: String,
+    content_new: Option<String>,
+    wing_new: Option<String>,
+    room_new: Option<String>,
+}
+
+/// Parse and validate all input args for `tool_update_drawer`.
 ///
-/// Recomputes the deterministic SHA256 ID after any change to keep it
-/// consistent with `tool_add_drawer`.  Rejects updates that would collide
-/// with an existing drawer.
-// The complexity comes from: ID recomputation, duplicate detection, conditional
-// reindex, and error propagation — each a distinct correctness concern that
-// cannot be collapsed without obscuring the logic.
-#[allow(clippy::too_many_lines)]
-async fn tool_update_drawer(connection: &Connection, args: &Value) -> Value {
-    let drawer_id = match sanitize_name(str_arg(args, "drawer_id"), "drawer_id") {
-        Ok(value) => value,
-        Err(error) => return error,
-    };
+/// Returns `Ok(UpdateDrawerArgs)` on success.  Returns `Err(Value)` on
+/// validation failure **or** when no fields were supplied (noop), so the
+/// caller can return the value directly in both cases.
+fn tool_update_drawer_validate_args(args: &Value) -> Result<UpdateDrawerArgs, Value> {
+    let drawer_id = sanitize_name(str_arg(args, "drawer_id"), "drawer_id")?;
     // Diary entries use UUID IDs; they must not be mutated via this handler.
     if !drawer_id.starts_with("drawer_") {
-        return json!({"success": false, "error": "drawer_id has invalid format", "public": true});
+        return Err(
+            json!({"success": false, "error": "drawer_id has invalid format", "public": true}),
+        );
     }
-
     let content_new = {
         let content_raw = str_arg(args, "content");
         if content_raw.is_empty() {
@@ -852,155 +864,185 @@ async fn tool_update_drawer(connection: &Connection, args: &Value) -> Value {
         } else {
             match sanitize_content(content_raw) {
                 Ok(value) => Some(value),
-                Err(error) => return error,
+                Err(error) => return Err(error),
             }
         }
     };
-    let wing_new = match sanitize_opt_name(str_arg(args, "wing"), "wing") {
-        Ok(value) => value,
-        Err(error) => return error,
-    };
-    let room_new = match sanitize_opt_name(str_arg(args, "room"), "room") {
-        Ok(value) => value,
-        Err(error) => return error,
-    };
-
-    // No-op: nothing to change.
+    let wing_new = sanitize_opt_name(str_arg(args, "wing"), "wing")?;
+    let room_new = sanitize_opt_name(str_arg(args, "room"), "room")?;
+    // No-op: nothing to change.  Return as Err so the caller can return early.
     if content_new.is_none() && wing_new.is_none() && room_new.is_none() {
-        return json!({"success": true, "drawer_id": drawer_id, "noop": true});
+        return Err(json!({"success": true, "drawer_id": drawer_id, "noop": true}));
     }
+    Ok(UpdateDrawerArgs {
+        drawer_id,
+        content_new,
+        wing_new,
+        room_new,
+    })
+}
 
-    // Fetch existing drawer.
-    let rows = query_all(
-        connection,
-        "SELECT wing, room, content FROM drawers WHERE id = ?",
-        [drawer_id.as_str()],
-    )
-    .await;
-
-    let rows = match rows {
-        Ok(rows) => rows,
-        Err(error) => return json!({"success": false, "error": error.to_string()}),
-    };
-
-    if rows.is_empty() {
-        return json!({"success": false, "error": format!("Drawer not found: {drawer_id}"), "public": true});
-    }
-
-    let wing_old: String = rows[0].get(0).unwrap_or_default();
-    let room_old: String = rows[0].get(1).unwrap_or_default();
-    let content_old: String = rows[0].get(2).unwrap_or_default();
-
-    let final_wing = wing_new.as_deref().unwrap_or(&wing_old);
-    let final_room = room_new.as_deref().unwrap_or(&room_old);
-    let final_content = content_new.as_deref().unwrap_or(&content_old);
-
-    // Recompute the deterministic ID to keep it consistent with tool_add_drawer.
-    // wing/room/content are all baked into the ID, so any change means a new ID.
-    let hash = sha2::Sha256::digest(
-        format!("{final_wing}\u{1f}{final_room}\u{1f}{final_content}").as_bytes(),
-    );
+/// Compute the deterministic SHA256-based drawer ID from wing, room, and content.
+///
+/// Mirrors the ID computation in `tool_add_drawer` so that IDs stay consistent
+/// across add and update operations.
+fn tool_update_drawer_recompute_id(wing: &str, room: &str, content: &str) -> String {
+    let hash = sha2::Sha256::digest(format!("{wing}\u{1f}{room}\u{1f}{content}").as_bytes());
     let hex: String = hash.iter().fold(String::new(), |mut hex_string, byte| {
         use std::fmt::Write as _;
         let _ = write!(hex_string, "{byte:02x}");
         hex_string
     });
-    let id_new = format!("drawer_{final_wing}_{final_room}_{}", &hex[..24]);
+    format!("drawer_{wing}_{room}_{}", &hex[..24])
+}
 
+/// Check whether `new_id` already belongs to a different drawer, rejecting
+/// updates that would silently duplicate an existing entry.
+///
+/// Returns `Some(error_json)` if the update must be rejected, `None` if safe.
+async fn tool_update_drawer_check_duplicate(
+    connection: &Connection,
+    old_id: &str,
+    new_id: &str,
+) -> Option<Value> {
+    if new_id == old_id {
+        return None;
+    }
+    let existing = query_all(connection, "SELECT id FROM drawers WHERE id = ?", [new_id]).await;
+    match existing {
+        Ok(rows) if !rows.is_empty() => Some(json!({
+            "success": false,
+            "error": "A drawer with this wing/room/content already exists",
+            "existing_drawer_id": new_id,
+            "public": true,
+        })),
+        Err(error) => Some(json!({"success": false, "error": error.to_string()})),
+        Ok(_) => None,
+    }
+}
+
+/// Execute the transactional reindex: update the drawers row to its new ID,
+/// wing, room, and content, then rebuild the `drawer_words` full-text index.
+///
+/// Wraps all mutations in BEGIN/COMMIT so drawers and `drawer_words` cannot
+/// diverge if any step fails mid-flight.
+async fn tool_update_drawer_reindex(
+    connection: &Connection,
+    old_id: &str,
+    new_id: &str,
+    final_wing: &str,
+    final_room: &str,
+    final_content: &str,
+) -> Result<(), Value> {
+    if let Err(e) = connection.execute("BEGIN", ()).await {
+        return Err(json!({"success": false, "error": e.to_string()}));
+    }
+    if let Err(e) = connection
+        .execute(
+            "UPDATE drawers SET id = ?1, wing = ?2, room = ?3, content = ?4 WHERE id = ?5",
+            turso::params![new_id, final_wing, final_room, final_content, old_id],
+        )
+        .await
+    {
+        let _ = connection.execute("ROLLBACK", ()).await;
+        return Err(json!({"success": false, "error": e.to_string()}));
+    }
+    // Re-index words: always needed when the ID changes or content changes.
+    if let Err(e) = connection
+        .execute("DELETE FROM drawer_words WHERE drawer_id = ?", [old_id])
+        .await
+    {
+        let _ = connection.execute("ROLLBACK", ()).await;
+        return Err(json!({"success": false, "error": e.to_string()}));
+    }
+    if new_id != old_id {
+        // drawer_words rows for old_id were deleted above; if new_id already
+        // had entries (shouldn't happen — we checked above), clean those too.
+        let _ = connection
+            .execute("DELETE FROM drawer_words WHERE drawer_id = ?", [new_id])
+            .await;
+    }
+    if let Err(e) = drawer::index_words(connection, new_id, final_content).await {
+        let _ = connection.execute("ROLLBACK", ()).await;
+        return Err(json!({"success": false, "error": e.to_string()}));
+    }
+    if let Err(e) = connection.execute("COMMIT", ()).await {
+        let _ = connection.execute("ROLLBACK", ()).await;
+        return Err(json!({"success": false, "error": e.to_string()}));
+    }
+    Ok(())
+}
+
+/// Update an existing drawer's content and/or location (wing/room).
+///
+/// Recomputes the deterministic SHA256 ID after any change to keep it
+/// consistent with `tool_add_drawer`.  Rejects updates that would collide
+/// with an existing drawer.
+async fn tool_update_drawer(connection: &Connection, args: &Value) -> Value {
+    let parsed = match tool_update_drawer_validate_args(args) {
+        Ok(parsed) => parsed,
+        Err(early) => return early,
+    };
+
+    // Fetch existing drawer to resolve final wing, room, and content values.
+    let rows = query_all(
+        connection,
+        "SELECT wing, room, content FROM drawers WHERE id = ?",
+        [parsed.drawer_id.as_str()],
+    )
+    .await;
+    let rows = match rows {
+        Ok(rows) => rows,
+        Err(error) => return json!({"success": false, "error": error.to_string()}),
+    };
+    if rows.is_empty() {
+        return json!({"success": false, "error": format!("Drawer not found: {}", parsed.drawer_id), "public": true});
+    }
+
+    let wing_old: String = rows[0].get(0).unwrap_or_default();
+    let room_old: String = rows[0].get(1).unwrap_or_default();
+    let content_old: String = rows[0].get(2).unwrap_or_default();
+    let final_wing = parsed.wing_new.as_deref().unwrap_or(&wing_old);
+    let final_room = parsed.room_new.as_deref().unwrap_or(&room_old);
+    let final_content = parsed.content_new.as_deref().unwrap_or(&content_old);
+
+    // Recompute the deterministic ID to keep it consistent with tool_add_drawer.
+    // wing/room/content are all baked into the ID, so any change means a new ID.
+    let id_new = tool_update_drawer_recompute_id(final_wing, final_room, final_content);
     wal_log(
         "update_drawer",
         json!({
-            "drawer_id": drawer_id,
+            "drawer_id": parsed.drawer_id,
             "new_drawer_id": id_new,
             "old_wing": wing_old,
             "old_room": room_old,
             "new_wing": final_wing,
             "new_room": final_room,
-            "content_changed": content_new.is_some(),
+            "content_changed": parsed.content_new.is_some(),
         }),
     )
     .await;
 
     // If the recomputed ID already exists (and differs), the new wing+room+content
     // is a duplicate of another drawer — reject to prevent silent duplication.
-    if id_new != drawer_id {
-        let existing = query_all(
-            connection,
-            "SELECT id FROM drawers WHERE id = ?",
-            [id_new.as_str()],
-        )
-        .await;
-        match existing {
-            Ok(rows) if !rows.is_empty() => {
-                return json!({
-                    "success": false,
-                    "error": "A drawer with this wing/room/content already exists",
-                    "existing_drawer_id": id_new,
-                    "public": true,
-                });
-            }
-            Err(error) => return json!({"success": false, "error": error.to_string()}),
-            Ok(_) => {}
-        }
-    }
-
-    // Wrap the row update and index rebuild in a transaction so drawers and
-    // drawer_words cannot diverge if any step fails mid-flight.
-    if let Err(e) = connection.execute("BEGIN", ()).await {
-        return json!({"success": false, "error": e.to_string()});
-    }
-
-    if let Err(e) = connection
-        .execute(
-            "UPDATE drawers SET id = ?1, wing = ?2, room = ?3, content = ?4 WHERE id = ?5",
-            turso::params![
-                id_new.as_str(),
-                final_wing,
-                final_room,
-                final_content,
-                drawer_id.as_str()
-            ],
-        )
-        .await
+    if let Some(error) =
+        tool_update_drawer_check_duplicate(connection, &parsed.drawer_id, &id_new).await
     {
-        let _ = connection.execute("ROLLBACK", ()).await;
-        return json!({"success": false, "error": e.to_string()});
+        return error;
     }
 
-    // Re-index words: always needed when the ID changes or content changes.
-    if let Err(e) = connection
-        .execute(
-            "DELETE FROM drawer_words WHERE drawer_id = ?",
-            [drawer_id.as_str()],
-        )
-        .await
+    if let Err(error) = tool_update_drawer_reindex(
+        connection,
+        &parsed.drawer_id,
+        &id_new,
+        final_wing,
+        final_room,
+        final_content,
+    )
+    .await
     {
-        let _ = connection.execute("ROLLBACK", ()).await;
-        return json!({"success": false, "error": e.to_string()});
+        return error;
     }
-
-    if id_new != drawer_id {
-        // drawer_words rows for the old ID were deleted above; if the new
-        // ID already had entries (shouldn't happen — we checked above),
-        // clean those too.
-        let _ = connection
-            .execute(
-                "DELETE FROM drawer_words WHERE drawer_id = ?",
-                [id_new.as_str()],
-            )
-            .await;
-    }
-
-    if let Err(e) = drawer::index_words(connection, &id_new, final_content).await {
-        let _ = connection.execute("ROLLBACK", ()).await;
-        return json!({"success": false, "error": e.to_string()});
-    }
-
-    if let Err(e) = connection.execute("COMMIT", ()).await {
-        let _ = connection.execute("ROLLBACK", ()).await;
-        return json!({"success": false, "error": e.to_string()});
-    }
-
     json!({
         "success": true,
         "drawer_id": id_new,
@@ -1009,6 +1051,7 @@ async fn tool_update_drawer(connection: &Connection, args: &Value) -> Value {
     })
 }
 
+/// Query all knowledge-graph facts for an entity, with optional direction and as-of filters.
 async fn tool_kg_query(connection: &Connection, args: &Value) -> Value {
     let entity = match sanitize_kg_value(str_arg(args, "entity"), "entity") {
         Ok(value) => value,
@@ -1043,6 +1086,7 @@ async fn tool_kg_query(connection: &Connection, args: &Value) -> Value {
     }
 }
 
+/// Add a subject–predicate–object triple to the knowledge graph.
 async fn tool_kg_add(connection: &Connection, args: &Value) -> Value {
     let subject = str_arg(args, "subject");
     let predicate = str_arg(args, "predicate");
@@ -1113,6 +1157,7 @@ async fn tool_kg_add(connection: &Connection, args: &Value) -> Value {
     }
 }
 
+/// End-date a knowledge-graph triple by setting its `valid_to` field.
 async fn tool_kg_invalidate(connection: &Connection, args: &Value) -> Value {
     let subject = str_arg(args, "subject");
     let predicate = str_arg(args, "predicate");
@@ -1159,6 +1204,7 @@ async fn tool_kg_invalidate(connection: &Connection, args: &Value) -> Value {
     }
 }
 
+/// Return all knowledge-graph facts sorted by validity date, optionally filtered by entity.
 async fn tool_kg_timeline(connection: &Connection, args: &Value) -> Value {
     let entity = {
         let raw_entity = str_arg(args, "entity").trim();
@@ -1185,6 +1231,7 @@ async fn tool_kg_timeline(connection: &Connection, args: &Value) -> Value {
     }
 }
 
+/// Return aggregate statistics for the knowledge graph (entity count, triple count, etc.).
 async fn tool_kg_stats(connection: &Connection) -> Value {
     match kg::query::stats(connection).await {
         Ok(stats) => json!(stats),
@@ -1192,6 +1239,7 @@ async fn tool_kg_stats(connection: &Connection) -> Value {
     }
 }
 
+/// BFS-traverse the palace graph from a starting room up to `max_hops` hops.
 async fn tool_traverse(connection: &Connection, args: &Value) -> Value {
     let start_room = match sanitize_name(str_arg(args, "start_room"), "start_room") {
         Ok(value) => value,
@@ -1205,6 +1253,7 @@ async fn tool_traverse(connection: &Connection, args: &Value) -> Value {
     }
 }
 
+/// Find rooms that bridge two wings, optionally filtering by wing names.
 async fn tool_find_tunnels(connection: &Connection, args: &Value) -> Value {
     let wing_a = match sanitize_opt_name(str_arg(args, "wing_a"), "wing_a") {
         Ok(value) => value,
@@ -1221,6 +1270,7 @@ async fn tool_find_tunnels(connection: &Connection, args: &Value) -> Value {
     }
 }
 
+/// Return aggregate statistics about the palace graph (room count, tunnel count, etc.).
 async fn tool_graph_stats(connection: &Connection) -> Value {
     match graph::graph_stats(connection).await {
         Ok(stats) => json!(stats),
@@ -1228,6 +1278,7 @@ async fn tool_graph_stats(connection: &Connection) -> Value {
     }
 }
 
+/// Create an explicit (agent-annotated) tunnel linking two palace locations.
 async fn tool_create_tunnel(connection: &Connection, args: &Value) -> Value {
     let source_wing = match sanitize_name(str_arg(args, "source_wing"), "source_wing") {
         Ok(value) => value,
@@ -1295,6 +1346,7 @@ async fn tool_create_tunnel(connection: &Connection, args: &Value) -> Value {
     }
 }
 
+/// Return all explicit tunnels, optionally filtered to those involving a specific wing.
 async fn tool_list_tunnels(connection: &Connection, args: &Value) -> Value {
     let wing = match sanitize_opt_name(str_arg(args, "wing"), "wing") {
         Ok(value) => value,
@@ -1307,6 +1359,7 @@ async fn tool_list_tunnels(connection: &Connection, args: &Value) -> Value {
     }
 }
 
+/// Delete an explicit tunnel by its 16-character hex ID.
 async fn tool_delete_tunnel(connection: &Connection, args: &Value) -> Value {
     // Trim before validation to avoid spurious failures from surrounding whitespace.
     let tunnel_id = str_arg(args, "tunnel_id").trim();
@@ -1327,6 +1380,7 @@ async fn tool_delete_tunnel(connection: &Connection, args: &Value) -> Value {
     }
 }
 
+/// Return all explicit tunnel connections from a given wing and room.
 async fn tool_follow_tunnels(connection: &Connection, args: &Value) -> Value {
     let wing = match sanitize_name(str_arg(args, "wing"), "wing") {
         Ok(value) => value,
@@ -1343,6 +1397,7 @@ async fn tool_follow_tunnels(connection: &Connection, args: &Value) -> Value {
     }
 }
 
+/// Append a diary entry for an agent in its personal wing.
 async fn tool_diary_write(connection: &Connection, args: &Value) -> Value {
     let agent_name = str_arg(args, "agent_name");
     let entry = str_arg(args, "entry");
@@ -1404,6 +1459,7 @@ async fn tool_diary_write(connection: &Connection, args: &Value) -> Value {
     }
 }
 
+/// Read the most recent diary entries for an agent, newest first.
 async fn tool_diary_read(connection: &Connection, args: &Value) -> Value {
     let agent_name = str_arg(args, "agent_name");
     let last_n = int_arg(args, "last_n", 10).clamp(1, 100);
@@ -1457,6 +1513,7 @@ async fn tool_diary_read(connection: &Connection, args: &Value) -> Value {
 mod tests {
     use super::*;
 
+    /// Open an in-memory test palace database and return the database + connection pair.
     async fn test_conn() -> (turso::Database, turso::Connection) {
         crate::test_helpers::test_db().await
     }
@@ -1590,9 +1647,9 @@ mod tests {
 
     // --- Helper: isolated WAL dir + env override + fresh connection ---
 
-    // Wraps the three-line test setup (tempdir, async_with_vars, test_conn) so
-    // callers only express what is under test.  The connection is passed by value
-    // so the closure can borrow it as `&connection` without lifetime complications.
+    /// Wraps the three-line test setup (tempdir, `async_with_vars`, `test_conn`) so
+    /// callers only express what is under test.  The connection is passed by value
+    /// so the closure can borrow it as `&connection` without lifetime complications.
     async fn with_isolated_env<F, Fut>(test: F)
     where
         F: FnOnce(turso::Connection) -> Fut,

--- a/src/normalize/chatgpt.rs
+++ b/src/normalize/chatgpt.rs
@@ -89,12 +89,12 @@ pub fn try_parse(data: &serde_json::Value) -> Option<String> {
 
     // Require at least one user turn AND at least one assistant turn so we
     // never store a one-sided transcript (e.g. a file with only system prompts).
-    let has_user = messages.iter().any(|(r, _)| r == "user");
-    let has_assistant = messages.iter().any(|(r, _)| r == "assistant");
+    let has_user = messages.iter().any(|(role, _)| role == "user");
+    let has_assistant = messages.iter().any(|(role, _)| role == "assistant");
     if has_user && has_assistant {
         let refs: Vec<(&str, &str)> = messages
             .iter()
-            .map(|(r, t)| (r.as_str(), t.as_str()))
+            .map(|(role, text)| (role.as_str(), text.as_str()))
             .collect();
         Some(messages_to_transcript(&refs))
     } else {

--- a/src/normalize/chatgpt.rs
+++ b/src/normalize/chatgpt.rs
@@ -12,8 +12,27 @@ use super::messages_to_transcript;
 /// — one-sided transcripts (e.g. system-prompt-only files) are rejected.
 pub fn try_parse(data: &serde_json::Value) -> Option<String> {
     let mapping = data.as_object()?.get("mapping")?.as_object()?;
+    let root = try_parse_find_root(mapping)?;
+    let messages = try_parse_walk_tree(root, mapping)?;
 
-    // Find root node (parent=null, no message)
+    // Require at least one user turn AND at least one assistant turn so we
+    // never store a one-sided transcript (e.g. a file with only system prompts).
+    let has_user = messages.iter().any(|(role, _)| role == "user");
+    let has_assistant = messages.iter().any(|(role, _)| role == "assistant");
+    if has_user && has_assistant {
+        let refs: Vec<(&str, &str)> = messages
+            .iter()
+            .map(|(role, text)| (role.as_str(), text.as_str()))
+            .collect();
+        Some(messages_to_transcript(&refs))
+    } else {
+        None
+    }
+}
+
+/// Find the root node ID in a `ChatGPT` mapping — the node with `parent=null`
+/// and no message body. Falls back to the first null-parent node with a message.
+fn try_parse_find_root(mapping: &serde_json::Map<String, serde_json::Value>) -> Option<&str> {
     let mut root_id: Option<&str> = None;
     let mut fallback_root: Option<&str> = None;
 
@@ -28,7 +47,17 @@ pub fn try_parse(data: &serde_json::Value) -> Option<String> {
         }
     }
 
-    let root = root_id.or(fallback_root)?;
+    root_id.or(fallback_root)
+}
+
+/// Walk the linear path of the message tree from `root`, collecting (role, text) pairs.
+///
+/// Returns `None` if any node lookup fails (malformed export). Always follows the
+/// first child so branching edits are ignored — see the comment in `try_parse`.
+fn try_parse_walk_tree(
+    root: &str,
+    mapping: &serde_json::Map<String, serde_json::Value>,
+) -> Option<Vec<(String, String)>> {
     let mut messages: Vec<(String, String)> = Vec::new();
     let mut id_current = root.to_string();
     let mut visited = HashSet::new();
@@ -87,19 +116,7 @@ pub fn try_parse(data: &serde_json::Value) -> Option<String> {
         }
     }
 
-    // Require at least one user turn AND at least one assistant turn so we
-    // never store a one-sided transcript (e.g. a file with only system prompts).
-    let has_user = messages.iter().any(|(role, _)| role == "user");
-    let has_assistant = messages.iter().any(|(role, _)| role == "assistant");
-    if has_user && has_assistant {
-        let refs: Vec<(&str, &str)> = messages
-            .iter()
-            .map(|(role, text)| (role.as_str(), text.as_str()))
-            .collect();
-        Some(messages_to_transcript(&refs))
-    } else {
-        None
-    }
+    Some(messages)
 }
 
 #[cfg(test)]

--- a/src/normalize/chatgpt.rs
+++ b/src/normalize/chatgpt.rs
@@ -30,18 +30,18 @@ pub fn try_parse(data: &serde_json::Value) -> Option<String> {
 
     let root = root_id.or(fallback_root)?;
     let mut messages: Vec<(String, String)> = Vec::new();
-    let mut current_id = root.to_string();
+    let mut id_current = root.to_string();
     let mut visited = HashSet::new();
 
     // Upper bound: each node in `mapping` can be visited at most once, so this
     // loop runs at most mapping.len() times regardless of the tree structure.
-    while !visited.contains(&current_id) {
+    while !visited.contains(&id_current) {
         assert!(
             visited.len() <= mapping.len(),
             "visited set cannot exceed mapping size — cycle guard is broken"
         );
-        visited.insert(current_id.clone());
-        let node = mapping.get(&current_id)?;
+        visited.insert(id_current.clone());
+        let node = mapping.get(&id_current)?;
 
         if let Some(msg) = node.get("message")
             && !msg.is_null()
@@ -78,7 +78,7 @@ pub fn try_parse(data: &serde_json::Value) -> Option<String> {
         let children = node.get("children").and_then(|c| c.as_array());
         if let Some(kids) = children {
             if let Some(first) = kids.first().and_then(|k| k.as_str()) {
-                current_id = first.to_string();
+                id_current = first.to_string();
             } else {
                 break;
             }

--- a/src/normalize/claude_ai.rs
+++ b/src/normalize/claude_ai.rs
@@ -24,9 +24,9 @@ pub fn try_parse(data: &serde_json::Value) -> Option<String> {
         // or messages key.  Only treat as privacy export if the first element looks
         // like a conversation object (has chat_messages or messages) to avoid
         // misclassifying a plain flat message array.
-        let first_is_convo = arr.first().is_some_and(|v| {
-            v.get("chat_messages")
-                .or_else(|| v.get("messages"))
+        let first_is_convo = arr.first().is_some_and(|item| {
+            item.get("chat_messages")
+                .or_else(|| item.get("messages"))
                 .and_then(|m| m.as_array())
                 .is_some()
         });
@@ -39,7 +39,7 @@ pub fn try_parse(data: &serde_json::Value) -> Option<String> {
                     let msgs = conv
                         .get("chat_messages")
                         .or_else(|| conv.get("messages"))
-                        .and_then(|v| v.as_array())?;
+                        .and_then(|msg_val| msg_val.as_array())?;
                     collect_messages(msgs)
                 })
                 .collect();
@@ -57,7 +57,7 @@ pub fn try_parse(data: &serde_json::Value) -> Option<String> {
         let items = obj
             .get("messages")
             .or_else(|| obj.get("chat_messages"))
-            .and_then(|v| v.as_array())?;
+            .and_then(|msg_val| msg_val.as_array())?;
         collect_messages(items)
     } else {
         None
@@ -81,7 +81,7 @@ fn collect_messages(items: &[serde_json::Value]) -> Option<String> {
         let role = obj
             .get("role")
             .or_else(|| obj.get("sender"))
-            .and_then(|v| v.as_str())
+            .and_then(|role_val| role_val.as_str())
             .unwrap_or("");
 
         // Primary: content blocks. Fallback: top-level "text" key.
@@ -89,7 +89,7 @@ fn collect_messages(items: &[serde_json::Value]) -> Option<String> {
             let from_content = obj.get("content").map(extract_content).unwrap_or_default();
             if from_content.is_empty() {
                 obj.get("text")
-                    .and_then(|v| v.as_str())
+                    .and_then(|text_val| text_val.as_str())
                     .unwrap_or("")
                     .trim()
                     .to_string()
@@ -112,7 +112,7 @@ fn collect_messages(items: &[serde_json::Value]) -> Option<String> {
     if messages.len() >= 2 {
         let refs: Vec<(&str, &str)> = messages
             .iter()
-            .map(|(r, t)| (r.as_str(), t.as_str()))
+            .map(|(role, text)| (role.as_str(), text.as_str()))
             .collect();
         Some(messages_to_transcript(&refs))
     } else {
@@ -122,12 +122,12 @@ fn collect_messages(items: &[serde_json::Value]) -> Option<String> {
 
 fn extract_content(value: &serde_json::Value) -> String {
     match value {
-        serde_json::Value::String(s) => s.trim().to_string(),
+        serde_json::Value::String(text) => text.trim().to_string(),
         serde_json::Value::Array(arr) => arr
             .iter()
             .filter_map(|item| {
-                if let Some(s) = item.as_str() {
-                    Some(s.to_string())
+                if let Some(text) = item.as_str() {
+                    Some(text.to_string())
                 } else if let Some(obj) = item.as_object() {
                     if obj.get("type").and_then(|t| t.as_str()) == Some("text") {
                         obj.get("text")

--- a/src/normalize/claude_code.rs
+++ b/src/normalize/claude_code.rs
@@ -114,32 +114,32 @@ pub fn strip_noise(text: &str) -> String {
     let mut result: Cow<str> = Cow::Borrowed(text);
     for re in NOISE_TAG_RES.iter() {
         let replaced = re.replace_all(result.as_ref(), "");
-        if let Cow::Owned(s) = replaced {
-            result = Cow::Owned(s);
+        if let Cow::Owned(owned) = replaced {
+            result = Cow::Owned(owned);
         }
     }
     for re in NOISE_LINE_RES.iter() {
         let replaced = re.replace_all(result.as_ref(), "");
-        if let Cow::Owned(s) = replaced {
-            result = Cow::Owned(s);
+        if let Cow::Owned(owned) = replaced {
+            result = Cow::Owned(owned);
         }
     }
     let replaced = HOOK_LINE_RE.replace_all(result.as_ref(), "");
-    if let Cow::Owned(s) = replaced {
-        result = Cow::Owned(s);
+    if let Cow::Owned(owned) = replaced {
+        result = Cow::Owned(owned);
     }
     let replaced = COLLAPSED_LINES_RE.replace_all(result.as_ref(), "");
-    if let Cow::Owned(s) = replaced {
-        result = Cow::Owned(s);
+    if let Cow::Owned(owned) = replaced {
+        result = Cow::Owned(owned);
     }
     let replaced = TOKEN_MARKER_RE.replace_all(result.as_ref(), "");
-    if let Cow::Owned(s) = replaced {
-        result = Cow::Owned(s);
+    if let Cow::Owned(owned) = replaced {
+        result = Cow::Owned(owned);
     }
     // Collapse runs of 4+ blank lines down to 3 (a visual paragraph break).
     let replaced = EXCESS_BLANK_RE.replace_all(result.as_ref(), "\n\n\n");
-    if let Cow::Owned(s) = replaced {
-        result = Cow::Owned(s);
+    if let Cow::Owned(owned) = replaced {
+        result = Cow::Owned(owned);
     }
 
     // Postcondition: result is trimmed (no leading/trailing whitespace).
@@ -161,16 +161,16 @@ pub fn try_parse(content: &str) -> Option<String> {
             continue;
         }
         let entry: serde_json::Value = serde_json::from_str(line).ok()?;
-        let obj = entry.as_object()?;
+        let entry_object = entry.as_object()?;
 
-        let msg_type = obj.get("type")?.as_str()?;
-        let message = obj.get("message")?.as_object()?;
-        let raw = extract_content(message.get("content")?);
-        if raw.is_empty() {
+        let msg_type = entry_object.get("type")?.as_str()?;
+        let message = entry_object.get("message")?.as_object()?;
+        let raw_content = extract_content(message.get("content")?);
+        if raw_content.is_empty() {
             continue;
         }
         // Strip system-injected noise per message, never across boundaries.
-        let text = strip_noise(&raw);
+        let text = strip_noise(&raw_content);
         if text.is_empty() {
             continue;
         }
@@ -185,7 +185,7 @@ pub fn try_parse(content: &str) -> Option<String> {
     if messages.len() >= 2 {
         let refs: Vec<(&str, &str)> = messages
             .iter()
-            .map(|(r, t)| (r.as_str(), t.as_str()))
+            .map(|(role, text)| (role.as_str(), text.as_str()))
             .collect();
         Some(messages_to_transcript(&refs))
     } else {
@@ -195,12 +195,12 @@ pub fn try_parse(content: &str) -> Option<String> {
 
 fn extract_content(value: &serde_json::Value) -> String {
     match value {
-        serde_json::Value::String(s) => s.trim().to_string(),
+        serde_json::Value::String(text) => text.trim().to_string(),
         serde_json::Value::Array(arr) => arr
             .iter()
             .filter_map(|item| {
-                if let Some(s) = item.as_str() {
-                    Some(s.to_string())
+                if let Some(text) = item.as_str() {
+                    Some(text.to_string())
                 } else if let Some(obj) = item.as_object() {
                     if obj.get("type").and_then(|t| t.as_str()) == Some("text") {
                         obj.get("text")

--- a/src/normalize/claude_code.rs
+++ b/src/normalize/claude_code.rs
@@ -56,6 +56,7 @@ static NOISE_TAG_RES: LazyLock<Vec<Regex>> = LazyLock::new(|| {
         .collect()
 });
 
+// Regex literals are compile-time constants; cannot fail to compile.
 #[allow(clippy::expect_used)]
 static NOISE_LINE_RES: LazyLock<Vec<Regex>> = LazyLock::new(|| {
     NOISE_LINE_PREFIXES

--- a/src/normalize/codex.rs
+++ b/src/normalize/codex.rs
@@ -20,14 +20,17 @@ pub fn try_parse(content: &str) -> Option<String> {
             continue;
         }
         let entry: serde_json::Value = match serde_json::from_str(line) {
-            Ok(v) => v,
+            Ok(parsed) => parsed,
             Err(_) => continue,
         };
         let Some(obj) = entry.as_object() else {
             continue;
         };
 
-        let entry_type = obj.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        let entry_type = obj
+            .get("type")
+            .and_then(|type_val| type_val.as_str())
+            .unwrap_or("");
 
         if entry_type == "session_meta" {
             has_session_meta = true;
@@ -38,13 +41,19 @@ pub fn try_parse(content: &str) -> Option<String> {
             continue;
         }
 
-        let Some(payload) = obj.get("payload").and_then(|v| v.as_object()) else {
+        let Some(payload) = obj
+            .get("payload")
+            .and_then(|payload_val| payload_val.as_object())
+        else {
             continue;
         };
 
-        let payload_type = payload.get("type").and_then(|v| v.as_str()).unwrap_or("");
-        let text = match payload.get("message").and_then(|v| v.as_str()) {
-            Some(s) => s.trim().to_string(),
+        let payload_type = payload
+            .get("type")
+            .and_then(|type_val| type_val.as_str())
+            .unwrap_or("");
+        let text = match payload.get("message").and_then(|msg_val| msg_val.as_str()) {
+            Some(message) => message.trim().to_string(),
             None => continue,
         };
 
@@ -62,7 +71,7 @@ pub fn try_parse(content: &str) -> Option<String> {
     if has_session_meta && messages.len() >= 2 {
         let refs: Vec<(&str, &str)> = messages
             .iter()
-            .map(|(r, t)| (r.as_str(), t.as_str()))
+            .map(|(role, text)| (role.as_str(), text.as_str()))
             .collect();
         Some(messages_to_transcript(&refs))
     } else {

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -74,20 +74,20 @@ pub fn normalize(filepath: &Path) -> Result<String> {
 }
 
 fn try_normalize_json(content: &str) -> Option<String> {
-    // Try Claude Code JSONL first
+    // Try Claude Code JSONL first.
     if let Some(result) = claude_code::try_parse(content) {
         return Some(result);
     }
 
-    // Try Codex CLI JSONL
+    // Try Codex CLI JSONL.
     if let Some(result) = codex::try_parse(content) {
         return Some(result);
     }
 
-    // Try parsing as JSON
+    // Try parsing as JSON.
     let data: serde_json::Value = serde_json::from_str(content).ok()?;
 
-    // Try each format
+    // Try each format.
     for parser in [claude_ai::try_parse, chatgpt::try_parse, slack::try_parse] {
         if let Some(result) = parser(&data) {
             return Some(result);
@@ -156,7 +156,7 @@ mod tests {
 
     #[test]
     fn normalize_passthrough_with_markers() {
-        // Text with >= 3 lines starting with > should pass through
+        // Text with >= 3 lines starting with > should pass through.
         let temp_dir = tempfile::tempdir().expect("create temp dir");
         let path = temp_dir.path().join("test.txt");
         std::fs::write(
@@ -166,7 +166,7 @@ mod tests {
         .expect("write test file");
         let result = normalize(&path).expect("normalize");
         assert!(result.contains("> hello"));
-        // TempDir auto-cleans up when dropped
+        // TempDir auto-cleans up when dropped.
     }
 
     #[test]

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -13,7 +13,7 @@ use crate::error::Result;
 /// Normalize a file to transcript format.
 /// Detects format automatically and converts to `> user\nresponse\n\n` format.
 pub fn normalize(filepath: &Path) -> Result<String> {
-    const MAX_SIZE: u64 = 500 * 1024 * 1024; // 500 MB safety limit
+    const SIZE_MAX: u64 = 500 * 1024 * 1024; // 500 MB safety limit
     if !filepath.exists() {
         return Err(crate::error::Error::Other(format!(
             "normalize: file not found: {}",
@@ -25,7 +25,7 @@ pub fn normalize(filepath: &Path) -> Result<String> {
             crate::error::Error::Other(format!("could not read {}: {e}", filepath.display()))
         })?
         .len();
-    if file_size > MAX_SIZE {
+    if file_size > SIZE_MAX {
         return Err(crate::error::Error::Other(format!(
             "file too large ({} MB): {}",
             file_size / (1024 * 1024),
@@ -348,15 +348,15 @@ mod tests {
     #[test]
     fn normalize_file_too_large_returns_error() {
         // Files exceeding the 500 MB safety limit must be rejected. Create a sparse
-        // file (no disk space consumed) whose metadata reports a size above MAX_SIZE.
+        // file (no disk space consumed) whose metadata reports a size above SIZE_MAX.
         let temp_directory =
             tempfile::tempdir().expect("failed to create temporary directory for size-limit test");
         let filepath = temp_directory.path().join("huge.json");
         let file = std::fs::File::create(&filepath)
             .expect("failed to create sparse file for size-limit test");
-        // 500 MB + 1 byte exceeds the MAX_SIZE constant (500 * 1024 * 1024).
+        // 500 MB + 1 byte exceeds the SIZE_MAX constant (500 * 1024 * 1024).
         file.set_len(500 * 1024 * 1024 + 1)
-            .expect("failed to set sparse file length above MAX_SIZE");
+            .expect("failed to set sparse file length above SIZE_MAX");
         drop(file);
 
         let result = normalize(&filepath);

--- a/src/normalize/slack.rs
+++ b/src/normalize/slack.rs
@@ -91,7 +91,7 @@ pub fn try_parse(data: &serde_json::Value) -> Option<String> {
     if messages.len() >= 2 {
         let refs: Vec<(&str, &str)> = messages
             .iter()
-            .map(|(r, t)| (r.as_str(), t.as_str()))
+            .map(|(role, text)| (role.as_str(), text.as_str()))
             .collect();
         Some(messages_to_transcript(&refs) + PROVENANCE_FOOTER)
     } else {

--- a/src/normalize/slack.rs
+++ b/src/normalize/slack.rs
@@ -143,7 +143,7 @@ mod tests {
         let result = try_parse(&data).expect("should parse");
         let lines: Vec<&str> = result.lines().collect();
 
-        // Filter out empty lines to check role markers
+        // Filter out empty lines to check role markers.
         let non_empty_lines: Vec<&str> = lines.iter().copied().filter(|l| !l.is_empty()).collect();
         assert!(
             non_empty_lines.len() >= 5,
@@ -151,24 +151,24 @@ mod tests {
             non_empty_lines.len()
         );
 
-        // Verify role alternation by checking > markers
-        // U1 is "user" (has > marker)
+        // Verify role alternation by checking > markers.
+        // U1 is "user" (has > marker).
         assert!(
             non_empty_lines[0].starts_with('>') && non_empty_lines[0].contains("first message")
         );
-        // U2 is "assistant" (no > marker)
+        // U2 is "assistant" (no > marker).
         assert!(
             !non_empty_lines[1].starts_with('>') && non_empty_lines[1].contains("second message")
         );
-        // U3 is "user" (has > marker)
+        // U3 is "user" (has > marker).
         assert!(
             non_empty_lines[2].starts_with('>') && non_empty_lines[2].contains("third message")
         );
-        // U1 remains "user" (has > marker)
+        // U1 remains "user" (has > marker).
         assert!(
             non_empty_lines[3].starts_with('>') && non_empty_lines[3].contains("back to first")
         );
-        // U2 remains "assistant" (no > marker)
+        // U2 remains "assistant" (no > marker).
         assert!(
             !non_empty_lines[4].starts_with('>') && non_empty_lines[4].contains("back to second")
         );

--- a/src/normalize/slack.rs
+++ b/src/normalize/slack.rs
@@ -73,16 +73,16 @@ pub fn try_parse(data: &serde_json::Value) -> Option<String> {
         let role = if let Some(existing_role) = seen_users.get(&user_id) {
             existing_role.clone()
         } else {
-            let new_role = if seen_users.is_empty() {
+            let role_new = if seen_users.is_empty() {
                 "user".to_string()
             } else if last_role.as_deref() == Some("user") {
                 "assistant".to_string()
             } else {
                 "user".to_string()
             };
-            seen_users.insert(user_id.clone(), new_role.clone());
-            last_role = Some(new_role.clone());
-            new_role
+            seen_users.insert(user_id.clone(), role_new.clone());
+            last_role = Some(role_new.clone());
+            role_new
         };
         // Prefix with speaker ID so the original author is preserved in the transcript.
         messages.push((role, format!("[{user_id}] {text}")));

--- a/src/palace/chunker.rs
+++ b/src/palace/chunker.rs
@@ -1,6 +1,11 @@
 const CHUNK_SIZE: usize = 800;
 const CHUNK_OVERLAP: usize = 100;
 const CHUNK_SIZE_MIN: usize = 50;
+/// UTF-8 code points are at most 4 bytes, so a char-boundary snap never takes more than 3 steps.
+const CHAR_BOUNDARY_SNAP_MAX: usize = 4;
+/// A chunk covers at least `CHUNK_SIZE_MIN` bytes, so max chunks = `text.len()` / `CHUNK_SIZE_MIN`.
+/// `5_000` is a generous upper bound for any realistic input.
+const CHUNKS_MAX: usize = 5_000;
 
 // Compile-time invariant: overlap must be less than chunk size.
 const _: () = assert!(CHUNK_OVERLAP < CHUNK_SIZE);
@@ -22,7 +27,13 @@ fn snap_forward(text: &str, mut pos: usize) -> usize {
         "snap_forward: pos {pos} exceeds string length {}",
         text.len()
     );
+    let mut snap_steps: usize = 0;
     while pos < text.len() && !text.is_char_boundary(pos) {
+        snap_steps += 1;
+        assert!(
+            snap_steps < CHAR_BOUNDARY_SNAP_MAX,
+            "snap_forward: exceeded CHAR_BOUNDARY_SNAP_MAX ({CHAR_BOUNDARY_SNAP_MAX}) steps"
+        );
         pos += 1;
     }
     debug_assert!(text.is_char_boundary(pos));
@@ -36,7 +47,13 @@ fn snap_backward(text: &str, mut pos: usize) -> usize {
         "snap_backward: pos {pos} exceeds string length {}",
         text.len()
     );
+    let mut snap_steps: usize = 0;
     while pos > 0 && !text.is_char_boundary(pos) {
+        snap_steps += 1;
+        assert!(
+            snap_steps < CHAR_BOUNDARY_SNAP_MAX,
+            "snap_backward: exceeded CHAR_BOUNDARY_SNAP_MAX ({CHAR_BOUNDARY_SNAP_MAX}) steps"
+        );
         pos -= 1;
     }
     debug_assert!(text.is_char_boundary(pos));
@@ -53,8 +70,14 @@ pub fn chunk_text(content: &str) -> Vec<Chunk> {
     let mut chunks = Vec::new();
     let mut start = 0;
     let mut chunk_index = 0;
+    let mut chunk_count: usize = 0;
 
     while start < content.len() {
+        assert!(
+            chunk_count < CHUNKS_MAX,
+            "chunk_text: exceeded CHUNKS_MAX ({CHUNKS_MAX}) iterations"
+        );
+        chunk_count += 1;
         let mut end = snap_backward(content, (start + CHUNK_SIZE).min(content.len()));
 
         // Try to break at paragraph boundary, then line boundary.

--- a/src/palace/chunker.rs
+++ b/src/palace/chunker.rs
@@ -57,7 +57,7 @@ pub fn chunk_text(content: &str) -> Vec<Chunk> {
     while start < content.len() {
         let mut end = snap_backward(content, (start + CHUNK_SIZE).min(content.len()));
 
-        // Try to break at paragraph boundary, then line boundary
+        // Try to break at paragraph boundary, then line boundary.
         if end < content.len() {
             if let Some(pos) = content[start..end].rfind("\n\n") {
                 let abs_pos = start + pos;
@@ -107,7 +107,7 @@ mod tests {
 
     #[test]
     fn short_string_below_min_size_returns_no_chunks() {
-        // Below CHUNK_SIZE_MIN (50)
+        // Below CHUNK_SIZE_MIN (50).
         assert!(chunk_text("too short").is_empty());
     }
 
@@ -122,13 +122,13 @@ mod tests {
 
     #[test]
     fn breaks_at_paragraph_boundary() {
-        // Single paragraph break within CHUNK_SIZE window (second half)
+        // Single paragraph break within CHUNK_SIZE window (second half).
         let before_break = "x".repeat(600);
         let after_break = "y".repeat(500);
         let text = format!("{before_break}\n\n{after_break}");
         let chunks = chunk_text(&text);
         assert!(chunks.len() >= 2);
-        // First chunk should end at the paragraph boundary (all x's)
+        // First chunk should end at the paragraph boundary (all x's).
         assert!(
             chunks[0].content.ends_with('x'),
             "first chunk should end with 'x' but was: ...{}",
@@ -158,11 +158,11 @@ mod tests {
 
     #[test]
     fn multibyte_utf8_does_not_panic() {
-        // Mix of ASCII, emoji, and CJK to stress char boundary snapping
+        // Mix of ASCII, emoji, and CJK to stress char boundary snapping.
         let text = "Hello \u{1F600} world! ".repeat(100) + &"\u{4E16}\u{754C}".repeat(200);
         let chunks = chunk_text(&text);
         assert!(!chunks.is_empty());
-        // Verify all chunks are valid UTF-8 (implicit — String guarantees this)
+        // Verify all chunks are valid UTF-8 (implicit — String guarantees this).
         for chunk in &chunks {
             assert!(chunk.content.len() >= CHUNK_SIZE_MIN);
         }
@@ -185,14 +185,14 @@ mod tests {
     #[test]
     fn snap_forward_finds_next_char_boundary() {
         let text = "\u{1F600}end"; // 4-byte emoji then ASCII
-        // Byte offset 1 is mid-emoji, should snap to 4
+        // Byte offset 1 is mid-emoji, should snap to 4.
         assert_eq!(snap_forward(text, 1), 4);
     }
 
     #[test]
     fn snap_backward_finds_prev_char_boundary() {
         let text = "\u{1F600}end"; // 4-byte emoji then ASCII
-        // Byte offset 3 is mid-emoji, should snap to 0
+        // Byte offset 3 is mid-emoji, should snap to 0.
         assert_eq!(snap_backward(text, 3), 0);
     }
 }

--- a/src/palace/chunker.rs
+++ b/src/palace/chunker.rs
@@ -16,30 +16,30 @@ pub struct Chunk {
 }
 
 /// Snap a byte offset to the nearest char boundary (forward).
-fn snap_forward(s: &str, mut pos: usize) -> usize {
+fn snap_forward(text: &str, mut pos: usize) -> usize {
     assert!(
-        pos <= s.len(),
+        pos <= text.len(),
         "snap_forward: pos {pos} exceeds string length {}",
-        s.len()
+        text.len()
     );
-    while pos < s.len() && !s.is_char_boundary(pos) {
+    while pos < text.len() && !text.is_char_boundary(pos) {
         pos += 1;
     }
-    debug_assert!(s.is_char_boundary(pos));
+    debug_assert!(text.is_char_boundary(pos));
     pos
 }
 
 /// Snap a byte offset to the nearest char boundary (backward).
-fn snap_backward(s: &str, mut pos: usize) -> usize {
+fn snap_backward(text: &str, mut pos: usize) -> usize {
     assert!(
-        pos <= s.len(),
+        pos <= text.len(),
         "snap_backward: pos {pos} exceeds string length {}",
-        s.len()
+        text.len()
     );
-    while pos > 0 && !s.is_char_boundary(pos) {
+    while pos > 0 && !text.is_char_boundary(pos) {
         pos -= 1;
     }
-    debug_assert!(s.is_char_boundary(pos));
+    debug_assert!(text.is_char_boundary(pos));
     pos
 }
 
@@ -170,29 +170,29 @@ mod tests {
 
     #[test]
     fn snap_forward_on_boundary_is_identity() {
-        let s = "hello";
-        assert_eq!(snap_forward(s, 0), 0);
-        assert_eq!(snap_forward(s, 3), 3);
+        let text = "hello";
+        assert_eq!(snap_forward(text, 0), 0);
+        assert_eq!(snap_forward(text, 3), 3);
     }
 
     #[test]
     fn snap_backward_on_boundary_is_identity() {
-        let s = "hello";
-        assert_eq!(snap_backward(s, 0), 0);
-        assert_eq!(snap_backward(s, 3), 3);
+        let text = "hello";
+        assert_eq!(snap_backward(text, 0), 0);
+        assert_eq!(snap_backward(text, 3), 3);
     }
 
     #[test]
     fn snap_forward_finds_next_char_boundary() {
-        let s = "\u{1F600}end"; // 4-byte emoji then ASCII
+        let text = "\u{1F600}end"; // 4-byte emoji then ASCII
         // Byte offset 1 is mid-emoji, should snap to 4
-        assert_eq!(snap_forward(s, 1), 4);
+        assert_eq!(snap_forward(text, 1), 4);
     }
 
     #[test]
     fn snap_backward_finds_prev_char_boundary() {
-        let s = "\u{1F600}end"; // 4-byte emoji then ASCII
+        let text = "\u{1F600}end"; // 4-byte emoji then ASCII
         // Byte offset 3 is mid-emoji, should snap to 0
-        assert_eq!(snap_backward(s, 3), 0);
+        assert_eq!(snap_backward(text, 3), 0);
     }
 }

--- a/src/palace/chunker.rs
+++ b/src/palace/chunker.rs
@@ -1,11 +1,11 @@
 const CHUNK_SIZE: usize = 800;
 const CHUNK_OVERLAP: usize = 100;
-const MIN_CHUNK_SIZE: usize = 50;
+const CHUNK_SIZE_MIN: usize = 50;
 
 // Compile-time invariant: overlap must be less than chunk size.
 const _: () = assert!(CHUNK_OVERLAP < CHUNK_SIZE);
 // Compile-time invariant: min chunk size must be less than chunk size.
-const _: () = assert!(MIN_CHUNK_SIZE < CHUNK_SIZE);
+const _: () = assert!(CHUNK_SIZE_MIN < CHUNK_SIZE);
 
 /// A single text chunk produced by [`chunk_text`].
 pub struct Chunk {
@@ -73,7 +73,7 @@ pub fn chunk_text(content: &str) -> Vec<Chunk> {
         }
 
         let chunk = content[start..end].trim();
-        if chunk.len() >= MIN_CHUNK_SIZE {
+        if chunk.len() >= CHUNK_SIZE_MIN {
             chunks.push(Chunk {
                 content: chunk.to_string(),
                 chunk_index,
@@ -90,7 +90,7 @@ pub fn chunk_text(content: &str) -> Vec<Chunk> {
     // Postcondition: chunk indices are sequential.
     debug_assert!(chunks.iter().enumerate().all(|(i, c)| c.chunk_index == i));
     // Postcondition: all chunks have content above minimum size.
-    debug_assert!(chunks.iter().all(|c| c.content.len() >= MIN_CHUNK_SIZE));
+    debug_assert!(chunks.iter().all(|c| c.content.len() >= CHUNK_SIZE_MIN));
 
     chunks
 }
@@ -107,7 +107,7 @@ mod tests {
 
     #[test]
     fn short_string_below_min_size_returns_no_chunks() {
-        // Below MIN_CHUNK_SIZE (50)
+        // Below CHUNK_SIZE_MIN (50)
         assert!(chunk_text("too short").is_empty());
     }
 
@@ -164,7 +164,7 @@ mod tests {
         assert!(!chunks.is_empty());
         // Verify all chunks are valid UTF-8 (implicit — String guarantees this)
         for chunk in &chunks {
-            assert!(chunk.content.len() >= MIN_CHUNK_SIZE);
+            assert!(chunk.content.len() >= CHUNK_SIZE_MIN);
         }
     }
 

--- a/src/palace/convo_miner.rs
+++ b/src/palace/convo_miner.rs
@@ -11,7 +11,7 @@ use crate::palace::miner::MineParams;
 use crate::palace::room_detect::is_skip_dir;
 
 const CONVO_EXTENSIONS: &[&str] = &["txt", "md", "json", "jsonl"];
-const MIN_CHUNK_SIZE: usize = 30;
+const CHUNK_SIZE_MIN: usize = 30;
 /// Bytes per drawer — large exchanges are split at this boundary (rounded down
 /// to a UTF-8 char boundary) so the full AI response is stored without
 /// truncation.  Mirrors miner.py's `CHUNK_SIZE`.  Uses `content.len()` (bytes),
@@ -19,10 +19,10 @@ const MIN_CHUNK_SIZE: usize = 30;
 /// multi-byte characters.
 const CHUNK_SIZE: usize = 800;
 /// Files larger than this are skipped — prevents OOM on huge files.
-const MAX_FILE_SIZE: u64 = 10 * 1024 * 1024; // 10 MB
+const FILE_SIZE_MAX: u64 = 10 * 1024 * 1024; // 10 MB
 
 // Compile-time invariant: chunk size must be greater than min chunk size.
-const _: () = assert!(CHUNK_SIZE > MIN_CHUNK_SIZE);
+const _: () = assert!(CHUNK_SIZE > CHUNK_SIZE_MIN);
 
 use super::WALK_DEPTH_LIMIT;
 
@@ -215,14 +215,14 @@ fn chunk_by_exchange(lines: &[&str]) -> Vec<Chunk> {
                 let first_end = chunk_by_exchange_floor_char_boundary(&content, CHUNK_SIZE);
                 let first = &content[..first_end];
                 // Guard first chunk to avoid nearly-empty starts.
-                if first.trim().len() > MIN_CHUNK_SIZE {
+                if first.trim().len() > CHUNK_SIZE_MIN {
                     chunks.push(Chunk {
                         content: first.to_string(),
                         chunk_index: chunks.len(),
                     });
                 }
                 // Remaining response in CHUNK_SIZE continuation drawers.
-                // Continuation fragments are always pushed (no MIN_CHUNK_SIZE filter)
+                // Continuation fragments are always pushed (no CHUNK_SIZE_MIN filter)
                 // to prevent silent data loss once we've committed to multi-chunk output.
                 let mut remainder = &content[first_end..];
                 while !remainder.is_empty() {
@@ -244,7 +244,7 @@ fn chunk_by_exchange(lines: &[&str]) -> Vec<Chunk> {
                         chunk_index: chunks.len(),
                     });
                 }
-            } else if content.trim().len() > MIN_CHUNK_SIZE {
+            } else if content.trim().len() > CHUNK_SIZE_MIN {
                 chunks.push(Chunk {
                     content,
                     chunk_index: chunks.len(),
@@ -272,7 +272,7 @@ fn chunk_by_paragraph(content: &str) -> Vec<Chunk> {
             .enumerate()
             .filter_map(|(i, group)| {
                 let text = group.join("\n");
-                if text.trim().len() > MIN_CHUNK_SIZE {
+                if text.trim().len() > CHUNK_SIZE_MIN {
                     Some(Chunk {
                         content: text.trim().to_string(),
                         chunk_index: i,
@@ -287,7 +287,7 @@ fn chunk_by_paragraph(content: &str) -> Vec<Chunk> {
     paragraphs
         .iter()
         .enumerate()
-        .filter(|(_, p)| p.len() > MIN_CHUNK_SIZE)
+        .filter(|(_, p)| p.len() > CHUNK_SIZE_MIN)
         .map(|(i, p)| Chunk {
             content: p.to_string(),
             chunk_index: i,
@@ -347,7 +347,7 @@ fn walk_convos(directory: &Path, files: &mut Vec<PathBuf>) {
                 if CONVO_EXTENSIONS.contains(&extension_lower.as_str())
                     && !name.ends_with(".meta.json")
                 {
-                    if std::fs::metadata(&path).is_ok_and(|m| m.len() > MAX_FILE_SIZE) {
+                    if std::fs::metadata(&path).is_ok_and(|m| m.len() > FILE_SIZE_MAX) {
                         continue;
                     }
                     files.push(path);
@@ -387,7 +387,7 @@ fn mine_convos_print_summary(
     files_unreadable: usize,
     files_too_short: usize,
     files_empty_chunks: usize,
-    total_drawers: usize,
+    drawers_total: usize,
     room_counts: &HashMap<String, usize>,
 ) {
     let files_processed = file_count
@@ -413,7 +413,7 @@ fn mine_convos_print_summary(
         println!("  Files skipped (no chunks):        {files_empty_chunks}");
     }
     println!(
-        "  Drawers {}: {total_drawers}",
+        "  Drawers {}: {drawers_total}",
         if dry_run { "would be filed" } else { "filed" }
     );
 
@@ -535,7 +535,7 @@ pub async fn mine_convos(
 
     mine_convos_print_header(wing, &directory, files.len(), extract_mode, opts.dry_run);
 
-    let mut total_drawers: usize = 0;
+    let mut drawers_total: usize = 0;
     let mut files_skipped: usize = 0;
     let mut files_unreadable: usize = 0;
     let mut files_too_short: usize = 0;
@@ -556,7 +556,7 @@ pub async fn mine_convos(
             files_unreadable += 1;
             continue;
         };
-        if content.trim().len() < MIN_CHUNK_SIZE {
+        if content.trim().len() < CHUNK_SIZE_MIN {
             files_too_short += 1;
             continue;
         }
@@ -600,7 +600,7 @@ pub async fn mine_convos(
             .await?;
         }
 
-        total_drawers += drawers_added;
+        drawers_total += drawers_added;
         *room_counts.entry(room.clone()).or_insert(0) += 1;
         println!(
             "  [{:4}/{}] {:50} +{drawers_added}",
@@ -617,7 +617,7 @@ pub async fn mine_convos(
         files_unreadable,
         files_too_short,
         files_empty_chunks,
-        total_drawers,
+        drawers_total,
         &room_counts,
     );
     Ok(())
@@ -672,7 +672,7 @@ mod tests {
 
     #[test]
     fn chunk_by_exchange_small_exchange_single_chunk() {
-        // Content is > MIN_CHUNK_SIZE (30) so it must produce exactly one chunk.
+        // Content is > CHUNK_SIZE_MIN (30) so it must produce exactly one chunk.
         let input = "> user asks a question here\nthe assistant replies with an answer";
         let lines: Vec<&str> = input.lines().collect();
         let chunks = chunk_by_exchange(&lines);
@@ -729,11 +729,11 @@ mod tests {
 
     #[test]
     fn chunk_by_exchange_small_tail_regression() {
-        // Regression test: tail chunk smaller than MIN_CHUNK_SIZE is preserved.
-        // Total size = CHUNK_SIZE + (MIN_CHUNK_SIZE - 1) - prefix_len so remainder
-        // after first CHUNK_SIZE bytes is strictly < MIN_CHUNK_SIZE.
+        // Regression test: tail chunk smaller than CHUNK_SIZE_MIN is preserved.
+        // Total size = CHUNK_SIZE + (CHUNK_SIZE_MIN - 1) - prefix_len so remainder
+        // after first CHUNK_SIZE bytes is strictly < CHUNK_SIZE_MIN.
         let prefix_len = "> user\n".len(); // 7 bytes
-        let ai_body = "x".repeat(CHUNK_SIZE + (MIN_CHUNK_SIZE - 1) - prefix_len); // 822 bytes
+        let ai_body = "x".repeat(CHUNK_SIZE + (CHUNK_SIZE_MIN - 1) - prefix_len); // 822 bytes
         let input = format!("> user\n{ai_body}");
         let lines: Vec<&str> = input.lines().collect();
 
@@ -797,7 +797,7 @@ mod tests {
 
     #[test]
     fn chunk_by_paragraph_multiple_paragraphs() {
-        // Content with multiple double-newline-separated paragraphs above MIN_CHUNK_SIZE
+        // Content with multiple double-newline-separated paragraphs above CHUNK_SIZE_MIN
         // must produce one chunk per paragraph with 0-based contiguous indices.
         let content = "First paragraph with enough text to exceed the minimum size check here.\n\n\
                        Second paragraph with its own content that also exceeds the minimum.\n\n\
@@ -836,18 +836,18 @@ mod tests {
         );
         for chunk in &chunks {
             assert!(
-                chunk.content.trim().len() > MIN_CHUNK_SIZE,
-                "every chunk must exceed MIN_CHUNK_SIZE"
+                chunk.content.trim().len() > CHUNK_SIZE_MIN,
+                "every chunk must exceed CHUNK_SIZE_MIN"
             );
         }
     }
 
     #[test]
     fn chunk_by_paragraph_short_paragraph_filtered() {
-        // A paragraph shorter than MIN_CHUNK_SIZE must be excluded from output.
+        // A paragraph shorter than CHUNK_SIZE_MIN must be excluded from output.
         let content = "short\n\nThis second paragraph has enough characters to exceed the minimum chunk threshold.";
         let chunks = chunk_by_paragraph(content);
-        // "short" (5 chars) is below MIN_CHUNK_SIZE=30 and must be filtered.
+        // "short" (5 chars) is below CHUNK_SIZE_MIN=30 and must be filtered.
         assert_eq!(
             chunks.len(),
             1,
@@ -1218,7 +1218,7 @@ mod tests {
 
     #[tokio::test]
     async fn mine_convos_skips_too_short_files() {
-        // Files with content below MIN_CHUNK_SIZE must be counted as too-short
+        // Files with content below CHUNK_SIZE_MIN must be counted as too-short
         // and must not produce any drawers.
         let temp_directory =
             tempfile::tempdir().expect("failed to create temporary directory for too-short test");

--- a/src/palace/convo_miner.rs
+++ b/src/palace/convo_miner.rs
@@ -12,6 +12,9 @@ use crate::palace::room_detect::is_skip_dir;
 
 const CONVO_EXTENSIONS: &[&str] = &["txt", "md", "json", "jsonl"];
 const CHUNK_SIZE_MIN: usize = 30;
+/// Upper bound on lines in a single conversation chunk; prevents unbounded iteration
+/// over malformed or adversarially large inputs.
+const LINES_MAX: usize = 100_000;
 /// Bytes per drawer — large exchanges are split at this boundary (rounded down
 /// to a UTF-8 char boundary) so the full AI response is stored without
 /// truncation.  Mirrors miner.py's `CHUNK_SIZE`.  Uses `content.len()` (bytes),
@@ -174,11 +177,20 @@ fn chunk_by_exchange_floor_char_boundary(text: &str, index: usize) -> usize {
 /// lines are joined with a single space.  When the combined content exceeds
 /// `CHUNK_SIZE` bytes, it is split across consecutive drawers so nothing is
 /// silently discarded (fixes the prior 8-line cap).
+// TigerStyle exemption: sequential loop structure with three bounded loops and
+// explicit upper-bound assertions; extracting helpers would obscure the control flow.
+#[allow(clippy::too_many_lines)]
 fn chunk_by_exchange(lines: &[&str]) -> Vec<Chunk> {
     let mut chunks = Vec::new();
     let mut i = 0;
+    let mut lines_count: usize = 0;
 
     while i < lines.len() {
+        lines_count += 1;
+        assert!(
+            lines_count <= LINES_MAX,
+            "chunk_by_exchange: exceeded LINES_MAX ({LINES_MAX}) outer iterations"
+        );
         // Upper bound: i strictly increases each iteration, bounded by lines.len().
         debug_assert!(i < lines.len());
         let line = lines[i].trim();
@@ -187,7 +199,13 @@ fn chunk_by_exchange(lines: &[&str]) -> Vec<Chunk> {
             i += 1;
 
             let mut ai_lines = Vec::new();
+            let mut exchange_count: usize = 0;
             while i < lines.len() {
+                exchange_count += 1;
+                assert!(
+                    exchange_count <= LINES_MAX,
+                    "chunk_by_exchange: exceeded LINES_MAX ({LINES_MAX}) inner (exchange-drain) iterations"
+                );
                 // Upper bound: i strictly increases each inner iteration, bounded by lines.len().
                 debug_assert!(i < lines.len());
                 let next = lines[i].trim();
@@ -225,7 +243,13 @@ fn chunk_by_exchange(lines: &[&str]) -> Vec<Chunk> {
                 // Continuation fragments are always pushed (no CHUNK_SIZE_MIN filter)
                 // to prevent silent data loss once we've committed to multi-chunk output.
                 let mut remainder = &content[first_end..];
+                let mut chunk_accumulation_count: usize = 0;
                 while !remainder.is_empty() {
+                    chunk_accumulation_count += 1;
+                    assert!(
+                        chunk_accumulation_count <= LINES_MAX,
+                        "chunk_by_exchange: exceeded LINES_MAX ({LINES_MAX}) chunk-accumulation iterations"
+                    );
                     let end = chunk_by_exchange_floor_char_boundary(remainder, CHUNK_SIZE);
                     // If floor_char_boundary returned 0 (edge case for corrupted input),
                     // advance by the first character's UTF-8 byte length to maintain

--- a/src/palace/convo_miner.rs
+++ b/src/palace/convo_miner.rs
@@ -150,20 +150,20 @@ fn chunk_exchanges(content: &str) -> Vec<Chunk> {
 
 /// Return the largest byte index ≤ `index` that is a UTF‑8 char boundary in `s`.
 ///
-/// Slicing `s` by a raw byte offset is unsafe when the string contains multi‑byte
+/// Slicing `text` by a raw byte offset is unsafe when the string contains multi‑byte
 /// characters (emoji, accented letters, CJK) because the offset may land mid‑
 /// codepoint, causing a panic.  This function walks backwards from `index` until
-/// it finds a valid boundary, guaranteeing `&s[..result]` never panics.
-fn chunk_by_exchange_floor_char_boundary(s: &str, index: usize) -> usize {
-    if index >= s.len() {
-        return s.len();
+/// it finds a valid boundary, guaranteeing `&text[..result]` never panics.
+fn chunk_by_exchange_floor_char_boundary(text: &str, index: usize) -> usize {
+    if index >= text.len() {
+        return text.len();
     }
     let mut i = index;
-    while !s.is_char_boundary(i) {
+    while !text.is_char_boundary(i) {
         i -= 1;
     }
-    // Postcondition: i is a valid char boundary within s.
-    debug_assert!(s.is_char_boundary(i));
+    // Postcondition: i is a valid char boundary within text.
+    debug_assert!(text.is_char_boundary(i));
     debug_assert!(i <= index);
     i
 }
@@ -575,9 +575,13 @@ pub async fn mine_convos(
         // duplicates on reruns and producing stale duplicate chunks.
         let Some(source_mtime) = std::fs::metadata(filepath)
             .ok()
-            .and_then(|m| m.modified().ok())
-            .and_then(|t| t.duration_since(std::time::SystemTime::UNIX_EPOCH).ok())
-            .map(|d| d.as_secs_f64())
+            .and_then(|metadata| metadata.modified().ok())
+            .and_then(|system_time| {
+                system_time
+                    .duration_since(std::time::SystemTime::UNIX_EPOCH)
+                    .ok()
+            })
+            .map(|duration| duration.as_secs_f64())
         else {
             files_unreadable += 1;
             continue;

--- a/src/palace/convo_miner.rs
+++ b/src/palace/convo_miner.rs
@@ -99,6 +99,10 @@ const TOPIC_KEYWORDS: &[(&str, &[&str])] = &[
     ),
 ];
 
+/// Classify conversation content into the best-matching topic room.
+///
+/// Scans the first 3000 characters for keyword matches across the `TOPIC_KEYWORDS`
+/// table and returns the room name with the highest score, defaulting to `"general"`.
 fn detect_convo_room(content: &str) -> String {
     assert!(
         !content.is_empty(),
@@ -122,6 +126,8 @@ fn detect_convo_room(content: &str) -> String {
     best.0.to_string()
 }
 
+/// Split conversation content into chunks, routing to `chunk_by_exchange` or
+/// `chunk_by_paragraph` depending on whether the content uses the quoted-turn format.
 fn chunk_exchanges(content: &str) -> Vec<Chunk> {
     assert!(
         !content.is_empty(),
@@ -171,15 +177,111 @@ fn chunk_by_exchange_floor_char_boundary(text: &str, index: usize) -> usize {
     i
 }
 
+/// Drain AI response lines from `lines` starting at `start_index`.
+///
+/// Collects non-empty lines until a new user turn (`>`) or separator (`---`)
+/// is found.  Returns the collected lines and the updated index, which points
+/// to the first line of the next exchange or past the end of the slice.
+fn chunk_by_exchange_drain_ai_lines<'a>(
+    lines: &[&'a str],
+    start_index: usize,
+) -> (Vec<&'a str>, usize) {
+    assert!(
+        start_index <= lines.len(),
+        "chunk_by_exchange_drain_ai_lines: start_index out of range"
+    );
+    let mut ai_lines = Vec::new();
+    let mut i = start_index;
+    let mut exchange_count: usize = 0;
+    while i < lines.len() {
+        exchange_count += 1;
+        assert!(
+            exchange_count <= LINES_MAX,
+            "chunk_by_exchange_drain_ai_lines: exceeded LINES_MAX ({LINES_MAX}) iterations"
+        );
+        // Upper bound: i strictly increases each iteration, bounded by lines.len().
+        debug_assert!(i < lines.len());
+        let next = lines[i].trim();
+        if next.starts_with('>') || next.starts_with("---") {
+            break;
+        }
+        if !next.is_empty() {
+            ai_lines.push(next);
+        }
+        i += 1;
+    }
+    // Postcondition: returned index is within bounds or at the end.
+    debug_assert!(i <= lines.len());
+    (ai_lines, i)
+}
+
+/// Flush an assembled exchange into `chunks`, splitting on `CHUNK_SIZE` boundaries.
+///
+/// When content fits in one chunk it is pushed as-is (guarded by `CHUNK_SIZE_MIN`).
+/// When it overflows, the first `CHUNK_SIZE` bytes form the head chunk and the
+/// remainder is split into continuation drawers — always pushed regardless of
+/// `CHUNK_SIZE_MIN` to prevent silent data loss.
+fn chunk_by_exchange_flush(content: String, chunks: &mut Vec<Chunk>) {
+    assert!(
+        !content.is_empty(),
+        "chunk_by_exchange_flush: content must not be empty"
+    );
+    if content.len() > CHUNK_SIZE {
+        // First chunk: user turn + as much response as fits.
+        // Use char-boundary-safe slicing: a raw byte offset can land
+        // mid-codepoint for multi-byte chars (emoji, CJK, accents).
+        let first_end = chunk_by_exchange_floor_char_boundary(&content, CHUNK_SIZE);
+        let first = &content[..first_end];
+        // Guard first chunk to avoid nearly-empty starts.
+        if first.trim().len() > CHUNK_SIZE_MIN {
+            chunks.push(Chunk {
+                content: first.to_string(),
+                chunk_index: chunks.len(),
+            });
+        }
+        // Remaining response in CHUNK_SIZE continuation drawers.
+        // Continuation fragments are always pushed (no CHUNK_SIZE_MIN filter)
+        // to prevent silent data loss once we've committed to multi-chunk output.
+        let mut remainder = &content[first_end..];
+        let mut chunk_accumulation_count: usize = 0;
+        while !remainder.is_empty() {
+            chunk_accumulation_count += 1;
+            assert!(
+                chunk_accumulation_count <= LINES_MAX,
+                "chunk_by_exchange_flush: exceeded LINES_MAX ({LINES_MAX}) chunk-accumulation iterations"
+            );
+            let end = chunk_by_exchange_floor_char_boundary(remainder, CHUNK_SIZE);
+            // If floor_char_boundary returned 0 (edge case for corrupted input),
+            // advance by the first character's UTF-8 byte length to maintain
+            // boundary safety and prevent infinite loops.
+            let end = if end == 0 {
+                // Invariant: remainder is non-empty (guarded by while condition),
+                // so chars().next() always returns Some.
+                remainder.chars().next().map_or(1, char::len_utf8)
+            } else {
+                end
+            };
+            let part = &remainder[..end];
+            remainder = &remainder[end..];
+            chunks.push(Chunk {
+                content: part.to_string(),
+                chunk_index: chunks.len(),
+            });
+        }
+    } else if content.trim().len() > CHUNK_SIZE_MIN {
+        chunks.push(Chunk {
+            content,
+            chunk_index: chunks.len(),
+        });
+    }
+}
+
 /// One user turn (>) + the full AI response that follows = one or more chunks.
 ///
 /// Each line is whitespace-trimmed and empty lines are dropped; the remaining
 /// lines are joined with a single space.  When the combined content exceeds
 /// `CHUNK_SIZE` bytes, it is split across consecutive drawers so nothing is
 /// silently discarded (fixes the prior 8-line cap).
-// TigerStyle exemption: sequential loop structure with three bounded loops and
-// explicit upper-bound assertions; extracting helpers would obscure the control flow.
-#[allow(clippy::too_many_lines)]
 fn chunk_by_exchange(lines: &[&str]) -> Vec<Chunk> {
     let mut chunks = Vec::new();
     let mut i = 0;
@@ -197,27 +299,8 @@ fn chunk_by_exchange(lines: &[&str]) -> Vec<Chunk> {
         if line.starts_with('>') {
             let user_turn = line;
             i += 1;
-
-            let mut ai_lines = Vec::new();
-            let mut exchange_count: usize = 0;
-            while i < lines.len() {
-                exchange_count += 1;
-                assert!(
-                    exchange_count <= LINES_MAX,
-                    "chunk_by_exchange: exceeded LINES_MAX ({LINES_MAX}) inner (exchange-drain) iterations"
-                );
-                // Upper bound: i strictly increases each inner iteration, bounded by lines.len().
-                debug_assert!(i < lines.len());
-                let next = lines[i].trim();
-                if next.starts_with('>') || next.starts_with("---") {
-                    break;
-                }
-                if !next.is_empty() {
-                    ai_lines.push(next);
-                }
-                i += 1;
-            }
-
+            let (ai_lines, new_i) = chunk_by_exchange_drain_ai_lines(lines, i);
+            i = new_i;
             // Full response — no truncation.
             let ai_response = ai_lines.join(" ");
             let content = if ai_response.is_empty() {
@@ -225,55 +308,7 @@ fn chunk_by_exchange(lines: &[&str]) -> Vec<Chunk> {
             } else {
                 format!("{user_turn}\n{ai_response}")
             };
-
-            if content.len() > CHUNK_SIZE {
-                // First chunk: user turn + as much response as fits.
-                // Use char-boundary-safe slicing: a raw byte offset can land
-                // mid-codepoint for multi-byte chars (emoji, CJK, accents).
-                let first_end = chunk_by_exchange_floor_char_boundary(&content, CHUNK_SIZE);
-                let first = &content[..first_end];
-                // Guard first chunk to avoid nearly-empty starts.
-                if first.trim().len() > CHUNK_SIZE_MIN {
-                    chunks.push(Chunk {
-                        content: first.to_string(),
-                        chunk_index: chunks.len(),
-                    });
-                }
-                // Remaining response in CHUNK_SIZE continuation drawers.
-                // Continuation fragments are always pushed (no CHUNK_SIZE_MIN filter)
-                // to prevent silent data loss once we've committed to multi-chunk output.
-                let mut remainder = &content[first_end..];
-                let mut chunk_accumulation_count: usize = 0;
-                while !remainder.is_empty() {
-                    chunk_accumulation_count += 1;
-                    assert!(
-                        chunk_accumulation_count <= LINES_MAX,
-                        "chunk_by_exchange: exceeded LINES_MAX ({LINES_MAX}) chunk-accumulation iterations"
-                    );
-                    let end = chunk_by_exchange_floor_char_boundary(remainder, CHUNK_SIZE);
-                    // If floor_char_boundary returned 0 (edge case for corrupted input),
-                    // advance by the first character's UTF-8 byte length to maintain
-                    // boundary safety and prevent infinite loops.
-                    let end = if end == 0 {
-                        // Invariant: remainder is non-empty (guarded by while condition),
-                        // so chars().next() always returns Some.
-                        remainder.chars().next().map_or(1, char::len_utf8)
-                    } else {
-                        end
-                    };
-                    let part = &remainder[..end];
-                    remainder = &remainder[end..];
-                    chunks.push(Chunk {
-                        content: part.to_string(),
-                        chunk_index: chunks.len(),
-                    });
-                }
-            } else if content.trim().len() > CHUNK_SIZE_MIN {
-                chunks.push(Chunk {
-                    content,
-                    chunk_index: chunks.len(),
-                });
-            }
+            chunk_by_exchange_flush(content, &mut chunks);
         } else {
             i += 1;
         }
@@ -282,6 +317,10 @@ fn chunk_by_exchange(lines: &[&str]) -> Vec<Chunk> {
     chunks
 }
 
+/// Split content into chunks by paragraph (blank-line boundary) or line groups.
+///
+/// Falls back to 25-line groups when the content has only one paragraph but more
+/// than 20 lines, which prevents the entire file from becoming a single oversized chunk.
 fn chunk_by_paragraph(content: &str) -> Vec<Chunk> {
     let paragraphs: Vec<&str> = content
         .split("\n\n")
@@ -319,6 +358,8 @@ fn chunk_by_paragraph(content: &str) -> Vec<Chunk> {
         .collect()
 }
 
+/// Return a flat list of all conversation files under `directory`.
+/// Delegates the actual traversal to `walk_convos`.
 fn scan_convos(directory: &Path) -> Vec<PathBuf> {
     assert!(
         directory.is_dir(),
@@ -329,6 +370,10 @@ fn scan_convos(directory: &Path) -> Vec<PathBuf> {
     files
 }
 
+/// Iteratively walk `directory` (depth-limited DFS) and collect conversation files.
+///
+/// Symlinks are skipped; directories named `tool-results` or `memory` are excluded;
+/// files larger than `FILE_SIZE_MAX` are silently skipped.
 fn walk_convos(directory: &Path, files: &mut Vec<PathBuf>) {
     // Iterative DFS with explicit depth tracking — no recursion.
     let mut stack: Vec<(PathBuf, usize)> = vec![(directory.to_path_buf(), 0)];
@@ -381,6 +426,7 @@ fn walk_convos(directory: &Path, files: &mut Vec<PathBuf>) {
     }
 }
 
+/// Print the mine-convos progress header to stdout.
 fn mine_convos_print_header(
     wing: &str,
     directory: &Path,
@@ -402,6 +448,7 @@ fn mine_convos_print_header(
     println!("-------------------------------------------------------\n");
 }
 
+/// Print the mine-convos completion summary (file counts, drawer counts, room breakdown) to stdout.
 // Eight independent summary counters; a dedicated struct would be over-engineered for a single private call site.
 #[allow(clippy::too_many_arguments)]
 fn mine_convos_print_summary(
@@ -509,14 +556,91 @@ async fn mine_convos_write_chunks(
     Ok(())
 }
 
-// Sequential file-scan loop with per-file counters mutated via continue/+=; no clean extraction boundary within 70 lines.
-#[allow(clippy::too_many_lines)]
-pub async fn mine_convos(
+/// Per-file outcome returned by `mine_convos_scan_file`.
+enum MineConvosFileOutcome {
+    /// File was already mined in a previous run; skip without writing.
+    AlreadyMined,
+    /// File could not be read or its mtime is unavailable.
+    Unreadable,
+    /// File content is below `CHUNK_SIZE_MIN`; not worth indexing.
+    TooShort,
+    /// Content parsed to zero chunks (e.g. no qualifying exchanges or paragraphs).
+    EmptyChunks,
+    /// File processed successfully; carry the room name and drawer count.
+    Processed { room: String, drawers_added: usize },
+}
+
+/// Read one conversation file and, unless `dry_run`, write its chunks to the
+/// palace.  Returns a `MineConvosFileOutcome` describing what happened so the
+/// caller can update its summary counters.
+async fn mine_convos_scan_file(
+    filepath: &Path,
     connection: &Connection,
-    directory: &Path,
-    extract_mode: &str,
+    wing: &str,
     opts: &MineParams,
-) -> Result<()> {
+) -> Result<MineConvosFileOutcome> {
+    assert!(
+        !wing.is_empty(),
+        "mine_convos_scan_file: wing must not be empty"
+    );
+    let source_file = filepath.to_string_lossy().to_string();
+    // Always check for duplicates so dry runs report accurate skip counts.
+    // Only the write path below is gated on !opts.dry_run.
+    if drawer::file_already_mined(connection, &source_file).await? {
+        return Ok(MineConvosFileOutcome::AlreadyMined);
+    }
+    let Ok(content) = normalize::normalize(filepath) else {
+        return Ok(MineConvosFileOutcome::Unreadable);
+    };
+    if content.trim().len() < CHUNK_SIZE_MIN {
+        return Ok(MineConvosFileOutcome::TooShort);
+    }
+    let chunks = chunk_exchanges(&content);
+    if chunks.is_empty() {
+        return Ok(MineConvosFileOutcome::EmptyChunks);
+    }
+    let room = detect_convo_room(&content);
+    let drawers_added = chunks.len();
+    // Mtime is required: None conflates "no on-disk source" with
+    // "unreadable filesystem", causing file_already_mined() to miss
+    // duplicates on reruns and producing stale duplicate chunks.
+    let Some(source_mtime) = std::fs::metadata(filepath)
+        .ok()
+        .and_then(|metadata| metadata.modified().ok())
+        .and_then(|system_time| {
+            system_time
+                .duration_since(std::time::SystemTime::UNIX_EPOCH)
+                .ok()
+        })
+        .map(|duration| duration.as_secs_f64())
+    else {
+        return Ok(MineConvosFileOutcome::Unreadable);
+    };
+    if !opts.dry_run {
+        mine_convos_write_chunks(
+            connection,
+            &chunks,
+            wing,
+            &room,
+            &source_file,
+            source_mtime,
+            opts,
+        )
+        .await?;
+    }
+    Ok(MineConvosFileOutcome::Processed {
+        room,
+        drawers_added,
+    })
+}
+
+/// Canonicalize `directory` and resolve the wing name.
+///
+/// Returns `(canonical_path, wing_name)` where `wing_name` is either the
+/// explicit override from `opts.wing` or derived from the directory's last
+/// path component.  Errors when the path cannot be canonicalized, is not a
+/// directory, or has no file-name component and no explicit wing override.
+fn mine_convos_resolve_wing(directory: &Path, opts: &MineParams) -> Result<(PathBuf, String)> {
     let directory = directory.canonicalize().map_err(|e| {
         crate::error::Error::Other(format!("directory not found: {}: {e}", directory.display()))
     })?;
@@ -526,28 +650,47 @@ pub async fn mine_convos(
             directory.display()
         )));
     }
-
+    if let Some(wing_name) = opts.wing.as_deref() {
+        assert!(
+            !wing_name.is_empty(),
+            "mine_convos_resolve_wing: explicit wing must not be empty"
+        );
+        return Ok((directory, wing_name.to_string()));
+    }
+    // file_name() returns None for filesystem roots (e.g. `/`), producing an empty
+    // dir_name.  An empty wing triggers the assert in drawer::add_drawer, so surface
+    // a clear error here instead.
     let dir_name = directory
         .file_name()
         .unwrap_or_default()
         .to_string_lossy()
         .to_lowercase()
         .replace([' ', '-'], "_");
-    // file_name() returns None for filesystem roots (e.g. `/`), producing an empty
-    // dir_name. An empty wing triggers the assert in drawer::add_drawer, so surface
-    // a clear error here instead.
-    let wing = if let Some(wing_name) = opts.wing.as_deref() {
-        wing_name
-    } else if dir_name.is_empty() {
+    if dir_name.is_empty() {
         return Err(crate::error::Error::Other(
             "mine convos: cannot determine wing name — directory is a filesystem root; \
              pass --wing to specify one explicitly"
                 .to_string(),
         ));
-    } else {
-        &dir_name
-    };
+    }
+    assert!(
+        !dir_name.is_empty(),
+        "mine_convos_resolve_wing: derived wing must not be empty"
+    );
+    Ok((directory, dir_name))
+}
 
+/// Mine all conversation files in `directory`, filing chunks as drawers in the palace.
+///
+/// Resolves the wing name, walks for eligible files, and delegates per-file
+/// processing to `mine_convos_scan_file`.
+pub async fn mine_convos(
+    connection: &Connection,
+    directory: &Path,
+    extract_mode: &str,
+    opts: &MineParams,
+) -> Result<()> {
+    let (directory, wing) = mine_convos_resolve_wing(directory, opts)?;
     let mut all_files = scan_convos(&directory);
     // Sort for deterministic ordering before applying any limit.
     all_files.sort_unstable();
@@ -556,84 +699,42 @@ pub async fn mine_convos(
     } else {
         all_files.into_iter().take(opts.limit).collect()
     };
-
-    mine_convos_print_header(wing, &directory, files.len(), extract_mode, opts.dry_run);
-
+    mine_convos_print_header(&wing, &directory, files.len(), extract_mode, opts.dry_run);
     let mut drawers_total: usize = 0;
     let mut files_skipped: usize = 0;
     let mut files_unreadable: usize = 0;
     let mut files_too_short: usize = 0;
     let mut files_empty_chunks: usize = 0;
     let mut room_counts: HashMap<String, usize> = HashMap::new();
-
     for (i, filepath) in files.iter().enumerate() {
-        let source_file = filepath.to_string_lossy().to_string();
-
-        // Always check for duplicates so dry runs report accurate skip counts.
-        // Only the write path below is gated on !opts.dry_run.
-        if drawer::file_already_mined(connection, &source_file).await? {
-            files_skipped += 1;
-            continue;
+        match mine_convos_scan_file(filepath, connection, &wing, opts).await? {
+            MineConvosFileOutcome::AlreadyMined => {
+                files_skipped += 1;
+            }
+            MineConvosFileOutcome::Unreadable => {
+                files_unreadable += 1;
+            }
+            MineConvosFileOutcome::TooShort => {
+                files_too_short += 1;
+            }
+            MineConvosFileOutcome::EmptyChunks => {
+                files_empty_chunks += 1;
+            }
+            MineConvosFileOutcome::Processed {
+                room,
+                drawers_added,
+            } => {
+                drawers_total += drawers_added;
+                *room_counts.entry(room).or_insert(0) += 1;
+                println!(
+                    "  [{:4}/{}] {:50} +{drawers_added}",
+                    i + 1,
+                    files.len(),
+                    filepath.file_name().unwrap_or_default().to_string_lossy(),
+                );
+            }
         }
-
-        let Ok(content) = normalize::normalize(filepath) else {
-            files_unreadable += 1;
-            continue;
-        };
-        if content.trim().len() < CHUNK_SIZE_MIN {
-            files_too_short += 1;
-            continue;
-        }
-
-        let chunks = chunk_exchanges(&content);
-        if chunks.is_empty() {
-            files_empty_chunks += 1;
-            continue;
-        }
-
-        let room = detect_convo_room(&content);
-        let drawers_added = chunks.len();
-
-        // Mtime is required: None conflates "no on-disk source" with
-        // "unreadable filesystem", causing file_already_mined() to miss
-        // duplicates on reruns and producing stale duplicate chunks.
-        let Some(source_mtime) = std::fs::metadata(filepath)
-            .ok()
-            .and_then(|metadata| metadata.modified().ok())
-            .and_then(|system_time| {
-                system_time
-                    .duration_since(std::time::SystemTime::UNIX_EPOCH)
-                    .ok()
-            })
-            .map(|duration| duration.as_secs_f64())
-        else {
-            files_unreadable += 1;
-            continue;
-        };
-
-        if !opts.dry_run {
-            mine_convos_write_chunks(
-                connection,
-                &chunks,
-                wing,
-                &room,
-                &source_file,
-                source_mtime,
-                opts,
-            )
-            .await?;
-        }
-
-        drawers_total += drawers_added;
-        *room_counts.entry(room.clone()).or_insert(0) += 1;
-        println!(
-            "  [{:4}/{}] {:50} +{drawers_added}",
-            i + 1,
-            files.len(),
-            filepath.file_name().unwrap_or_default().to_string_lossy(),
-        );
     }
-
     mine_convos_print_summary(
         opts.dry_run,
         files.len(),

--- a/src/palace/drawer.rs
+++ b/src/palace/drawer.rs
@@ -469,30 +469,20 @@ mod async_tests {
     }
 }
 
-/// Add a drawer and index its words.
-///
-/// Returns `true` when the drawer was inserted, `false` when a drawer with the
-/// same `id` already exists (idempotent — no error is raised).
-///
-/// The INSERT and word indexing are wrapped in a savepoint so that a failed
-/// `index_words` call rolls back the drawer too, leaving no unsearchable
-/// orphans.  Savepoints nest correctly if the caller is already inside a
-/// transaction.
-pub async fn add_drawer(connection: &Connection, params: &DrawerParams<'_>) -> Result<bool> {
-    // Preconditions: all required fields must be non-empty.
+/// Execute the INSERT OR IGNORE for a drawer inside the `add_drawer` savepoint.
+/// On SQL error, rolls back and releases the savepoint before returning `Err`.
+/// Returns the number of rows affected (0 or 1).
+/// Called by `add_drawer` to keep that function within the 70-line limit.
+async fn add_drawer_insert(
+    connection: &Connection,
+    params: &DrawerParams<'_>,
+    chunk_index_sql: i32,
+) -> Result<u64> {
     assert!(!params.id.is_empty(), "drawer id must not be empty");
-    assert!(!params.wing.is_empty(), "drawer wing must not be empty");
-    assert!(!params.room.is_empty(), "drawer room must not be empty");
     assert!(
         !params.content.is_empty(),
         "drawer content must not be empty"
     );
-
-    // SQLite only has i64 integers, so we cast chunk_index (usize) to i32 at the SQL boundary.
-    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-    let chunk_index_sql = params.chunk_index as i32;
-
-    connection.execute("SAVEPOINT add_drawer", ()).await?;
 
     let rows_affected = connection
         .execute(
@@ -529,21 +519,26 @@ pub async fn add_drawer(connection: &Connection, params: &DrawerParams<'_>) -> R
         rows_affected <= 1,
         "INSERT OR IGNORE must affect 0 or 1 rows, got {rows_affected}"
     );
+    Ok(rows_affected)
+}
 
-    if rows_affected == 0 {
-        // Already exists — nothing was written; release the savepoint and report.
-        connection
-            .execute("RELEASE SAVEPOINT add_drawer", ())
-            .await?;
-        return Ok(false);
-    }
+/// Index a drawer's words inside the `add_drawer` savepoint, releasing or
+/// rolling back the savepoint depending on whether indexing succeeds.
+/// Called by `add_drawer` to keep that function within the 70-line limit.
+async fn add_drawer_index_words(
+    connection: &Connection,
+    drawer_id: &str,
+    content: &str,
+) -> Result<()> {
+    assert!(!drawer_id.is_empty(), "drawer_id must not be empty");
+    assert!(!content.is_empty(), "content must not be empty");
 
-    match index_words(connection, params.id, params.content).await {
+    match index_words(connection, drawer_id, content).await {
         Ok(()) => {
             connection
                 .execute("RELEASE SAVEPOINT add_drawer", ())
                 .await?;
-            Ok(true)
+            Ok(())
         }
         Err(e) => {
             let _ = connection
@@ -553,4 +548,43 @@ pub async fn add_drawer(connection: &Connection, params: &DrawerParams<'_>) -> R
             Err(e)
         }
     }
+}
+
+/// Add a drawer and index its words.
+///
+/// Returns `true` when the drawer was inserted, `false` when a drawer with the
+/// same `id` already exists (idempotent — no error is raised).
+///
+/// The INSERT and word indexing are wrapped in a savepoint so that a failed
+/// `index_words` call rolls back the drawer too, leaving no unsearchable
+/// orphans.  Savepoints nest correctly if the caller is already inside a
+/// transaction.
+pub async fn add_drawer(connection: &Connection, params: &DrawerParams<'_>) -> Result<bool> {
+    // Preconditions: all required fields must be non-empty.
+    assert!(!params.id.is_empty(), "drawer id must not be empty");
+    assert!(!params.wing.is_empty(), "drawer wing must not be empty");
+    assert!(!params.room.is_empty(), "drawer room must not be empty");
+    assert!(
+        !params.content.is_empty(),
+        "drawer content must not be empty"
+    );
+
+    // SQLite only has i64 integers, so we cast chunk_index (usize) to i32 at the SQL boundary.
+    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+    let chunk_index_sql = params.chunk_index as i32;
+
+    connection.execute("SAVEPOINT add_drawer", ()).await?;
+
+    let rows_affected = add_drawer_insert(connection, params, chunk_index_sql).await?;
+
+    if rows_affected == 0 {
+        // Already exists — nothing was written; release the savepoint and report.
+        connection
+            .execute("RELEASE SAVEPOINT add_drawer", ())
+            .await?;
+        return Ok(false);
+    }
+
+    add_drawer_index_words(connection, params.id, params.content).await?;
+    Ok(true)
 }

--- a/src/palace/drawer.rs
+++ b/src/palace/drawer.rs
@@ -125,7 +125,7 @@ fn file_mtime(path: &str) -> Option<f64> {
         .ok()?
         .duration_since(std::time::SystemTime::UNIX_EPOCH)
         .ok()
-        .map(|d| d.as_secs_f64())
+        .map(|duration| duration.as_secs_f64())
 }
 
 /// Check whether a file has already been mined *and is unchanged* since it was
@@ -238,7 +238,7 @@ mod async_tests {
     #[tokio::test]
     async fn add_drawer_inserts_row() {
         let (_db, connection) = crate::test_helpers::test_db().await;
-        let p = DrawerParams {
+        let params = DrawerParams {
             id: "d1",
             wing: "test_wing",
             room: "general",
@@ -249,7 +249,7 @@ mod async_tests {
             ingest_mode: "projects",
             source_mtime: None,
         };
-        let inserted = add_drawer(&connection, &p)
+        let inserted = add_drawer(&connection, &params)
             .await
             .expect("add_drawer should succeed for valid new drawer");
         assert!(inserted);
@@ -267,7 +267,7 @@ mod async_tests {
     #[tokio::test]
     async fn add_drawer_duplicate_returns_false() {
         let (_db, connection) = crate::test_helpers::test_db().await;
-        let p = DrawerParams {
+        let params = DrawerParams {
             id: "dup1",
             wing: "w",
             room: "r",
@@ -278,11 +278,11 @@ mod async_tests {
             ingest_mode: "projects",
             source_mtime: None,
         };
-        let first = add_drawer(&connection, &p)
+        let first = add_drawer(&connection, &params)
             .await
             .expect("first add_drawer should succeed for new drawer");
         assert!(first);
-        let second = add_drawer(&connection, &p)
+        let second = add_drawer(&connection, &params)
             .await
             .expect("second add_drawer on same id should not error (INSERT OR IGNORE)");
         assert!(!second);
@@ -291,7 +291,7 @@ mod async_tests {
     #[tokio::test]
     async fn add_drawer_stores_mtime() {
         let (_db, connection) = crate::test_helpers::test_db().await;
-        let p = DrawerParams {
+        let params = DrawerParams {
             id: "mt1",
             wing: "w",
             room: "r",
@@ -302,7 +302,7 @@ mod async_tests {
             ingest_mode: "projects",
             source_mtime: Some(1_700_000_000.5),
         };
-        add_drawer(&connection, &p)
+        add_drawer(&connection, &params)
             .await
             .expect("add_drawer should succeed for valid new drawer with mtime");
 
@@ -384,9 +384,9 @@ mod async_tests {
     #[tokio::test]
     async fn file_already_mined_matching_mtime_returns_true() {
         let (_db, connection) = crate::test_helpers::test_db().await;
-        let tmp = tempfile::NamedTempFile::new()
+        let temp_file = tempfile::NamedTempFile::new()
             .expect("tempfile::NamedTempFile::new should succeed in test environment");
-        let path = tmp.path().to_string_lossy().to_string();
+        let path = temp_file.path().to_string_lossy().to_string();
         let mtime =
             file_mtime(&path).expect("file_mtime should succeed for existing temp file on disk");
 
@@ -411,9 +411,9 @@ mod async_tests {
     #[tokio::test]
     async fn file_already_mined_stale_mtime_returns_false() {
         let (_db, connection) = crate::test_helpers::test_db().await;
-        let tmp = tempfile::NamedTempFile::new()
+        let temp_file = tempfile::NamedTempFile::new()
             .expect("tempfile::NamedTempFile::new should succeed in test environment");
-        let path = tmp.path().to_string_lossy().to_string();
+        let path = temp_file.path().to_string_lossy().to_string();
         // Store an obviously wrong mtime.
         let stale_mtime: f64 = 0.0;
 
@@ -439,9 +439,9 @@ mod async_tests {
     #[tokio::test]
     async fn file_already_mined_disagreeing_mtimes_returns_false() {
         let (_db, connection) = crate::test_helpers::test_db().await;
-        let tmp = tempfile::NamedTempFile::new()
+        let temp_file = tempfile::NamedTempFile::new()
             .expect("tempfile::NamedTempFile::new should succeed in test environment");
-        let path = tmp.path().to_string_lossy().to_string();
+        let path = temp_file.path().to_string_lossy().to_string();
 
         connection
             .execute(

--- a/src/palace/drawer.rs
+++ b/src/palace/drawer.rs
@@ -196,7 +196,7 @@ mod tests {
     #[test]
     fn tokenize_filters_short_words() {
         let tokens = tokenize("I am OK hi no");
-        // All words are < 3 chars
+        // All words are < 3 chars.
         assert!(tokens.is_empty());
     }
 
@@ -321,7 +321,7 @@ mod async_tests {
     #[tokio::test]
     async fn index_words_creates_entries() {
         let (_db, connection) = crate::test_helpers::test_db().await;
-        // Insert a drawer first
+        // Insert a drawer first.
         connection
             .execute(
                 "INSERT INTO drawers (id, wing, room, content) VALUES ('iw1', 'w', 'r', 'test')",

--- a/src/palace/entity_detect.rs
+++ b/src/palace/entity_detect.rs
@@ -50,19 +50,19 @@ pub struct DetectionResult {
 }
 
 /// Scan files and detect entity candidates.
-pub fn detect_entities(file_paths: &[&Path], max_files: usize) -> DetectionResult {
-    assert!(max_files > 0, "detect_entities: max_files must be positive");
+pub fn detect_entities(file_paths: &[&Path], files_max: usize) -> DetectionResult {
+    assert!(files_max > 0, "detect_entities: files_max must be positive");
     let mut all_text = String::new();
     let mut all_lines = Vec::new();
-    let max_bytes_per_file = 5000;
+    let bytes_per_file_max = 5000;
 
     for (i, path) in file_paths.iter().enumerate() {
-        if i >= max_files {
+        if i >= files_max {
             break;
         }
         if let Ok(content) = fs::read_to_string(path) {
-            let truncated = if content.len() > max_bytes_per_file {
-                &content[..max_bytes_per_file]
+            let truncated = if content.len() > bytes_per_file_max {
+                &content[..bytes_per_file_max]
             } else {
                 &content
             };
@@ -668,9 +668,9 @@ Clara said the migration is complete. He agreed.\n";
         let result = detect_entities(&paths, 10);
 
         // Postcondition: detection found entities across multiple categories.
-        let total_entities = result.people.len() + result.projects.len() + result.uncertain.len();
+        let entities_total = result.people.len() + result.projects.len() + result.uncertain.len();
         assert!(
-            total_entities > 0,
+            entities_total > 0,
             "detection should find at least one entity across all categories"
         );
 

--- a/src/palace/entity_detect.rs
+++ b/src/palace/entity_detect.rs
@@ -61,7 +61,14 @@ pub fn detect_entities(file_paths: &[&Path], files_max: usize) -> DetectionResul
         }
         if let Ok(content) = fs::read_to_string(path) {
             let truncated = if content.len() > bytes_per_file_max {
-                &content[..bytes_per_file_max]
+                // Walk backward from the byte limit to find a valid UTF-8 char
+                // boundary.  Slicing at a raw byte offset can land mid-codepoint
+                // for multi-byte characters (emoji, CJK, accented letters) and panic.
+                let mut end = bytes_per_file_max;
+                while end > 0 && !content.is_char_boundary(end) {
+                    end -= 1;
+                }
+                &content[..end]
             } else {
                 &content
             };
@@ -71,6 +78,15 @@ pub fn detect_entities(file_paths: &[&Path], files_max: usize) -> DetectionResul
         }
     }
 
+    // Guard against the case where no files were readable: extract_candidates
+    // has an assert!(!text.is_empty()) that would panic on empty input.
+    if all_text.is_empty() {
+        return DetectionResult {
+            people: vec![],
+            projects: vec![],
+            uncertain: vec![],
+        };
+    }
     let candidates = extract_candidates(&all_text);
     if candidates.is_empty() {
         return DetectionResult {

--- a/src/palace/entity_detect.rs
+++ b/src/palace/entity_detect.rs
@@ -98,6 +98,29 @@ pub fn detect_entities(file_paths: &[&Path], files_max: usize) -> DetectionResul
         }
     }
 
+    detect_entities_sort_and_truncate(&mut people, &mut projects, &mut uncertain);
+
+    DetectionResult {
+        people,
+        projects,
+        uncertain,
+    }
+}
+
+/// Called by `detect_entities` to keep that function within the 70-line limit.
+///
+/// Sort each result list by descending confidence (people, projects) or descending
+/// frequency (uncertain), then truncate to the per-category caps of 15/10/8.
+fn detect_entities_sort_and_truncate(
+    people: &mut Vec<DetectedEntity>,
+    projects: &mut Vec<DetectedEntity>,
+    uncertain: &mut Vec<DetectedEntity>,
+) {
+    assert!(
+        people.len() + projects.len() + uncertain.len() > 0,
+        "at least one entity must be present"
+    );
+
     people.sort_by(|a, b| {
         b.confidence
             .partial_cmp(&a.confidence)
@@ -118,12 +141,6 @@ pub fn detect_entities(file_paths: &[&Path], files_max: usize) -> DetectionResul
     debug_assert!(people.len() <= 15);
     debug_assert!(projects.len() <= 10);
     debug_assert!(uncertain.len() <= 8);
-
-    DetectionResult {
-        people,
-        projects,
-        uncertain,
-    }
 }
 
 /// Build the stop word set for entity candidate extraction.
@@ -174,6 +191,8 @@ fn extract_candidates_stop_words() -> HashSet<&'static str> {
     stops
 }
 
+/// Extract capitalized-word candidates from `text`, filtered by stop words and a
+/// minimum frequency of 3 occurrences.  Returns a map of candidate name to count.
 fn extract_candidates(text: &str) -> HashMap<String, usize> {
     assert!(
         !text.is_empty(),
@@ -263,18 +282,7 @@ fn score_entity_person(name: &str, escaped: &str, text: &str, lines: &[String]) 
         category_count += 1;
     }
 
-    let name_lower = name.to_lowercase();
-    let mut pronoun_hits = 0;
-    for (i, line) in lines.iter().enumerate() {
-        if line.to_lowercase().contains(&name_lower) {
-            let start = i.saturating_sub(2);
-            let end = (i + 3).min(lines.len());
-            let window: String = lines[start..end].join(" ");
-            if PRONOUN_RE.is_match(&window) {
-                pronoun_hits += 1;
-            }
-        }
-    }
+    let pronoun_hits = score_entity_person_pronoun_score(name, lines);
     if pronoun_hits > 0 {
         score += pronoun_hits * 2;
         category_count += 1;
@@ -293,7 +301,34 @@ fn score_entity_person(name: &str, escaped: &str, text: &str, lines: &[String]) 
     (score, category_count)
 }
 
-/// Score project-related signals: build/deploy verbs, versioned references.
+/// Called by `score_entity_person` to keep that function within the 70-line limit.
+///
+/// Scan `lines` for lines containing `name` and count how many have a gendered or
+/// plural pronoun within a ±2-line window, indicating a person-like antecedent.
+/// Returns the raw hit count (caller multiplies by weight).
+fn score_entity_person_pronoun_score(name: &str, lines: &[String]) -> i32 {
+    assert!(!name.is_empty(), "name must not be empty");
+
+    let name_lower = name.to_lowercase();
+    let mut pronoun_hits = 0i32;
+    for (i, line) in lines.iter().enumerate() {
+        if line.to_lowercase().contains(&name_lower) {
+            let start = i.saturating_sub(2);
+            let end = (i + 3).min(lines.len());
+            let window: String = lines[start..end].join(" ");
+            if PRONOUN_RE.is_match(&window) {
+                pronoun_hits += 1;
+            }
+        }
+    }
+
+    // Postcondition: hit count is non-negative.
+    debug_assert!(pronoun_hits >= 0);
+
+    pronoun_hits
+}
+
+/// Score project-related signals for `escaped` against `text`: build/deploy verbs and versioned references.
 fn score_entity_project(escaped: &str, text: &str) -> i32 {
     let mut score = 0i32;
 
@@ -328,6 +363,10 @@ fn score_entity_project(escaped: &str, text: &str) -> i32 {
     score
 }
 
+/// Compute person and project signal scores for `name` against `text` and `lines`.
+///
+/// Returns an [`EntityScores`] combining the outputs of `score_entity_person`
+/// and `score_entity_project`.
 fn score_entity(name: &str, text: &str, lines: &[String]) -> EntityScores {
     assert!(!name.is_empty(), "score_entity: name must not be empty");
     let escaped = regex::escape(name);
@@ -340,6 +379,8 @@ fn score_entity(name: &str, text: &str, lines: &[String]) -> EntityScores {
     }
 }
 
+/// Classify `name` into `"person"`, `"project"`, or `"uncertain"` based on its signal scores
+/// and occurrence frequency.
 fn classify_entity(name: &str, frequency: usize, scores: &EntityScores) -> DetectedEntity {
     let person_score = scores.person_score;
     let project_score = scores.project_score;
@@ -366,7 +407,9 @@ fn classify_entity(name: &str, frequency: usize, scores: &EntityScores) -> Detec
     classify_entity_build(name, frequency, person_ratio, has_two, person_score)
 }
 
-/// Build the `DetectedEntity` once `person_ratio` and `has_two` are known.
+/// Called by [`classify_entity`] to keep that function within the 70-line limit.
+///
+/// Constructs the [`DetectedEntity`] from pre-computed ratio and corroboration flags.
 fn classify_entity_build(
     name: &str,
     frequency: usize,
@@ -571,13 +614,13 @@ mod tests {
         );
     }
 
-    #[test]
-    fn detect_entities_with_project_entities() {
-        // Exercises the project classification branch in detect_entities.
-        // Each project name appears 4+ times with build/deploy verbs and zero
-        // person signals, pushing person_ratio <= 0.3 so classify_entity picks
-        // the "project" branch. Person names get speech verbs and pronouns to
-        // land in the "person" bucket and verify both arms fire in one call.
+    /// Called by `detect_entities_with_project_entities` to keep that function within the 70-line limit.
+    ///
+    /// Create two temp files with content designed to trigger project and person
+    /// classification branches.  Returns `(tempdir, path_one, path_two)`; the
+    /// caller must keep `tempdir` alive for the duration of the test.
+    fn detect_entities_with_project_entities_setup_files()
+    -> (tempfile::TempDir, std::path::PathBuf, std::path::PathBuf) {
         let temp_directory = tempfile::tempdir()
             .expect("failed to create temporary directory for entity detection test");
 
@@ -617,6 +660,19 @@ Clara said the migration is complete. He agreed.\n";
         file_two
             .write_all(content_two.as_bytes())
             .expect("failed to write second temp file for project entity test");
+
+        (temp_directory, file_path_one, file_path_two)
+    }
+
+    #[test]
+    fn detect_entities_with_project_entities() {
+        // Exercises the project classification branch in detect_entities.
+        // Each project name appears 4+ times with build/deploy verbs and zero
+        // person signals, pushing person_ratio <= 0.3 so classify_entity picks
+        // the "project" branch. Person names get speech verbs and pronouns to
+        // land in the "person" bucket and verify both arms fire in one call.
+        let (_temp_directory, file_path_one, file_path_two) =
+            detect_entities_with_project_entities_setup_files();
 
         let paths: Vec<&Path> = vec![file_path_one.as_path(), file_path_two.as_path()];
         let result = detect_entities(&paths, 10);

--- a/src/palace/entity_detect.rs
+++ b/src/palace/entity_detect.rs
@@ -39,7 +39,6 @@ pub struct DetectedEntity {
     pub entity_type: String, // "person", "project", or "uncertain"
     pub confidence: f64,
     pub frequency: usize,
-    pub signals: Vec<String>,
 }
 
 /// Detection results grouped by type.
@@ -215,32 +214,34 @@ fn extract_candidates(text: &str) -> HashMap<String, usize> {
 struct EntityScores {
     person_score: i32,
     project_score: i32,
-    person_signals: Vec<String>,
-    project_signals: Vec<String>,
+    // Count of distinct person-signal categories (verb, dialogue, pronoun, addressed)
+    // used by classify_entity to require corroboration before committing to "person".
+    person_category_count: usize,
 }
 
 /// Score person-related signals: verb patterns, dialogue markers, pronouns, direct address.
-fn score_entity_person(
-    name: &str,
-    escaped: &str,
-    text: &str,
-    lines: &[String],
-) -> (i32, Vec<String>) {
+/// Returns `(score, category_count)` where `category_count` is the number of distinct
+/// signal categories that fired (verb, dialogue, pronoun, addressed — max 4).
+fn score_entity_person(name: &str, escaped: &str, text: &str, lines: &[String]) -> (i32, usize) {
     let mut score = 0i32;
-    let mut signals = Vec::new();
+    let mut category_count: usize = 0;
 
     let person_verbs = [
         "said", "asked", "told", "replied", "laughed", "smiled", "cried", "felt", "thinks?",
         "wants?", "loves?", "hates?", "knows?", "decided", "pushed", "wrote",
     ];
+    let mut verb_hit = false;
     for verb in person_verbs {
         if let Ok(re) = Regex::new(&format!(r"(?i)\b{escaped}\s+{verb}\b")) {
             let count = re.find_iter(text).count();
             if count > 0 {
                 score += i32::try_from(count).unwrap_or(i32::MAX) * 2;
-                signals.push(format!("'{name} {verb}' ({count}x)"));
+                verb_hit = true;
             }
         }
+    }
+    if verb_hit {
+        category_count += 1;
     }
 
     let dialogue_pats = [
@@ -248,14 +249,18 @@ fn score_entity_person(
         format!(r"(?im)^{escaped}:\s"),
         format!(r"(?im)^\[{escaped}\]"),
     ];
+    let mut dialogue_hit = false;
     for pat in &dialogue_pats {
         if let Ok(re) = Regex::new(pat) {
             let count = re.find_iter(text).count();
             if count > 0 {
                 score += i32::try_from(count).unwrap_or(i32::MAX) * 3;
-                signals.push(format!("dialogue marker ({count}x)"));
+                dialogue_hit = true;
             }
         }
+    }
+    if dialogue_hit {
+        category_count += 1;
     }
 
     let name_lower = name.to_lowercase();
@@ -272,7 +277,7 @@ fn score_entity_person(
     }
     if pronoun_hits > 0 {
         score += pronoun_hits * 2;
-        signals.push(format!("pronoun nearby ({pronoun_hits}x)"));
+        category_count += 1;
     }
 
     if let Ok(re) = Regex::new(&format!(
@@ -281,18 +286,16 @@ fn score_entity_person(
         let count = re.find_iter(text).count();
         if count > 0 {
             score += i32::try_from(count).unwrap_or(i32::MAX) * 4;
-            signals.push(format!("addressed directly ({count}x)"));
+            category_count += 1;
         }
     }
 
-    signals.truncate(3);
-    (score, signals)
+    (score, category_count)
 }
 
 /// Score project-related signals: build/deploy verbs, versioned references.
-fn score_entity_project(escaped: &str, text: &str) -> (i32, Vec<String>) {
+fn score_entity_project(escaped: &str, text: &str) -> i32 {
     let mut score = 0i32;
-    let mut signals = Vec::new();
 
     let project_pats = [
         format!(r"(?i)\bbuilding\s+{escaped}\b"),
@@ -311,7 +314,6 @@ fn score_entity_project(escaped: &str, text: &str) -> (i32, Vec<String>) {
             let count = re.find_iter(text).count();
             if count > 0 {
                 score += i32::try_from(count).unwrap_or(i32::MAX) * 2;
-                signals.push(format!("project verb ({count}x)"));
             }
         }
     }
@@ -320,26 +322,21 @@ fn score_entity_project(escaped: &str, text: &str) -> (i32, Vec<String>) {
         let count = re.find_iter(text).count();
         if count > 0 {
             score += i32::try_from(count).unwrap_or(i32::MAX) * 3;
-            signals.push(format!("versioned ({count}x)"));
         }
     }
 
-    signals.truncate(3);
-    (score, signals)
+    score
 }
 
 fn score_entity(name: &str, text: &str, lines: &[String]) -> EntityScores {
     assert!(!name.is_empty(), "score_entity: name must not be empty");
     let escaped = regex::escape(name);
 
-    let (person_score, person_signals) = score_entity_person(name, &escaped, text, lines);
-    let (project_score, project_signals) = score_entity_project(&escaped, text);
-
+    let (person_score, person_category_count) = score_entity_person(name, &escaped, text, lines);
     EntityScores {
         person_score,
-        project_score,
-        person_signals,
-        project_signals,
+        project_score: score_entity_project(&escaped, text),
+        person_category_count,
     }
 }
 
@@ -357,36 +354,22 @@ fn classify_entity(name: &str, frequency: usize, scores: &EntityScores) -> Detec
             entity_type: "uncertain".to_string(),
             confidence,
             frequency,
-            signals: vec![format!("appears {frequency}x, no strong type signals")],
         };
     }
 
     let person_ratio = f64::from(person_score) / f64::from(total);
 
-    // Count distinct signal categories to distinguish corroborated person signals
-    // from pronoun-only matches, which are too weak for a confident classification.
-    let mut signal_cats: HashSet<&str> = HashSet::new();
-    for signal in &scores.person_signals {
-        if signal.contains("dialogue") {
-            signal_cats.insert("dialogue");
-        } else if signal.contains("action") || signal.contains("said") || signal.contains("asked") {
-            signal_cats.insert("action");
-        } else if signal.contains("pronoun") {
-            signal_cats.insert("pronoun");
-        } else if signal.contains("addressed") {
-            signal_cats.insert("addressed");
-        }
-    }
-    let has_two = signal_cats.len() >= 2;
+    // Require at least two distinct signal categories to distinguish corroborated
+    // person signals from pronoun-only matches, which are too weak alone.
+    let has_two = scores.person_category_count >= 2;
 
-    classify_entity_build(name, frequency, scores, person_ratio, has_two, person_score)
+    classify_entity_build(name, frequency, person_ratio, has_two, person_score)
 }
 
 /// Build the `DetectedEntity` once `person_ratio` and `has_two` are known.
 fn classify_entity_build(
     name: &str,
     frequency: usize,
-    scores: &EntityScores,
     person_ratio: f64,
     has_two: bool,
     person_score: i32,
@@ -397,11 +380,6 @@ fn classify_entity_build(
             entity_type: "person".to_string(),
             confidence: (0.5 + person_ratio * 0.5).min(0.99),
             frequency,
-            signals: if scores.person_signals.is_empty() {
-                vec![format!("appears {frequency}x")]
-            } else {
-                scores.person_signals.clone()
-            },
         }
     } else if person_ratio >= 0.7 && (!has_two || person_score < 5) {
         DetectedEntity {
@@ -409,11 +387,6 @@ fn classify_entity_build(
             entity_type: "uncertain".to_string(),
             confidence: 0.4,
             frequency,
-            signals: {
-                let mut signal_list = scores.person_signals.clone();
-                signal_list.push(format!("appears {frequency}x — pronoun-only match"));
-                signal_list
-            },
         }
     } else if person_ratio <= 0.3 {
         DetectedEntity {
@@ -421,23 +394,13 @@ fn classify_entity_build(
             entity_type: "project".to_string(),
             confidence: (0.5 + (1.0 - person_ratio) * 0.5).min(0.99),
             frequency,
-            signals: if scores.project_signals.is_empty() {
-                vec![format!("appears {frequency}x")]
-            } else {
-                scores.project_signals.clone()
-            },
         }
     } else {
-        let mut signals: Vec<String> = scores.person_signals.clone();
-        signals.extend(scores.project_signals.clone());
-        signals.truncate(3);
-        signals.push("mixed signals — needs review".to_string());
         DetectedEntity {
             name: name.to_string(),
             entity_type: "uncertain".to_string(),
             confidence: 0.5,
             frequency,
-            signals,
         }
     }
 }
@@ -528,8 +491,8 @@ mod tests {
             "Person score should be positive when speech verbs are present"
         );
         assert!(
-            !scores.person_signals.is_empty(),
-            "Person signals should be non-empty for speech verb matches"
+            scores.person_category_count > 0,
+            "Person category count should be positive for speech verb matches"
         );
     }
 
@@ -543,24 +506,16 @@ mod tests {
             scores.project_score > 0,
             "Project score should be positive when build verbs are present"
         );
-        assert!(
-            !scores.project_signals.is_empty(),
-            "Project signals should be non-empty for build verb matches"
-        );
     }
 
     #[test]
     fn classify_entity_as_person() {
         // High person score with multiple signal categories triggers person classification.
+        // person_category_count >= 2 satisfies the has_two corroboration requirement.
         let scores = EntityScores {
             person_score: 12,
             project_score: 0,
-            person_signals: vec![
-                "'Alice said' (3x)".to_string(),
-                "dialogue marker (2x)".to_string(),
-                "pronoun nearby (1x)".to_string(),
-            ],
-            project_signals: vec![],
+            person_category_count: 3,
         };
         let entity = classify_entity("Alice", 10, &scores);
         assert_eq!(
@@ -579,8 +534,7 @@ mod tests {
         let scores = EntityScores {
             person_score: 0,
             project_score: 10,
-            person_signals: vec![],
-            project_signals: vec!["project verb (5x)".to_string()],
+            person_category_count: 0,
         };
         let entity = classify_entity("Mempalace", 8, &scores);
         assert_eq!(

--- a/src/palace/entity_detect.rs
+++ b/src/palace/entity_detect.rs
@@ -18,6 +18,7 @@ static SINGLE_RE: LazyLock<Regex> = LazyLock::new(|| {
     )
 });
 
+// Regex pattern is a compile-time literal and cannot fail to compile at runtime.
 #[allow(clippy::expect_used)]
 // Matches two or more consecutive capitalized words (multi-word entity names).
 static MULTI_RE: LazyLock<Regex> = LazyLock::new(|| {
@@ -26,6 +27,7 @@ static MULTI_RE: LazyLock<Regex> = LazyLock::new(|| {
     )
 });
 
+// Regex pattern is a compile-time literal and cannot fail to compile at runtime.
 #[allow(clippy::expect_used)]
 // Matches gendered and plural pronouns to score person-like proximity.
 static PRONOUN_RE: LazyLock<Regex> = LazyLock::new(|| {

--- a/src/palace/entity_detect.rs
+++ b/src/palace/entity_detect.rs
@@ -326,9 +326,14 @@ fn score_entity_person_pronoun_score(name: &str, lines: &[String]) -> i32 {
     assert!(!name.is_empty(), "name must not be empty");
 
     let name_lower = name.to_lowercase();
+    // Build a word-boundary regex so "al" does not match inside "palantir".
+    // Compile once outside the loop; fall back to no matches if the name yields
+    // an invalid pattern (cannot happen with regex::escape, but handle gracefully).
+    let escaped = regex::escape(&name_lower);
+    let name_re = Regex::new(&format!(r"(?i)\b{escaped}\b")).ok();
     let mut pronoun_hits = 0i32;
     for (i, line) in lines.iter().enumerate() {
-        if line.to_lowercase().contains(&name_lower) {
+        if name_re.as_ref().is_some_and(|re| re.is_match(line)) {
             let start = i.saturating_sub(2);
             let end = (i + 3).min(lines.len());
             let window: String = lines[start..end].join(" ");

--- a/src/palace/entity_detect.rs
+++ b/src/palace/entity_detect.rs
@@ -204,10 +204,10 @@ fn extract_candidates(text: &str) -> HashMap<String, usize> {
     // Require at least 3 occurrences before treating a name as an entity.
     // Once or twice is likely a passing reference; three times suggests the
     // name is a recurring actor or concept worth storing.
-    counts.retain(|_, v| *v >= 3);
+    counts.retain(|_, freq| *freq >= 3);
 
     // Postcondition: all surviving candidates have frequency >= 3.
-    debug_assert!(counts.values().all(|&v| v >= 3));
+    debug_assert!(counts.values().all(|&freq| freq >= 3));
 
     counts
 }
@@ -344,9 +344,9 @@ fn score_entity(name: &str, text: &str, lines: &[String]) -> EntityScores {
 }
 
 fn classify_entity(name: &str, frequency: usize, scores: &EntityScores) -> DetectedEntity {
-    let ps = scores.person_score;
-    let prs = scores.project_score;
-    let total = ps + prs;
+    let person_score = scores.person_score;
+    let project_score = scores.project_score;
+    let total = person_score + project_score;
 
     if total == 0 {
         // frequency is a name occurrence count, always small enough for exact f64 representation
@@ -361,25 +361,25 @@ fn classify_entity(name: &str, frequency: usize, scores: &EntityScores) -> Detec
         };
     }
 
-    let person_ratio = f64::from(ps) / f64::from(total);
+    let person_ratio = f64::from(person_score) / f64::from(total);
 
     // Count distinct signal categories to distinguish corroborated person signals
     // from pronoun-only matches, which are too weak for a confident classification.
     let mut signal_cats: HashSet<&str> = HashSet::new();
-    for s in &scores.person_signals {
-        if s.contains("dialogue") {
+    for signal in &scores.person_signals {
+        if signal.contains("dialogue") {
             signal_cats.insert("dialogue");
-        } else if s.contains("action") || s.contains("said") || s.contains("asked") {
+        } else if signal.contains("action") || signal.contains("said") || signal.contains("asked") {
             signal_cats.insert("action");
-        } else if s.contains("pronoun") {
+        } else if signal.contains("pronoun") {
             signal_cats.insert("pronoun");
-        } else if s.contains("addressed") {
+        } else if signal.contains("addressed") {
             signal_cats.insert("addressed");
         }
     }
     let has_two = signal_cats.len() >= 2;
 
-    classify_entity_build(name, frequency, scores, person_ratio, has_two, ps)
+    classify_entity_build(name, frequency, scores, person_ratio, has_two, person_score)
 }
 
 /// Build the `DetectedEntity` once `person_ratio` and `has_two` are known.
@@ -389,9 +389,9 @@ fn classify_entity_build(
     scores: &EntityScores,
     person_ratio: f64,
     has_two: bool,
-    ps: i32,
+    person_score: i32,
 ) -> DetectedEntity {
-    if person_ratio >= 0.7 && has_two && ps >= 5 {
+    if person_ratio >= 0.7 && has_two && person_score >= 5 {
         DetectedEntity {
             name: name.to_string(),
             entity_type: "person".to_string(),
@@ -403,16 +403,16 @@ fn classify_entity_build(
                 scores.person_signals.clone()
             },
         }
-    } else if person_ratio >= 0.7 && (!has_two || ps < 5) {
+    } else if person_ratio >= 0.7 && (!has_two || person_score < 5) {
         DetectedEntity {
             name: name.to_string(),
             entity_type: "uncertain".to_string(),
             confidence: 0.4,
             frequency,
             signals: {
-                let mut s = scores.person_signals.clone();
-                s.push(format!("appears {frequency}x — pronoun-only match"));
-                s
+                let mut signal_list = scores.person_signals.clone();
+                signal_list.push(format!("appears {frequency}x — pronoun-only match"));
+                signal_list
             },
         }
     } else if person_ratio <= 0.3 {

--- a/src/palace/graph.rs
+++ b/src/palace/graph.rs
@@ -52,11 +52,11 @@ pub struct TraversalResult {
 #[derive(Debug, Clone, Serialize)]
 pub struct GraphStats {
     /// Total distinct rooms (excluding "general").
-    pub total_rooms: usize,
+    pub rooms_total: usize,
     /// Rooms that span two or more wings.
     pub tunnel_rooms: usize,
     /// Total tunnel edges (wing-pair connections).
-    pub total_edges: usize,
+    pub edges_total: usize,
     /// Room count per wing.
     pub rooms_per_wing: HashMap<String, usize>,
     /// Top rooms by number of wings spanned.
@@ -137,9 +137,9 @@ const GRAPH_RESULT_CAP: usize = 50;
 pub async fn traverse(
     connection: &Connection,
     start_room: &str,
-    max_hops: usize,
+    hops_max: usize,
 ) -> Result<(Vec<TraversalResult>, bool)> {
-    assert!(max_hops > 0, "max_hops must be positive");
+    assert!(hops_max > 0, "hops_max must be positive");
     assert!(!start_room.is_empty(), "start_room must not be empty");
 
     let (nodes, _) = build_graph(connection).await?;
@@ -165,17 +165,17 @@ pub async fn traverse(
 
     // Upper bound: each room enters `visited` before being pushed to `frontier`,
     // so the frontier empties after at most nodes.len() iterations.
-    while let Some((current_room, depth)) = frontier.pop_front() {
+    while let Some((room_current, depth)) = frontier.pop_front() {
         assert!(
             visited.len() <= nodes.len(),
             "visited set cannot exceed node count — frontier invariant is broken"
         );
-        if depth >= max_hops {
+        if depth >= hops_max {
             continue;
         }
 
-        let current_wings: HashSet<String> = nodes
-            .get(&current_room)
+        let wings_current: HashSet<String> = nodes
+            .get(&room_current)
             .map(|n| n.wings.iter().cloned().collect())
             .unwrap_or_default();
 
@@ -184,7 +184,7 @@ pub async fn traverse(
                 continue;
             }
             let node_wings: HashSet<String> = node.wings.iter().cloned().collect();
-            let shared: Vec<String> = current_wings.intersection(&node_wings).cloned().collect();
+            let shared: Vec<String> = wings_current.intersection(&node_wings).cloned().collect();
             if !shared.is_empty() {
                 visited.insert(room.clone());
                 let mut sorted_shared = shared;
@@ -196,7 +196,7 @@ pub async fn traverse(
                     hop: depth + 1,
                     connected_via: Some(sorted_shared),
                 });
-                if depth + 1 < max_hops {
+                if depth + 1 < hops_max {
                     frontier.push_back((room.clone(), depth + 1));
                 }
             }
@@ -279,9 +279,9 @@ pub async fn graph_stats(connection: &Connection) -> Result<GraphStats> {
     top_tunnels.truncate(10);
 
     Ok(GraphStats {
-        total_rooms: nodes.len(),
+        rooms_total: nodes.len(),
         tunnel_rooms,
-        total_edges: edges.len(),
+        edges_total: edges.len(),
         rooms_per_wing: wing_counts,
         top_tunnels,
     })

--- a/src/palace/graph.rs
+++ b/src/palace/graph.rs
@@ -173,34 +173,15 @@ pub async fn traverse(
         if depth >= hops_max {
             continue;
         }
-
-        let wings_current: HashSet<String> = nodes
-            .get(&room_current)
-            .map(|n| n.wings.iter().cloned().collect())
-            .unwrap_or_default();
-
-        for (room, node) in &nodes {
-            if visited.contains(room) {
-                continue;
-            }
-            let node_wings: HashSet<String> = node.wings.iter().cloned().collect();
-            let shared: Vec<String> = wings_current.intersection(&node_wings).cloned().collect();
-            if !shared.is_empty() {
-                visited.insert(room.clone());
-                let mut sorted_shared = shared;
-                sorted_shared.sort();
-                results.push(TraversalResult {
-                    room: room.clone(),
-                    wings: node.wings.clone(),
-                    count: node.count,
-                    hop: depth + 1,
-                    connected_via: Some(sorted_shared),
-                });
-                if depth + 1 < hops_max {
-                    frontier.push_back((room.clone(), depth + 1));
-                }
-            }
-        }
+        traverse_expand_frontier(
+            &room_current,
+            depth,
+            hops_max,
+            &nodes,
+            &mut visited,
+            &mut frontier,
+            &mut results,
+        );
     }
 
     // Sort by hop first so callers see the closest rooms first; break ties by
@@ -213,6 +194,52 @@ pub async fn traverse(
     debug_assert!(results.len() <= GRAPH_RESULT_CAP);
 
     Ok((results, truncated))
+}
+
+/// Called by `traverse` to keep that function within the 70-line limit.
+///
+/// For one BFS frontier node at `room_current`/`depth`, find all unvisited rooms
+/// that share at least one wing with it, record them in `results`, mark them
+/// `visited`, and push them onto `frontier` if they are below `hops_max`.
+fn traverse_expand_frontier(
+    room_current: &str,
+    depth: usize,
+    hops_max: usize,
+    nodes: &HashMap<String, RoomNode>,
+    visited: &mut HashSet<String>,
+    frontier: &mut VecDeque<(String, usize)>,
+    results: &mut Vec<TraversalResult>,
+) {
+    assert!(!room_current.is_empty(), "room_current must not be empty");
+    assert!(depth < hops_max, "depth must be below hops_max on entry");
+
+    let wings_current: HashSet<String> = nodes
+        .get(room_current)
+        .map(|n| n.wings.iter().cloned().collect())
+        .unwrap_or_default();
+
+    for (room, node) in nodes {
+        if visited.contains(room) {
+            continue;
+        }
+        let node_wings: HashSet<String> = node.wings.iter().cloned().collect();
+        let shared: Vec<String> = wings_current.intersection(&node_wings).cloned().collect();
+        if !shared.is_empty() {
+            visited.insert(room.clone());
+            let mut sorted_shared = shared;
+            sorted_shared.sort();
+            results.push(TraversalResult {
+                room: room.clone(),
+                wings: node.wings.clone(),
+                count: node.count,
+                hop: depth + 1,
+                connected_via: Some(sorted_shared),
+            });
+            if depth + 1 < hops_max {
+                frontier.push_back((room.clone(), depth + 1));
+            }
+        }
+    }
 }
 
 /// Find rooms that connect two wings (tunnels).

--- a/src/palace/graph.rs
+++ b/src/palace/graph.rs
@@ -362,22 +362,22 @@ fn canonical_tunnel_id(
     assert!(!target_wing.is_empty(), "target_wing must not be empty");
     assert!(!target_room.is_empty(), "target_room must not be empty");
 
-    let src = format!("{source_wing}/{source_room}");
-    let tgt = format!("{target_wing}/{target_room}");
-    let (a, b) = if src <= tgt {
-        (src.as_str(), tgt.as_str())
+    let source_path = format!("{source_wing}/{source_room}");
+    let target_path = format!("{target_wing}/{target_room}");
+    let (first_endpoint, second_endpoint) = if source_path <= target_path {
+        (source_path.as_str(), target_path.as_str())
     } else {
-        (tgt.as_str(), src.as_str())
+        (target_path.as_str(), source_path.as_str())
     };
     // ↔ (U+2194) separates the two endpoints. A bare `/` would be ambiguous
     // because wing and room strings can themselves contain slashes in principle;
     // a non-ASCII multi-byte separator makes accidental collisions impossible.
-    let input = format!("{a}\u{2194}{b}");
+    let input = format!("{first_endpoint}\u{2194}{second_endpoint}");
     let hash = sha2::Sha256::digest(input.as_bytes());
-    let hex: String = hash.iter().fold(String::new(), |mut s, byte| {
+    let hex: String = hash.iter().fold(String::new(), |mut hex_string, byte| {
         use std::fmt::Write as _;
-        let _ = write!(s, "{byte:02x}");
-        s
+        let _ = write!(hex_string, "{byte:02x}");
+        hex_string
     });
     // Postcondition: SHA256 hex is always 64 chars; we take the first 16.
     assert_eq!(hex.len(), 64, "SHA256 hex output must be 64 characters");

--- a/src/palace/graph.rs
+++ b/src/palace/graph.rs
@@ -78,7 +78,7 @@ pub async fn build_graph(
     )
     .await?;
 
-    // Aggregate room data across wings
+    // Aggregate room data across wings.
     let mut room_data: HashMap<String, (HashSet<String>, usize)> = HashMap::new();
     for row in &rows {
         let room: String = row.get(0)?;
@@ -89,7 +89,7 @@ pub async fn build_graph(
         entry.1 += usize::try_from(count).unwrap_or(0);
     }
 
-    // Build nodes
+    // Build nodes.
     let mut nodes = HashMap::new();
     for (room, (wings, count)) in &room_data {
         let mut wing_list: Vec<String> = wings.iter().cloned().collect();
@@ -104,7 +104,7 @@ pub async fn build_graph(
         );
     }
 
-    // Build edges from rooms spanning multiple wings
+    // Build edges from rooms spanning multiple wings.
     let mut edges = Vec::new();
     for (room, (wings, count)) in &room_data {
         let mut wing_list: Vec<&String> = wings.iter().collect();
@@ -664,7 +664,7 @@ mod tests {
     use super::*;
 
     async fn seed_graph(connection: &Connection) {
-        // Create drawers across wings and rooms to build a graph
+        // Create drawers across wings and rooms to build a graph.
         for (id, wing, room) in [
             ("g1", "proj_a", "backend"),
             ("g2", "proj_a", "frontend"),
@@ -703,12 +703,12 @@ mod tests {
             .await
             .expect("traverse");
         assert!(!truncated);
-        // frontend (hop 0) → backend (hop 1, shared proj_a) → database (hop 2, shared proj_b)
+        // frontend (hop 0) → backend (hop 1, shared proj_a) → database (hop 2, shared proj_b).
         assert!(!results.is_empty());
         assert_eq!(results[0].room, "frontend");
         assert_eq!(results[0].hop, 0);
 
-        // Verify hop 1: backend reached via shared proj_a wing
+        // Verify hop 1: backend reached via shared proj_a wing.
         let hop1 = results
             .iter()
             .find(|r| r.room == "backend" && r.hop == 1)
@@ -717,7 +717,7 @@ mod tests {
         assert!(hop1.wings.contains(&"proj_b".to_string()));
         assert_eq!(hop1.connected_via, Some(vec!["proj_a".to_string()]));
 
-        // Verify hop 2: database reached via shared proj_b wing
+        // Verify hop 2: database reached via shared proj_b wing.
         let hop2 = results
             .iter()
             .find(|r| r.room == "database" && r.hop == 2)

--- a/src/palace/layers.rs
+++ b/src/palace/layers.rs
@@ -10,11 +10,11 @@ use crate::error::Result;
 
 // L1 is injected into AI context windows. 15 drawers at ~200 chars each is
 // ~3 000 chars — enough for a meaningful summary without crowding the prompt.
-const MAX_DRAWERS: usize = 15;
+const DRAWERS_MAX: usize = 15;
 // Hard character cap so a wing with many long drawers cannot overflow the
 // context budget. 3 200 chars is roughly 800 tokens at the 4-chars/token
 // rule of thumb, leaving headroom for L0 and the user's own message.
-const MAX_CHARS: usize = 3200;
+const CHARS_MAX: usize = 3200;
 
 /// Layer 0: Identity text from `$XDG_DATA_HOME/mempalace/identity.txt`.
 pub fn layer0() -> String {
@@ -60,7 +60,7 @@ pub async fn layer1(connection: &Connection, wing: Option<&str>) -> Result<Strin
     // Use insertion order as a proxy for recency. A proper recency sort would
     // require a timestamp column; insertion order is good enough until that
     // column exists.
-    let top_drawers = &rows[..rows.len().min(MAX_DRAWERS)];
+    let top_drawers = &rows[..rows.len().min(DRAWERS_MAX)];
     let by_room = layer1_build_room_map(top_drawers);
 
     let mut lines = vec!["## L1 — ESSENTIAL STORY".to_string()];
@@ -89,7 +89,7 @@ pub async fn layer1(connection: &Connection, wing: Option<&str>) -> Result<Strin
                 let _ = write!(entry, "  ({source})");
             }
 
-            if total_len + entry.len() > MAX_CHARS {
+            if total_len + entry.len() > CHARS_MAX {
                 lines.push("  ... (more in L3 search)".to_string());
                 return Ok(lines.join("\n"));
             }

--- a/src/palace/layers.rs
+++ b/src/palace/layers.rs
@@ -42,10 +42,10 @@ pub fn layer0() -> String {
 
 /// Layer 1: Essential story — top drawers grouped by room.
 pub async fn layer1(connection: &Connection, wing: Option<&str>) -> Result<String> {
-    let sql = if let Some(w) = wing {
+    let sql = if let Some(wing_name) = wing {
         format!(
             "SELECT content, wing, room, source_file FROM drawers WHERE wing = '{}' LIMIT 1000",
-            w.replace('\'', "''")
+            wing_name.replace('\'', "''")
         )
     } else {
         "SELECT content, wing, room, source_file FROM drawers LIMIT 1000".to_string()
@@ -60,8 +60,8 @@ pub async fn layer1(connection: &Connection, wing: Option<&str>) -> Result<Strin
     // Use insertion order as a proxy for recency. A proper recency sort would
     // require a timestamp column; insertion order is good enough until that
     // column exists.
-    let top = &rows[..rows.len().min(MAX_DRAWERS)];
-    let by_room = layer1_build_room_map(top);
+    let top_drawers = &rows[..rows.len().min(MAX_DRAWERS)];
+    let by_room = layer1_build_room_map(top_drawers);
 
     let mut lines = vec!["## L1 — ESSENTIAL STORY".to_string()];
     let mut total_len = 0usize;
@@ -109,17 +109,17 @@ fn layer1_build_room_map(rows: &[turso::Row]) -> HashMap<String, Vec<(String, St
         let content = row
             .get_value(0)
             .ok()
-            .and_then(|v| v.as_text().cloned())
+            .and_then(|cell| cell.as_text().cloned())
             .unwrap_or_default();
         let room = row
             .get_value(2)
             .ok()
-            .and_then(|v| v.as_text().cloned())
+            .and_then(|cell| cell.as_text().cloned())
             .unwrap_or_default();
         let source = row
             .get_value(3)
             .ok()
-            .and_then(|v| v.as_text().cloned())
+            .and_then(|cell| cell.as_text().cloned())
             .unwrap_or_default();
         let source_name = Path::new(&source)
             .file_name()

--- a/src/palace/miner.rs
+++ b/src/palace/miner.rs
@@ -247,6 +247,20 @@ async fn mine_write_chunks(
     source_mtime: Option<f64>,
     opts: &MineParams,
 ) -> Result<()> {
+    // Preconditions: callers must supply at least one chunk and a non-empty destination.
+    assert!(
+        !chunks.is_empty(),
+        "mine_write_chunks: chunks must not be empty"
+    );
+    assert!(
+        !wing.is_empty(),
+        "mine_write_chunks: wing must not be empty"
+    );
+    assert!(
+        !room.is_empty(),
+        "mine_write_chunks: room must not be empty"
+    );
+
     for chunk in chunks {
         let id = format!(
             "drawer_{wing}_{room}_{}",

--- a/src/palace/miner.rs
+++ b/src/palace/miner.rs
@@ -95,7 +95,7 @@ fn walk_dir_gitignore(project_dir: &Path) -> Vec<PathBuf> {
         }
         let path = entry.path();
 
-        // Check all path components against SKIP_DIRS
+        // Check all path components against SKIP_DIRS.
         let skip = path.components().any(|component| {
             let component_name = component.as_os_str().to_string_lossy();
             is_skip_dir(component_name.as_ref())

--- a/src/palace/miner.rs
+++ b/src/palace/miner.rs
@@ -96,9 +96,9 @@ fn walk_dir_gitignore(project_dir: &Path) -> Vec<PathBuf> {
         let path = entry.path();
 
         // Check all path components against SKIP_DIRS
-        let skip = path.components().any(|c| {
-            let s = c.as_os_str().to_string_lossy();
-            is_skip_dir(s.as_ref())
+        let skip = path.components().any(|component| {
+            let component_name = component.as_os_str().to_string_lossy();
+            is_skip_dir(component_name.as_ref())
         });
         if skip {
             continue;
@@ -190,7 +190,7 @@ fn mine_print_header(
         "  Rooms:   {}",
         rooms
             .iter()
-            .map(|r| r.name.as_str())
+            .map(|room| room.name.as_str())
             .collect::<Vec<_>>()
             .join(", ")
     );
@@ -325,9 +325,13 @@ async fn mine_process_files(
             // Capture mtime now so all chunks from the same file share the same timestamp.
             let source_mtime: Option<f64> = std::fs::metadata(filepath)
                 .ok()
-                .and_then(|m| m.modified().ok())
-                .and_then(|t| t.duration_since(std::time::SystemTime::UNIX_EPOCH).ok())
-                .map(|d| d.as_secs_f64());
+                .and_then(|metadata| metadata.modified().ok())
+                .and_then(|system_time| {
+                    system_time
+                        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+                        .ok()
+                })
+                .map(|duration| duration.as_secs_f64());
             mine_write_chunks(
                 connection,
                 &chunks,

--- a/src/palace/miner.rs
+++ b/src/palace/miner.rs
@@ -24,7 +24,7 @@ pub struct MineParams {
 }
 
 /// Files larger than this are skipped — prevents OOM on huge files.
-const MAX_FILE_SIZE: u64 = 10 * 1024 * 1024; // 10 MB
+const FILE_SIZE_MAX: u64 = 10 * 1024 * 1024; // 10 MB
 
 use super::WALK_DEPTH_LIMIT;
 
@@ -119,7 +119,7 @@ fn walk_dir_gitignore(project_dir: &Path) -> Vec<PathBuf> {
             .unwrap_or("")
             .to_lowercase();
         if READABLE_EXTENSIONS.contains(&extension.as_str()) {
-            if entry.metadata().is_ok_and(|m| m.len() > MAX_FILE_SIZE) {
+            if entry.metadata().is_ok_and(|m| m.len() > FILE_SIZE_MAX) {
                 continue;
             }
             files.push(path.to_path_buf());
@@ -162,7 +162,7 @@ fn walk_dir(directory: &Path, files: &mut Vec<PathBuf>) {
                 if READABLE_EXTENSIONS.contains(&extension_lower.as_str())
                     && !is_skip_file(name.as_str())
                 {
-                    if std::fs::metadata(&path).is_ok_and(|m| m.len() > MAX_FILE_SIZE) {
+                    if std::fs::metadata(&path).is_ok_and(|m| m.len() > FILE_SIZE_MAX) {
                         continue;
                     }
                     files.push(path);
@@ -203,7 +203,7 @@ fn mine_print_summary(
     file_count: usize,
     files_skipped: usize,
     files_unreadable_or_too_short: usize,
-    total_drawers: usize,
+    drawers_total: usize,
     room_counts: &HashMap<String, usize>,
 ) {
     println!("\n=======================================================");
@@ -221,7 +221,7 @@ fn mine_print_summary(
         println!("  Files skipped (empty/unreadable/too short): {files_unreadable_or_too_short}");
     }
     println!(
-        "  Drawers {}: {total_drawers}",
+        "  Drawers {}: {drawers_total}",
         if dry_run { "would be filed" } else { "filed" }
     );
     println!("\n  By room:");
@@ -288,7 +288,7 @@ fn mine_read_file(filepath: &Path) -> Option<String> {
     Some(content)
 }
 
-/// Process all files in the mine loop. Returns `(total_drawers, files_skipped, files_unreadable_or_too_short, room_counts)`.
+/// Process all files in the mine loop. Returns `(drawers_total, files_skipped, files_unreadable_or_too_short, room_counts)`.
 async fn mine_process_files(
     connection: &Connection,
     files: &[PathBuf],
@@ -297,7 +297,7 @@ async fn mine_process_files(
     project_dir: &Path,
     opts: &MineParams,
 ) -> Result<(usize, usize, usize, HashMap<String, usize>)> {
-    let mut total_drawers: usize = 0;
+    let mut drawers_total: usize = 0;
     let mut files_skipped: usize = 0;
     let mut files_unreadable_or_too_short: usize = 0;
     let mut room_counts: HashMap<String, usize> = HashMap::new();
@@ -344,7 +344,7 @@ async fn mine_process_files(
             .await?;
         }
 
-        total_drawers += drawers_added;
+        drawers_total += drawers_added;
         *room_counts.entry(room.clone()).or_insert(0) += 1;
         println!(
             "  [{:4}/{}] {:50} +{drawers_added}",
@@ -355,7 +355,7 @@ async fn mine_process_files(
     }
 
     Ok((
-        total_drawers,
+        drawers_total,
         files_skipped,
         files_unreadable_or_too_short,
         room_counts,
@@ -471,7 +471,7 @@ pub async fn mine(connection: &Connection, project_dir: &Path, opts: &MineParams
 
     mine_print_header(wing, &rooms, files.len(), opts.dry_run);
 
-    let (total_drawers, files_skipped, files_unreadable_or_too_short, room_counts) =
+    let (drawers_total, files_skipped, files_unreadable_or_too_short, room_counts) =
         mine_process_files(connection, &files, wing, &rooms, &project_dir, opts).await?;
 
     mine_print_summary(
@@ -479,7 +479,7 @@ pub async fn mine(connection: &Connection, project_dir: &Path, opts: &MineParams
         files.len(),
         files_skipped,
         files_unreadable_or_too_short,
-        total_drawers,
+        drawers_total,
         &room_counts,
     );
     Ok(())

--- a/src/palace/mod.rs
+++ b/src/palace/mod.rs
@@ -7,7 +7,7 @@ pub const WALK_DEPTH_LIMIT: usize = 64;
 pub mod chunker;
 pub mod convo_miner;
 pub mod drawer;
-#[allow(dead_code)]
+#[cfg(test)]
 pub mod entity_detect;
 pub mod graph;
 pub mod layers;

--- a/src/palace/query_sanitizer.rs
+++ b/src/palace/query_sanitizer.rs
@@ -64,7 +64,7 @@ pub fn sanitize_query(raw: &str) -> SanitizedQuery {
     let segments: Vec<&str> = raw
         .lines()
         .map(str::trim)
-        .filter(|s| !s.is_empty())
+        .filter(|segment| !segment.is_empty())
         .collect();
 
     // Step 2/3: treat the trailing segment as the primary intent carrier.
@@ -97,10 +97,10 @@ pub fn sanitize_query(raw: &str) -> SanitizedQuery {
     sanitized(candidate, original_length, "tail_truncation")
 }
 
-fn passthrough(s: String, len: usize) -> SanitizedQuery {
+fn passthrough(clean_query: String, len: usize) -> SanitizedQuery {
     SanitizedQuery {
         clean_length: len,
-        clean_query: s,
+        clean_query,
         was_sanitized: false,
         original_length: len,
         method: "passthrough",
@@ -118,17 +118,17 @@ fn sanitized(clean_query: String, original_length: usize, method: &'static str) 
     }
 }
 
-/// Return the last [`MAX_QUERY_LEN`] chars of `s`.
-fn tail_guard(s: &str) -> String {
-    assert!(!s.is_empty(), "tail_guard: input must not be empty");
+/// Return the last [`MAX_QUERY_LEN`] chars of `text`.
+fn tail_guard(text: &str) -> String {
+    assert!(!text.is_empty(), "tail_guard: input must not be empty");
 
-    let total = s.chars().count();
+    let total = text.chars().count();
     if total <= MAX_QUERY_LEN {
-        return s.to_owned();
+        return text.to_owned();
     }
     let skip = total - MAX_QUERY_LEN;
-    let byte_start = s.char_indices().nth(skip).map_or(0, |(i, _)| i);
-    let result = s[byte_start..].to_owned();
+    let byte_start = text.char_indices().nth(skip).map_or(0, |(i, _)| i);
+    let result = text[byte_start..].to_owned();
 
     // Postcondition: output is bounded by MAX_QUERY_LEN.
     debug_assert!(result.chars().count() <= MAX_QUERY_LEN);
@@ -142,17 +142,17 @@ mod tests {
 
     #[test]
     fn passthrough_short() {
-        let r = sanitize_query("what is the capital of France?");
-        assert!(!r.was_sanitized);
-        assert_eq!(r.method, "passthrough");
-        assert_eq!(r.clean_query, "what is the capital of France?");
+        let result = sanitize_query("what is the capital of France?");
+        assert!(!result.was_sanitized);
+        assert_eq!(result.method, "passthrough");
+        assert_eq!(result.clean_query, "what is the capital of France?");
     }
 
     #[test]
     fn passthrough_empty() {
-        let r = sanitize_query("   ");
-        assert!(!r.was_sanitized);
-        assert_eq!(r.clean_query, "");
+        let result = sanitize_query("   ");
+        assert!(!result.was_sanitized);
+        assert_eq!(result.clean_query, "");
     }
 
     #[test]
@@ -161,11 +161,11 @@ mod tests {
             "{}\nwhat did we decide about the database schema?",
             "x".repeat(300)
         );
-        let r = sanitize_query(&prompt);
-        assert!(r.was_sanitized);
-        assert_eq!(r.method, "question_extraction");
+        let result = sanitize_query(&prompt);
+        assert!(result.was_sanitized);
+        assert_eq!(result.method, "question_extraction");
         assert_eq!(
-            r.clean_query,
+            result.clean_query,
             "what did we decide about the database schema?"
         );
     }
@@ -173,46 +173,46 @@ mod tests {
     #[test]
     fn question_extraction_short_question_segment() {
         let prompt = format!("{}\nETA?", "x".repeat(300));
-        let r = sanitize_query(&prompt);
-        assert!(r.was_sanitized);
-        assert_eq!(r.method, "question_extraction");
-        assert_eq!(r.clean_query, "ETA?");
+        let result = sanitize_query(&prompt);
+        assert!(result.was_sanitized);
+        assert_eq!(result.method, "question_extraction");
+        assert_eq!(result.clean_query, "ETA?");
     }
 
     #[test]
     fn tail_sentence() {
         let prompt = format!("{}\nchromadb locking bug", "x".repeat(300));
-        let r = sanitize_query(&prompt);
-        assert!(r.was_sanitized);
-        assert_eq!(r.method, "tail_sentence");
-        assert_eq!(r.clean_query, "chromadb locking bug");
+        let result = sanitize_query(&prompt);
+        assert!(result.was_sanitized);
+        assert_eq!(result.method, "tail_sentence");
+        assert_eq!(result.clean_query, "chromadb locking bug");
     }
 
     #[test]
     fn tail_truncation() {
         // All newline-segments are tiny (only 2 chars each), forcing fallback to tail_truncation.
         let prompt = "ab\n".repeat(100); // 300 chars; each segment "ab" is only 2 chars
-        let r = sanitize_query(&prompt);
-        assert!(r.was_sanitized);
-        assert_eq!(r.method, "tail_truncation");
+        let result = sanitize_query(&prompt);
+        assert!(result.was_sanitized);
+        assert_eq!(result.method, "tail_truncation");
     }
 
     #[test]
     fn tail_sentence_long_line() {
         // Single long line with no newlines → tail_sentence via the last (only) segment.
         let prompt = "a".repeat(600);
-        let r = sanitize_query(&prompt);
-        assert!(r.was_sanitized);
-        assert_eq!(r.method, "tail_sentence");
-        assert_eq!(r.clean_length, MAX_QUERY_LEN);
+        let result = sanitize_query(&prompt);
+        assert!(result.was_sanitized);
+        assert_eq!(result.method, "tail_sentence");
+        assert_eq!(result.clean_length, MAX_QUERY_LEN);
     }
 
     #[test]
     fn utf8_boundary_safe() {
         // Force truncation with multi-byte chars to validate UTF-8-safe slicing.
         let prompt = "é".repeat(550);
-        let r = sanitize_query(&prompt);
-        assert_eq!(r.clean_length, MAX_QUERY_LEN);
-        assert!(std::str::from_utf8(r.clean_query.as_bytes()).is_ok());
+        let result = sanitize_query(&prompt);
+        assert_eq!(result.clean_length, MAX_QUERY_LEN);
+        assert!(std::str::from_utf8(result.clean_query.as_bytes()).is_ok());
     }
 }

--- a/src/palace/query_sanitizer.rs
+++ b/src/palace/query_sanitizer.rs
@@ -15,9 +15,9 @@ use std::sync::LazyLock;
 
 use regex::Regex;
 
-const MAX_QUERY_LEN: usize = 250;
+const QUERY_LEN_MAX: usize = 250;
 const SAFE_QUERY_LEN: usize = 200;
-const MIN_QUESTION_SEGMENT_LEN: usize = 3;
+const QUESTION_SEGMENT_LEN_MIN: usize = 3;
 
 #[allow(clippy::expect_used)]
 // Matches a sentence ending with a question mark (including Unicode `？`),
@@ -70,7 +70,7 @@ pub fn sanitize_query(raw: &str) -> SanitizedQuery {
     // Step 2/3: treat the trailing segment as the primary intent carrier.
     if let Some(last_seg) = segments.last().copied() {
         let last_len = last_seg.chars().count();
-        if QUESTION_RE.is_match(last_seg) && last_len >= MIN_QUESTION_SEGMENT_LEN {
+        if QUESTION_RE.is_match(last_seg) && last_len >= QUESTION_SEGMENT_LEN_MIN {
             let candidate = tail_guard(last_seg);
             eprintln!(
                 "mempalace: query sanitized {original_length} → {} chars (method=question_extraction)",
@@ -78,7 +78,7 @@ pub fn sanitize_query(raw: &str) -> SanitizedQuery {
             );
             return sanitized(candidate, original_length, "question_extraction");
         }
-        if last_len >= MIN_QUESTION_SEGMENT_LEN {
+        if last_len >= QUESTION_SEGMENT_LEN_MIN {
             let candidate = tail_guard(last_seg);
             eprintln!(
                 "mempalace: query sanitized {original_length} → {} chars (method=tail_sentence)",
@@ -118,20 +118,20 @@ fn sanitized(clean_query: String, original_length: usize, method: &'static str) 
     }
 }
 
-/// Return the last [`MAX_QUERY_LEN`] chars of `text`.
+/// Return the last [`QUERY_LEN_MAX`] chars of `text`.
 fn tail_guard(text: &str) -> String {
     assert!(!text.is_empty(), "tail_guard: input must not be empty");
 
     let total = text.chars().count();
-    if total <= MAX_QUERY_LEN {
+    if total <= QUERY_LEN_MAX {
         return text.to_owned();
     }
-    let skip = total - MAX_QUERY_LEN;
+    let skip = total - QUERY_LEN_MAX;
     let byte_start = text.char_indices().nth(skip).map_or(0, |(i, _)| i);
     let result = text[byte_start..].to_owned();
 
-    // Postcondition: output is bounded by MAX_QUERY_LEN.
-    debug_assert!(result.chars().count() <= MAX_QUERY_LEN);
+    // Postcondition: output is bounded by QUERY_LEN_MAX.
+    debug_assert!(result.chars().count() <= QUERY_LEN_MAX);
 
     result
 }
@@ -204,7 +204,7 @@ mod tests {
         let result = sanitize_query(&prompt);
         assert!(result.was_sanitized);
         assert_eq!(result.method, "tail_sentence");
-        assert_eq!(result.clean_length, MAX_QUERY_LEN);
+        assert_eq!(result.clean_length, QUERY_LEN_MAX);
     }
 
     #[test]
@@ -212,7 +212,7 @@ mod tests {
         // Force truncation with multi-byte chars to validate UTF-8-safe slicing.
         let prompt = "é".repeat(550);
         let result = sanitize_query(&prompt);
-        assert_eq!(result.clean_length, MAX_QUERY_LEN);
+        assert_eq!(result.clean_length, QUERY_LEN_MAX);
         assert!(std::str::from_utf8(result.clean_query.as_bytes()).is_ok());
     }
 }

--- a/src/palace/room_detect.rs
+++ b/src/palace/room_detect.rs
@@ -173,12 +173,19 @@ pub fn detect_rooms_from_folders(project_dir: &Path) -> Vec<RoomConfig> {
 
     rooms.sort_by(|a, b| a.name.cmp(&b.name));
 
-    if !rooms.iter().any(|r| r.name == "general") {
+    if !rooms
+        .iter()
+        .any(|room_config| room_config.name == "general")
+    {
         rooms.push(general_room());
     }
 
     // Postcondition: result always contains a "general" room.
-    debug_assert!(rooms.iter().any(|r| r.name == "general"));
+    debug_assert!(
+        rooms
+            .iter()
+            .any(|room_config| room_config.name == "general")
+    );
 
     rooms
 }
@@ -214,8 +221,8 @@ pub fn detect_room(
     let path_parts: Vec<&str> = relative.split(['/', '\\']).collect();
     for part in &path_parts[..path_parts.len().saturating_sub(1)] {
         for room in rooms {
-            let rn = room.name.to_lowercase();
-            if rn.contains(part) || part.contains(&rn) {
+            let room_name_lower = room.name.to_lowercase();
+            if room_name_lower.contains(part) || part.contains(&room_name_lower) {
                 return room.name.clone();
             }
         }
@@ -223,8 +230,8 @@ pub fn detect_room(
 
     // Priority 2: filename matches room name
     for room in rooms {
-        let rn = room.name.to_lowercase();
-        if rn.contains(&filename) || filename.contains(&rn) {
+        let room_name_lower = room.name.to_lowercase();
+        if room_name_lower.contains(&filename) || filename.contains(&room_name_lower) {
             return room.name.clone();
         }
     }

--- a/src/palace/room_detect.rs
+++ b/src/palace/room_detect.rs
@@ -125,7 +125,7 @@ pub fn detect_rooms_from_folders(project_dir: &Path) -> Vec<RoomConfig> {
         return vec![general_room()];
     };
 
-    // Top-level directories
+    // Top-level directories.
     for entry in entries.flatten() {
         let path = entry.path();
         if !path.is_dir() {
@@ -144,7 +144,7 @@ pub fn detect_rooms_from_folders(project_dir: &Path) -> Vec<RoomConfig> {
             found.entry(clean).or_insert(name.clone());
         }
 
-        // One level deeper
+        // One level deeper.
         if let Ok(sub_entries) = std::fs::read_dir(&path) {
             for sub_entry in sub_entries.flatten() {
                 if !sub_entry.path().is_dir() {
@@ -217,7 +217,7 @@ pub fn detect_room(
         .to_string_lossy()
         .to_lowercase();
 
-    // Priority 1: folder path contains room name
+    // Priority 1: folder path contains room name.
     let path_parts: Vec<&str> = relative.split(['/', '\\']).collect();
     for part in &path_parts[..path_parts.len().saturating_sub(1)] {
         for room in rooms {
@@ -228,7 +228,7 @@ pub fn detect_room(
         }
     }
 
-    // Priority 2: filename matches room name
+    // Priority 2: filename matches room name.
     for room in rooms {
         let room_name_lower = room.name.to_lowercase();
         if room_name_lower.contains(&filename) || filename.contains(&room_name_lower) {
@@ -236,7 +236,7 @@ pub fn detect_room(
         }
     }
 
-    // Priority 3: keyword scoring
+    // Priority 3: keyword scoring.
     let content_lower = content
         .chars()
         .take(2000)
@@ -330,7 +330,7 @@ mod tests {
             keywords: vec!["testing".to_string()],
         }];
         let project = PathBuf::from("/project");
-        // File at root (no folder match), but filename contains room name
+        // File at root (no folder match), but filename contains room name.
         let filepath = PathBuf::from("/project/testing_utils.rs");
         assert_eq!(detect_room(&filepath, "", &rooms, &project), "testing");
     }
@@ -396,7 +396,7 @@ mod tests {
         assert!(names.contains(&"backend"));
         assert!(names.contains(&"documentation"));
         assert!(names.contains(&"general"));
-        // TempDir auto-cleans up when dropped
+        // TempDir auto-cleans up when dropped.
     }
 
     #[test]

--- a/src/palace/search.rs
+++ b/src/palace/search.rs
@@ -67,7 +67,7 @@ pub async fn search_memories(
         param_offset + 1
     );
 
-    // Build params
+    // Build params.
     let mut params: Vec<turso::Value> = words
         .iter()
         .map(|w| turso::Value::from(w.as_str()))
@@ -205,7 +205,7 @@ mod async_tests {
     use super::*;
 
     async fn seed_drawers(connection: &Connection) {
-        // Insert two drawers with indexed words
+        // Insert two drawers with indexed words.
         crate::palace::drawer::add_drawer(
             connection,
             &crate::palace::drawer::DrawerParams {

--- a/src/palace/search.rs
+++ b/src/palace/search.rs
@@ -75,8 +75,8 @@ pub async fn search_memories(
     if let Some(w) = wing {
         params.push(turso::Value::from(w));
     }
-    if let Some(r) = room {
-        params.push(turso::Value::from(r));
+    if let Some(room_name) = room {
+        params.push(turso::Value::from(room_name));
     }
     // SQLite LIMIT expects a signed integer. Callers are unlikely to request
     // more than i32::MAX results, but we saturate rather than panic.
@@ -100,33 +100,33 @@ fn search_memories_parse_rows(rows: &[turso::Row]) -> Vec<SearchResult> {
         let text = row
             .get_value(1)
             .ok()
-            .and_then(|v| v.as_text().cloned())
+            .and_then(|cell| cell.as_text().cloned())
             .unwrap_or_default();
         let wing = row
             .get_value(2)
             .ok()
-            .and_then(|v| v.as_text().cloned())
+            .and_then(|cell| cell.as_text().cloned())
             .unwrap_or_default();
         let room = row
             .get_value(3)
             .ok()
-            .and_then(|v| v.as_text().cloned())
+            .and_then(|cell| cell.as_text().cloned())
             .unwrap_or_default();
         let source = row
             .get_value(4)
             .ok()
-            .and_then(|v| v.as_text().cloned())
+            .and_then(|cell| cell.as_text().cloned())
             .unwrap_or_default();
         let raw_relevance = row
             .get_value(5)
             .ok()
-            .and_then(|v| v.as_integer().copied())
+            .and_then(|cell| cell.as_integer().copied())
             .unwrap_or(0);
         let relevance = f64::from(i32::try_from(raw_relevance).unwrap_or(i32::MAX));
         let created_at = row
             .get_value(6)
             .ok()
-            .and_then(|v| v.as_text().cloned())
+            .and_then(|cell| cell.as_text().cloned())
             .unwrap_or_default();
 
         let source_name = Path::new(&source)
@@ -154,10 +154,10 @@ fn search_memories_parse_rows(rows: &[turso::Row]) -> Vec<SearchResult> {
 /// and would fan out to enormous result sets, hurting relevance.
 fn tokenize_query(query: &str) -> Vec<String> {
     query
-        .split(|c: char| !c.is_alphanumeric() && c != '_')
-        .filter(|w| w.len() >= 3)
+        .split(|character: char| !character.is_alphanumeric() && character != '_')
+        .filter(|token| token.len() >= 3)
         .map(str::to_lowercase)
-        .filter(|w| !crate::palace::drawer::is_stop_word(w))
+        .filter(|token| !crate::palace::drawer::is_stop_word(token))
         .collect()
 }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -114,7 +114,7 @@ pub async fn ensure_schema(connection: &Connection) -> Result<()> {
     .await?;
     let table_names: Vec<String> = rows
         .iter()
-        .filter_map(|r| r.get::<String>(0).ok())
+        .filter_map(|row| row.get::<String>(0).ok())
         .collect();
     assert!(
         table_names.contains(&"drawers".to_string()),
@@ -173,7 +173,7 @@ mod tests {
 
         let table_names: Vec<String> = rows
             .iter()
-            .filter_map(|r| r.get::<String>(0).ok())
+            .filter_map(|row| row.get::<String>(0).ok())
             .collect();
 
         // All 6 core tables must be present.

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -6,14 +6,14 @@ use turso::Connection;
 /// Create an in-memory turso database with the full schema applied.
 /// Returns (Database, Connection) tuple to keep the Database alive for the test lifetime.
 pub async fn test_db() -> (turso::Database, Connection) {
-    let db = turso::Builder::new_local(":memory:")
+    let database = turso::Builder::new_local(":memory:")
         .experimental_triggers(true)
         .build()
         .await
         .expect("failed to create in-memory db");
-    let connection = db.connect().expect("failed to connect");
+    let connection = database.connect().expect("failed to connect");
     crate::schema::ensure_schema(&connection)
         .await
         .expect("failed to apply schema");
-    (db, connection)
+    (database, connection)
 }

--- a/tests/app_dispatch.rs
+++ b/tests/app_dispatch.rs
@@ -61,7 +61,7 @@ async fn app_run_split_with_no_mega_files_returns_ok() {
             directory: temp_directory.path().to_path_buf(),
             output_dir: None,
             dry_run: false,
-            min_sessions: 2,
+            sessions_min: 2,
             no_gitignore: false,
         },
     };

--- a/tests/compress_pipeline.rs
+++ b/tests/compress_pipeline.rs
@@ -41,7 +41,7 @@ fn dialect_with_entities_replaces_names() {
     let mut entities = HashMap::new();
     entities.insert("Alice".to_string(), "ALC".to_string());
     entities.insert("Bob".to_string(), "BOB".to_string());
-    let dialect = Dialect::new(&entities, vec![]);
+    let dialect = Dialect::new(&entities);
 
     let text = "Alice and Bob discussed the new database migration strategy \
         for the quarterly planning review session yesterday afternoon.";

--- a/tests/kg_workflow.rs
+++ b/tests/kg_workflow.rs
@@ -145,7 +145,7 @@ async fn stats_reflect_operations() {
     assert_eq!(stats_after_add.entities, 2, "should have 2 entities");
     assert_eq!(stats_after_add.triples, 1, "should have 1 triple");
     assert_eq!(
-        stats_after_add.current_facts, 1,
+        stats_after_add.facts_current, 1,
         "1 current fact before invalidation"
     );
 
@@ -162,7 +162,7 @@ async fn stats_reflect_operations() {
         "total triples unchanged after invalidation"
     );
     assert_eq!(
-        stats_after_invalidate.current_facts, 0,
+        stats_after_invalidate.facts_current, 0,
         "no current facts after invalidation"
     );
     assert_eq!(


### PR DESCRIPTION
## Summary

Full pass to bring the codebase into STYLEGUIDE.md compliance, split across six atomic commits:

- **Rename abbreviated variables** — extended `clippy.toml` `disallowed-names` with `s`, `v`, `r`, `d`, `q` and renamed all violations to full-form equivalents across 31 files
- **Fix qualifier order** — renamed ~45 identifiers to put qualifiers last (`DRAWERS_MAX` not `MAX_DRAWERS`, `wing_current` not `current_wing`, etc.)
- **Fix comment punctuation** — standalone comments are now full sentences with capital first letter and terminal `.` across 16 files
- **Fix lint suppression / remove dead code** — every `#[allow(...)]` now has a justification comment; `#[allow(dead_code)]` eliminated by deleting unused code (`Dialect::skip_names`, `emotion_codes`, `entity_detect` gated behind `#[cfg(test)]`) or explaining the genuine exception (`add_entity` is a public library fn used by integration tests)
- **Add loop upper bounds** — every loop now has a bound constant and assertion per TigerStyle
- **Split over-70-line functions** — 17 functions split into helpers prefixed with the parent name; doc comments added to all extracted helpers and any function missing one

822 tests pass. Line coverage: 95.24% (above the 95% floor).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactoring & Code Quality**
  * CLI flag renamed: --min-sessions → --sessions-min.
  * Simplified dialect constructor and many internal helpers refactored for clarity.

* **Bug Fixes & Safety**
  * Added runtime guards to prevent unbounded processing.
  * Improved UTF‑8-safe slicing and other robustness fixes.

* **Behavioral / Data**
  * Removed per-entity human-readable "signals".
  * Renamed some serialized/stat fields (rooms_total, edges_total, facts_current).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->