### PR TITLE
Resync with mempalace-py @ 87102fb

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -174,6 +174,34 @@ continuations. Original files are renamed to `.mega_backup`.
 
 ---
 
+### `mempalace sweep <target>`
+
+Sweeps a single `.jsonl` Claude Code transcript file, or every `.jsonl` in a directory tree,
+inserting one drawer per user/assistant message. Idempotent: re-running the same target is a
+safe no-op — already-present messages are detected by UUID and counted but not re-inserted.
+
+```bash
+mempalace sweep ~/.claude/projects/my-project/session.jsonl
+mempalace sweep ~/.claude/projects/my-project/
+mempalace sweep ~/.claude/projects/ --wing conversations
+```
+
+```text
+Options:
+  --wing <name>  Wing to file drawers under (default: conversations)
+```
+
+Each drawer contains one raw user or assistant message. The message UUID from the JSONL record
+is embedded in the drawer ID (`sweep_{session_id}_{uuid}`), so repeated runs never create
+duplicates.
+
+**Difference from `mine --mode convos`:** `mine --mode convos` normalises Claude Code JSONL into
+exchange pairs (user turn + AI response) and chunks them at 800-character boundaries. `sweep`
+inserts raw individual messages with no chunking or pairing — useful when you want message-level
+granularity or when the exchange-pair format loses context you care about.
+
+---
+
 ### `mempalace search "<query>"`
 
 Keyword search using the inverted index.
@@ -370,11 +398,11 @@ Diary entries live in `wing_{agent_name}/diary`. Use AAAK format for compact ent
 
 Single SQLite file at `$XDG_DATA_HOME/mempalace/palace.db` (default: `~/.local/share/mempalace/palace.db`):
 
-| Table              | Purpose                                                                                        |
-| ------------------ | ---------------------------------------------------------------------------------------------- |
-| `drawers`          | Content chunks: wing, room, content, source_file, chunk_index, added_by, ingest_mode, filed_at |
-| `drawer_words`     | Inverted index: word → drawer_id → count                                                       |
-| `entities`         | Knowledge graph nodes: name, type, properties (JSON)                                           |
-| `triples`          | Knowledge graph edges: subject, predicate, object, valid_from, valid_to, confidence            |
-| `compressed`       | AAAK-compressed drawer versions                                                                |
-| `explicit_tunnels` | Agent-created cross-wing links: source/target wing+room, label, canonical SHA256 tunnel_id     |
+| Table              | Purpose                                                                                                             |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------- |
+| `drawers`          | Content chunks: wing, room, content, source_file, chunk_index, added_by, ingest_mode, filed_at                      |
+| `drawer_words`     | Inverted index: word → drawer_id → count                                                                            |
+| `entities`         | Knowledge graph nodes: name, type, properties (JSON)                                                                |
+| `triples`          | Knowledge graph edges: subject, predicate, object, valid_from, valid_to, confidence, source_drawer_id, adapter_name |
+| `compressed`       | AAAK-compressed drawer versions                                                                                     |
+| `explicit_tunnels` | Agent-created cross-wing links: source/target wing+room, label, canonical SHA256 tunnel_id                          |

--- a/src/app.rs
+++ b/src/app.rs
@@ -429,7 +429,7 @@ mod tests {
 
         // Write a minimal valid Claude JSONL record so the sweep has something to process.
         let jsonl_path = temp_directory.path().join("session.jsonl");
-        let record = r#"{"type":"message","session_id":"s1","uuid":"u1","message":{"role":"user","content":"hello"}}"#;
+        let record = r#"{"type":"user","sessionId":"s1","uuid":"u1","message":{"role":"user","content":"hello"}}"#;
         std::fs::write(&jsonl_path, format!("{record}\n"))
             .expect("must write test JSONL file for sweep");
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -132,6 +132,10 @@ pub async fn run(cli: Cli) -> error::Result<()> {
             )?;
         }
 
+        Command::Sweep { target, wing } => {
+            run_sweep(target, wing).await?;
+        }
+
         Command::Repair => {
             run_repair().await?;
         }
@@ -238,6 +242,13 @@ async fn run_compress(
         None => None,
     };
     cli::compress::run(&connection, wing.as_deref(), dry_run, config_str).await
+}
+
+/// Handle the `sweep` sub-command — expands `~` then delegates to the sweeper.
+async fn run_sweep(target: std::path::PathBuf, wing: String) -> error::Result<()> {
+    let target = expand_tilde(&target);
+    let (_db, connection, _path) = open_palace().await?;
+    cli::sweep::run(&connection, &target, &wing).await
 }
 
 /// Handle the `mine` sub-command — delegates to the correct miner by mode.

--- a/src/app.rs
+++ b/src/app.rs
@@ -412,6 +412,54 @@ mod tests {
         );
     }
 
+    // -- run_sweep via Command dispatch ----------------------------------------
+
+    #[tokio::test]
+    async fn run_command_sweep_with_file_target_returns_ok() {
+        // Exercises both the Command::Sweep dispatch arm and run_sweep end-to-end.
+        // A real palace DB is created by open_palace() inside run_sweep, so we
+        // point MEMPALACE_DIR at a temp directory to avoid polluting the real palace.
+        let temp_directory = tempfile::tempdir()
+            .expect("failed to create temporary directory for Command::Sweep test");
+        let temp_directory_path_string = temp_directory
+            .path()
+            .to_str()
+            .expect("temporary directory path must be valid UTF-8")
+            .to_string();
+
+        // Write a minimal valid Claude JSONL record so the sweep has something to process.
+        let jsonl_path = temp_directory.path().join("session.jsonl");
+        let record = r#"{"type":"message","session_id":"s1","uuid":"u1","message":{"role":"user","content":"hello"}}"#;
+        std::fs::write(&jsonl_path, format!("{record}\n"))
+            .expect("must write test JSONL file for sweep");
+
+        temp_env::async_with_vars(
+            [
+                ("MEMPALACE_DIR", Some(temp_directory_path_string.as_str())),
+                ("MEMPALACE_PALACE_PATH", None),
+            ],
+            async {
+                let cli = Cli {
+                    command: Command::Sweep {
+                        target: jsonl_path,
+                        wing: "conversations".to_string(),
+                    },
+                };
+                let result = run(cli).await;
+                assert!(
+                    result.is_ok(),
+                    "run must return Ok for Command::Sweep with a valid JSONL file"
+                );
+                // Pair assertion: the palace DB must have been created by open_palace.
+                assert!(
+                    temp_directory.path().join("palace.db").exists(),
+                    "palace.db must exist after a successful sweep"
+                );
+            },
+        )
+        .await;
+    }
+
     // -- run_status without a palace ------------------------------------------
 
     #[tokio::test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -6,6 +6,7 @@ pub mod repair;
 pub mod search;
 pub mod split;
 pub mod status;
+pub mod sweep;
 pub mod wakeup;
 
 use std::path::PathBuf;
@@ -133,6 +134,20 @@ pub enum Command {
         /// Disable .gitignore filtering (include all files regardless of gitignore rules)
         #[arg(long)]
         no_gitignore: bool,
+    },
+
+    /// Tandem miner: catch messages the primary miner missed
+    ///
+    /// Sweeps a `.jsonl` transcript file or directory, inserting one drawer
+    /// per user/assistant message not already present.  Idempotent: re-running
+    /// the same target is a safe no-op.
+    Sweep {
+        /// Path to a `.jsonl` transcript file or a directory to scan recursively
+        target: PathBuf,
+
+        /// Wing to file drawers under
+        #[arg(long, default_value = "conversations")]
+        wing: String,
     },
 
     /// Show palace overview and stats

--- a/src/cli/sweep.rs
+++ b/src/cli/sweep.rs
@@ -50,3 +50,59 @@ pub async fn run(connection: &Connection, target: &Path, wing: &str) -> Result<(
 
     Ok(())
 }
+
+#[cfg(test)]
+// Test code — .expect() is acceptable with a descriptive message.
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    /// Write a minimal valid Claude JSONL record to `path` for use in sweep tests.
+    fn write_valid_jsonl(path: &Path) {
+        let record = r#"{"type":"message","session_id":"sess1","uuid":"u001","message":{"role":"user","content":"hi"}}"#;
+        std::fs::write(path, format!("{record}\n")).expect("must write test JSONL file");
+    }
+
+    #[tokio::test]
+    async fn run_file_target_returns_ok() {
+        // Single-file branch: run must accept a regular .jsonl file and return Ok.
+        let dir = tempdir().expect("must create temp dir");
+        let file = dir.path().join("session.jsonl");
+        write_valid_jsonl(&file);
+        let (_database, connection) = crate::test_helpers::test_db().await;
+        let result = run(&connection, &file, "test_wing").await;
+        assert!(result.is_ok(), "run must return Ok for a valid file target");
+    }
+
+    #[tokio::test]
+    async fn run_directory_target_returns_ok() {
+        // Directory branch: run must accept a directory and return Ok.
+        let dir = tempdir().expect("must create temp dir");
+        let file = dir.path().join("session.jsonl");
+        write_valid_jsonl(&file);
+        let (_database, connection) = crate::test_helpers::test_db().await;
+        let result = run(&connection, dir.path(), "test_wing").await;
+        assert!(
+            result.is_ok(),
+            "run must return Ok for a valid directory target"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn run_special_file_returns_error() {
+        // Else branch: /dev/null exists but is neither a regular file nor a directory.
+        // run must return Err rather than silently succeeding or panicking.
+        let target = Path::new("/dev/null");
+        assert!(target.exists(), "/dev/null must exist on Unix");
+        assert!(!target.is_file(), "/dev/null must not be a regular file");
+        assert!(!target.is_dir(), "/dev/null must not be a directory");
+        let (_database, connection) = crate::test_helpers::test_db().await;
+        let result = run(&connection, target, "test_wing").await;
+        assert!(
+            result.is_err(),
+            "run must return Err for a special-file target"
+        );
+    }
+}

--- a/src/cli/sweep.rs
+++ b/src/cli/sweep.rs
@@ -1,0 +1,52 @@
+//! `sweep` subcommand handler.
+//!
+//! Delegates to `palace::sweeper` for the actual ingestion logic.  Prints
+//! a human-readable summary on completion.
+
+use std::path::Path;
+
+use turso::Connection;
+
+use crate::error::Result;
+use crate::palace::sweeper;
+
+/// Run the `sweep` subcommand.
+///
+/// Sweeps a single `.jsonl` file or every `.jsonl` in a directory tree,
+/// inserting one drawer per user/assistant message that is not already
+/// present.  Reports counts to stdout on completion.
+pub async fn run(connection: &Connection, target: &Path, wing: &str) -> Result<()> {
+    assert!(
+        target.exists(),
+        "sweep: target must exist: {}",
+        target.display()
+    );
+    assert!(!wing.is_empty(), "sweep: wing must not be empty");
+
+    if target.is_file() {
+        let result = sweeper::sweep(connection, target, wing).await?;
+        println!(
+            "  Swept {}: +{} new, {} already present.",
+            target.display(),
+            result.drawers_added,
+            result.drawers_already_present,
+        );
+    } else if target.is_dir() {
+        let result = sweeper::sweep_directory(connection, target, wing).await?;
+        println!(
+            "  Swept {}/{} files from {}: +{} new, {} already present.",
+            result.files_succeeded,
+            result.files_attempted,
+            target.display(),
+            result.drawers_added,
+            result.drawers_already_present,
+        );
+    } else {
+        return Err(crate::error::Error::Other(format!(
+            "sweep target is neither a file nor a directory: {}",
+            target.display()
+        )));
+    }
+
+    Ok(())
+}

--- a/src/cli/sweep.rs
+++ b/src/cli/sweep.rs
@@ -58,26 +58,49 @@ mod tests {
     use super::*;
     use tempfile::tempdir;
 
-    /// Write a minimal valid Claude JSONL record to `path` for use in sweep tests.
+    /// Write a minimal valid Claude Code JSONL record to `path`.
+    ///
+    /// Uses the Claude Code native format: top-level `type` is `"user"` or
+    /// `"assistant"`, with the message payload in a nested `message` object.
     fn write_valid_jsonl(path: &Path) {
-        let record = r#"{"type":"message","session_id":"sess1","uuid":"u001","message":{"role":"user","content":"hi"}}"#;
+        let record = r#"{"type":"user","sessionId":"sess1","uuid":"u001","message":{"role":"user","content":"hi"}}"#;
         std::fs::write(path, format!("{record}\n")).expect("must write test JSONL file");
+    }
+
+    /// Query the number of drawers in `wing` on `connection`.
+    async fn drawer_count(connection: &turso::Connection, wing: &str) -> i64 {
+        let rows = crate::db::query_all(
+            connection,
+            "SELECT COUNT(*) FROM drawers WHERE wing = ?1",
+            turso::params![wing],
+        )
+        .await
+        .expect("drawer count query must succeed");
+        rows[0].get(0).expect("COUNT(*) must be readable as i64")
     }
 
     #[tokio::test]
     async fn run_file_target_returns_ok() {
-        // Single-file branch: run must accept a regular .jsonl file and return Ok.
+        // Single-file branch: run must accept a regular .jsonl file, return Ok,
+        // and insert the message as a drawer.
         let dir = tempdir().expect("must create temp dir");
         let file = dir.path().join("session.jsonl");
         write_valid_jsonl(&file);
         let (_database, connection) = crate::test_helpers::test_db().await;
         let result = run(&connection, &file, "test_wing").await;
         assert!(result.is_ok(), "run must return Ok for a valid file target");
+        // Pair assertion: the message in the fixture must have been inserted.
+        assert_eq!(
+            drawer_count(&connection, "test_wing").await,
+            1,
+            "run must insert one drawer for the single user message"
+        );
     }
 
     #[tokio::test]
     async fn run_directory_target_returns_ok() {
-        // Directory branch: run must accept a directory and return Ok.
+        // Directory branch: run must accept a directory, return Ok, and insert
+        // the message from the fixture file as a drawer.
         let dir = tempdir().expect("must create temp dir");
         let file = dir.path().join("session.jsonl");
         write_valid_jsonl(&file);
@@ -86,6 +109,12 @@ mod tests {
         assert!(
             result.is_ok(),
             "run must return Ok for a valid directory target"
+        );
+        // Pair assertion: the message from the file must have been inserted.
+        assert_eq!(
+            drawer_count(&connection, "test_wing").await,
+            1,
+            "run must insert one drawer for the single user message"
         );
     }
 

--- a/src/kg/mod.rs
+++ b/src/kg/mod.rs
@@ -59,6 +59,8 @@ mod tests {
             confidence: f64::NAN,
             source_closet: None,
             source_file: None,
+            source_drawer_id: None,
+            adapter_name: None,
         };
         let result = add_triple_validate_params(&params);
         assert!(result.is_err(), "NaN confidence must be rejected");
@@ -82,6 +84,8 @@ mod tests {
             confidence: -0.1,
             source_closet: None,
             source_file: None,
+            source_drawer_id: None,
+            adapter_name: None,
         };
         let result = add_triple_validate_params(&params);
         assert!(result.is_err(), "negative confidence must be rejected");
@@ -105,6 +109,8 @@ mod tests {
             confidence: 1.1,
             source_closet: None,
             source_file: None,
+            source_drawer_id: None,
+            adapter_name: None,
         };
         let result = add_triple_validate_params(&params);
         assert!(result.is_err(), "confidence > 1.0 must be rejected");
@@ -128,6 +134,8 @@ mod tests {
             confidence: 0.5,
             source_closet: None,
             source_file: None,
+            source_drawer_id: None,
+            adapter_name: None,
         };
         let result = add_triple_validate_params(&params);
         assert!(result.is_err(), "invalid date format must be rejected");
@@ -151,6 +159,8 @@ mod tests {
             confidence: 0.8,
             source_closet: None,
             source_file: None,
+            source_drawer_id: None,
+            adapter_name: None,
         };
         let result = add_triple_validate_params(&params);
         assert!(
@@ -177,6 +187,8 @@ mod tests {
             confidence: 0.5,
             source_closet: None,
             source_file: None,
+            source_drawer_id: None,
+            adapter_name: None,
         };
         let result = add_triple_validate_params(&params);
         assert!(result.is_err(), "invalid valid_to date must be rejected");
@@ -245,6 +257,8 @@ mod async_tests {
                 confidence: 0.9,
                 source_closet: None,
                 source_file: None,
+                source_drawer_id: None,
+                adapter_name: None,
             },
         )
         .await
@@ -271,6 +285,8 @@ mod async_tests {
             confidence: 1.0,
             source_closet: None,
             source_file: None,
+            source_drawer_id: None,
+            adapter_name: None,
         };
         let id1 = add_triple(&connection, &params)
             .await
@@ -295,6 +311,8 @@ mod async_tests {
                 confidence: 1.0,
                 source_closet: None,
                 source_file: None,
+                source_drawer_id: None,
+                adapter_name: None,
             },
         )
         .await
@@ -376,6 +394,12 @@ pub struct TripleParams<'a> {
     pub source_closet: Option<&'a str>,
     /// Optional file path that sourced this fact.
     pub source_file: Option<&'a str>,
+    /// RFC 002 §5.5: drawer ID of the source record, set by adapters that
+    /// advertise `supports_kg_triples`.  `None` for all non-adapter paths.
+    pub source_drawer_id: Option<&'a str>,
+    /// RFC 002 §5.5: adapter that produced this triple.
+    /// `None` for all non-adapter paths.
+    pub adapter_name: Option<&'a str>,
 }
 
 /// Validate confidence and ISO date fields on a `TripleParams`.
@@ -528,6 +552,32 @@ pub async fn add_triple(connection: &Connection, params: &TripleParams<'_>) -> R
     // Postcondition: triple ID follows naming convention.
     assert!(triple_id.starts_with("t_"), "triple_id must start with t_");
 
+    add_triple_insert_row(
+        connection,
+        &triple_id,
+        &subject_id,
+        &predicate,
+        &object_id,
+        params,
+    )
+    .await?;
+
+    Ok(triple_id)
+}
+
+/// Execute the final `INSERT INTO triples` for `add_triple`.
+/// Extracted to keep `add_triple` within the 70-line limit.
+async fn add_triple_insert_row(
+    connection: &Connection,
+    triple_id: &str,
+    subject_id: &str,
+    predicate: &str,
+    object_id: &str,
+    params: &TripleParams<'_>,
+) -> Result<()> {
+    assert!(!triple_id.is_empty(), "triple_id must not be empty");
+    assert!(!object_id.is_empty(), "object_id must not be empty");
+
     let valid_from_value: turso::Value = params
         .valid_from
         .map_or(turso::Value::Null, turso::Value::from);
@@ -540,14 +590,36 @@ pub async fn add_triple(connection: &Connection, params: &TripleParams<'_>) -> R
     let source_file_value: turso::Value = params
         .source_file
         .map_or(turso::Value::Null, turso::Value::from);
+    let source_drawer_id_value: turso::Value = params
+        .source_drawer_id
+        .map_or(turso::Value::Null, turso::Value::from);
+    let adapter_name_value: turso::Value = params
+        .adapter_name
+        .map_or(turso::Value::Null, turso::Value::from);
 
-    connection.execute(
-        "INSERT INTO triples (id, subject, predicate, object, valid_from, valid_to, confidence, source_closet, source_file) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
-        turso::params![triple_id.as_str(), subject_id.as_str(), predicate.as_str(), object_id.as_str(), valid_from_value, valid_to_value, params.confidence, source_closet_value, source_file_value],
-    )
-    .await?;
-
-    Ok(triple_id)
+    connection
+        .execute(
+            "INSERT INTO triples \
+             (id, subject, predicate, object, valid_from, valid_to, \
+              confidence, source_closet, source_file, \
+              source_drawer_id, adapter_name) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+            turso::params![
+                triple_id,
+                subject_id,
+                predicate,
+                object_id,
+                valid_from_value,
+                valid_to_value,
+                params.confidence,
+                source_closet_value,
+                source_file_value,
+                source_drawer_id_value,
+                adapter_name_value
+            ],
+        )
+        .await?;
+    Ok(())
 }
 
 /// Mark a relationship as ended (set `valid_to`).

--- a/src/kg/query.rs
+++ b/src/kg/query.rs
@@ -323,6 +323,8 @@ mod tests {
                 confidence: 1.0,
                 source_closet: None,
                 source_file: None,
+                source_drawer_id: None,
+                adapter_name: None,
             },
         )
         .await
@@ -394,6 +396,8 @@ mod tests {
                 confidence: 1.0,
                 source_closet: None,
                 source_file: None,
+                source_drawer_id: None,
+                adapter_name: None,
             },
         )
         .await
@@ -422,6 +426,8 @@ mod tests {
                 confidence: 1.0,
                 source_closet: None,
                 source_file: None,
+                source_drawer_id: None,
+                adapter_name: None,
             },
         )
         .await

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1162,6 +1162,8 @@ async fn tool_kg_add(connection: &Connection, args: &Value) -> Value {
             confidence: 1.0,
             source_closet: source_closet.as_deref(),
             source_file: None,
+            source_drawer_id: None,
+            adapter_name: None,
         },
     )
     .await

--- a/src/palace/convo_miner.rs
+++ b/src/palace/convo_miner.rs
@@ -22,7 +22,12 @@ const LINES_MAX: usize = 100_000;
 /// multi-byte characters.
 const CHUNK_SIZE: usize = 800;
 /// Files larger than this are skipped — prevents OOM on huge files.
-const FILE_SIZE_MAX: u64 = 10 * 1024 * 1024; // 10 MB
+/// Long Claude Code sessions, multi-year `ChatGPT` exports, and lifetime
+/// Slack dumps routinely exceed 10 MB; the cap guards against
+/// pathological binaries, not legitimate text.  Per-drawer size is
+/// bounded by `CHUNK_SIZE`, but content is loaded fully into memory
+/// before chunking, so memory use scales with source size.
+const FILE_SIZE_MAX: u64 = 500 * 1024 * 1024; // 500 MB
 
 // Compile-time invariant: chunk size must be greater than min chunk size.
 const _: () = assert!(CHUNK_SIZE > CHUNK_SIZE_MIN);

--- a/src/palace/miner.rs
+++ b/src/palace/miner.rs
@@ -24,14 +24,18 @@ pub struct MineParams {
 }
 
 /// Files larger than this are skipped — prevents OOM on huge files.
-const FILE_SIZE_MAX: u64 = 10 * 1024 * 1024; // 10 MB
+/// Large sessions (Claude Code, `ChatGPT` exports) routinely exceed 10 MB;
+/// the cap guards against pathological binaries, not legitimate text.
+/// Per-drawer size is bounded by `CHUNK_SIZE`, but the whole file is read
+/// into memory before chunking, so memory scales with source size.
+const FILE_SIZE_MAX: u64 = 500 * 1024 * 1024; // 500 MB
 
 use super::WALK_DEPTH_LIMIT;
 
 const READABLE_EXTENSIONS: &[&str] = &[
-    "txt", "md", "py", "js", "ts", "jsx", "tsx", "json", "yaml", "yml", "html", "css", "java",
-    "go", "rs", "rb", "sh", "csv", "sql", "toml", "c", "cpp", "h", "hpp", "swift", "kt", "scala",
-    "lua", "r", "php", "pl", "zig", "nim", "ex", "exs", "erl", "hs", "ml",
+    "txt", "md", "py", "js", "ts", "jsx", "tsx", "json", "jsonl", "yaml", "yml", "html", "css",
+    "java", "go", "rs", "rb", "sh", "csv", "sql", "toml", "c", "cpp", "h", "hpp", "swift", "kt",
+    "scala", "lua", "r", "php", "pl", "zig", "nim", "ex", "exs", "erl", "hs", "ml",
 ];
 
 /// Config filenames recognised by the miner, in load-precedence order.

--- a/src/palace/mod.rs
+++ b/src/palace/mod.rs
@@ -15,3 +15,4 @@ pub mod miner;
 pub mod query_sanitizer;
 pub mod room_detect;
 pub mod search;
+pub mod sweeper;

--- a/src/palace/sweeper.rs
+++ b/src/palace/sweeper.rs
@@ -1,0 +1,473 @@
+//! Sweep ingester — message-granular miner that catches what the primary
+//! file-level miners missed.
+//!
+//! Algorithm, per session:
+//!
+//!   `already_swept` = set of message UUIDs stored with `ingest_mode = "sweep"`
+//!   For each user/assistant message in the .jsonl:
+//!       if uuid in `already_swept`: count as already present, continue
+//!       else: insert a drawer keyed by `"sweep_{session_id}_{uuid}"`
+//!
+//! Properties:
+//!
+//! - Idempotent: deterministic drawer IDs and `add_drawer`'s `INSERT OR
+//!   IGNORE` make re-runs no-ops for already-stored messages.
+//! - Resume-safe: a crash mid-sweep is recovered on the next run — UUID
+//!   presence determines what to skip, so partial ingestion is completed
+//!   automatically on rerun.
+//! - Coordination with primary miners (`miner.rs`, `convo_miner.rs`) is
+//!   limited: those miners chunk at a fixed char size without storing
+//!   session/UUID metadata, so sweep drawers may overlap with primary-miner
+//!   drawers under different IDs.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+use serde_json::{Map, Value};
+use turso::Connection;
+
+use crate::error::Result;
+use crate::palace::WALK_DEPTH_LIMIT;
+use crate::palace::drawer::{self, DrawerParams};
+
+/// Maximum messages parsed from a single JSONL file.
+/// Guards against adversarially large inputs being loaded fully into memory.
+const MESSAGES_MAX: usize = 1_000_000;
+
+/// Maximum `.jsonl` files scanned in a single directory sweep.
+const FILES_MAX: usize = 100_000;
+
+// Compile-time invariants: limits must be positive.
+const _: () = assert!(MESSAGES_MAX > 0);
+const _: () = assert!(FILES_MAX > 0);
+
+/// A parsed user or assistant message from a Claude Code `.jsonl` file.
+struct SweepMessage {
+    session_id: String,
+    uuid: String,
+    role: String,
+    content: String,
+}
+
+/// Counts returned by a single-file sweep.
+pub struct SweepResult {
+    /// Drawers inserted that did not exist before this sweep.
+    pub drawers_added: usize,
+    /// Drawers already present (by UUID pre-check or INSERT OR IGNORE).
+    pub drawers_already_present: usize,
+}
+
+/// Counts returned by a directory sweep.
+pub struct SweepDirectoryResult {
+    /// Total `.jsonl` files found.
+    pub files_attempted: usize,
+    /// Files that completed without error.
+    pub files_succeeded: usize,
+    /// Total new drawers inserted across all files.
+    pub drawers_added: usize,
+    /// Total drawers already present across all files.
+    pub drawers_already_present: usize,
+}
+
+/// Render one assistant message content block as a plain string.
+///
+/// Called by `flatten_content` for each element of an array-typed message.
+/// All block types are preserved verbatim — tool inputs and results must
+/// not be silently discarded.
+fn flatten_content_block(
+    block_type: &str,
+    block_map: &Map<String, Value>,
+    block: &Value,
+) -> String {
+    assert!(
+        block.is_object(),
+        "flatten_content_block: block must be a JSON object"
+    );
+    let result = match block_type {
+        "text" => block_map
+            .get("text")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string(),
+        "tool_use" => format!(
+            "[tool_use: {} input={}]",
+            block_map.get("name").and_then(Value::as_str).unwrap_or("?"),
+            block_map
+                .get("input")
+                .map_or_else(|| "{}".to_string(), ToString::to_string),
+        ),
+        "tool_result" => format!(
+            "[tool_result: {}]",
+            block_map
+                .get("content")
+                .map_or_else(String::new, ToString::to_string),
+        ),
+        other => format!("[{other}: {block}]"),
+    };
+    // Negative space: result must not contain null bytes (would corrupt SQLite TEXT).
+    debug_assert!(!result.contains('\0'), "result must not contain null bytes");
+    result
+}
+
+/// Normalise Claude Code message content to a plain string.
+///
+/// User messages are plain strings; assistant messages are a list of content
+/// blocks (`text`, `tool_use`, `tool_result`, or other).  All blocks are
+/// preserved verbatim so nothing is silently discarded.
+fn flatten_content(content: &Value) -> String {
+    match content {
+        Value::String(string_content) => string_content.clone(),
+        Value::Array(blocks) => {
+            // Pre-allocate one slot per block; many blocks may yield empty strings.
+            let mut parts: Vec<String> = Vec::with_capacity(blocks.len());
+            for block in blocks {
+                let Some(block_map) = block.as_object() else {
+                    continue;
+                };
+                let block_type = block_map.get("type").and_then(Value::as_str).unwrap_or("");
+                let part = flatten_content_block(block_type, block_map, block);
+                if !part.is_empty() {
+                    parts.push(part);
+                }
+            }
+            parts.join("\n")
+        }
+        other => other.to_string(),
+    }
+}
+
+/// Parse one JSONL record into a `SweepMessage`, or `None` if not applicable.
+///
+/// Non-message record types (progress, file-history-snapshot, system,
+/// queue-operation, last-prompt) are filtered by checking `"type"` against
+/// `"user"` and `"assistant"`.  Malformed fields produce `None` — transcript
+/// quality is the writer's responsibility.
+fn parse_claude_jsonl_record(record: &Value) -> Option<SweepMessage> {
+    assert!(record.is_object(), "record must be a JSON object");
+
+    // Only user and assistant type records carry conversation content.
+    let rtype = record.get("type")?.as_str()?;
+    if rtype != "user" && rtype != "assistant" {
+        return None;
+    }
+
+    let msg = record.get("message")?.as_object()?;
+    let role = msg.get("role")?.as_str()?;
+    if role != "user" && role != "assistant" {
+        return None;
+    }
+
+    let uuid = record.get("uuid")?.as_str()?;
+    let session_id = record
+        .get("sessionId")
+        .or_else(|| record.get("session_id"))?
+        .as_str()?;
+
+    let content = flatten_content(msg.get("content").unwrap_or(&Value::Null));
+    if content.trim().is_empty() {
+        return None;
+    }
+
+    // Postcondition: all required fields are non-empty strings.
+    assert!(!uuid.is_empty(), "uuid must not be empty after filtering");
+    assert!(
+        !session_id.is_empty(),
+        "session_id must not be empty after filtering"
+    );
+
+    Some(SweepMessage {
+        session_id: session_id.to_string(),
+        uuid: uuid.to_string(),
+        role: role.to_string(),
+        content,
+    })
+}
+
+/// Parse a Claude Code `.jsonl` file and return all user/assistant messages.
+///
+/// Each JSONL line is parsed independently; malformed lines are silently
+/// skipped.  Processing stops at `MESSAGES_MAX` to prevent OOM on huge files.
+fn parse_claude_jsonl(path: &Path) -> Result<Vec<SweepMessage>> {
+    assert!(
+        path.exists(),
+        "parse_claude_jsonl: path must exist: {}",
+        path.display()
+    );
+
+    let file_content = std::fs::read_to_string(path)?;
+    let mut messages: Vec<SweepMessage> = Vec::new();
+    let mut line_count: usize = 0;
+
+    for line in file_content.lines() {
+        assert!(
+            line_count < MESSAGES_MAX,
+            "parse_claude_jsonl: MESSAGES_MAX exceeded"
+        );
+        line_count += 1;
+        if line_count > MESSAGES_MAX {
+            break;
+        }
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(record) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        if let Some(msg) = parse_claude_jsonl_record(&record) {
+            messages.push(msg);
+        }
+    }
+
+    // Postcondition: message count is within the configured bound.
+    assert!(
+        messages.len() <= MESSAGES_MAX,
+        "message count must not exceed MESSAGES_MAX"
+    );
+    Ok(messages)
+}
+
+/// Build the deterministic drawer ID for a swept message.
+///
+/// Uses the full `session_id` (not a prefix) to avoid cross-session
+/// collision risk when session identifiers share prefixes.
+fn sweep_make_drawer_id(session_id: &str, uuid: &str) -> String {
+    assert!(!session_id.is_empty(), "session_id must not be empty");
+    assert!(!uuid.is_empty(), "uuid must not be empty");
+
+    let drawer_id = format!("sweep_{session_id}_{uuid}");
+
+    // Postcondition: ID starts with the sweep prefix and encodes both fields.
+    assert!(
+        drawer_id.starts_with("sweep_"),
+        "drawer_id must start with sweep_"
+    );
+    // Negative space: no null bytes (would corrupt SQLite TEXT).
+    debug_assert!(
+        !drawer_id.contains('\0'),
+        "drawer_id must not contain null bytes"
+    );
+    drawer_id
+}
+
+/// Query the set of message UUIDs already swept for each session in `session_ids`.
+///
+/// Drawer IDs for swept messages follow the pattern `"sweep_{session_id}_{uuid}"`.
+/// Querying by that prefix and stripping it yields the stored UUIDs, letting the
+/// caller skip re-processing.  A `LIMIT` is applied to avoid hitting
+/// `query_all`'s `ROWS_MAX` guard on sessions with many prior sweeps.
+async fn sweep_load_cursors(
+    connection: &Connection,
+    session_ids: &HashSet<String>,
+) -> Result<HashMap<String, HashSet<String>>> {
+    let mut cursors: HashMap<String, HashSet<String>> = HashMap::with_capacity(session_ids.len());
+
+    for session_id in session_ids {
+        assert!(!session_id.is_empty(), "session_id must not be empty");
+
+        let prefix = format!("sweep_{session_id}_");
+        let like_pattern = format!("{prefix}%");
+
+        let rows = crate::db::query_all(
+            connection,
+            "SELECT id FROM drawers WHERE id LIKE ?1 AND ingest_mode = 'sweep' LIMIT 100000",
+            turso::params![like_pattern.as_str()],
+        )
+        .await?;
+
+        let mut uuids: HashSet<String> = HashSet::with_capacity(rows.len());
+        for row in &rows {
+            if let Ok(id) = row.get::<String>(0)
+                && let Some(uuid) = id.strip_prefix(&prefix)
+            {
+                uuids.insert(uuid.to_string());
+            }
+        }
+
+        // Pair assertion: all extracted UUIDs are non-empty strings.
+        debug_assert!(
+            uuids.iter().all(|u| !u.is_empty()),
+            "all extracted UUIDs must be non-empty"
+        );
+
+        cursors.insert(session_id.clone(), uuids);
+    }
+
+    // Postcondition: result has one entry per session queried.
+    assert!(
+        cursors.len() == session_ids.len(),
+        "cursor map must have one entry per session ID"
+    );
+    Ok(cursors)
+}
+
+/// Sweep a single Claude Code `.jsonl` file into the palace.
+///
+/// Parses every user/assistant message, skips those already stored (identified
+/// by UUID), and inserts the rest as individual drawers.  The deterministic
+/// drawer ID makes re-running safe.
+pub async fn sweep(connection: &Connection, jsonl_path: &Path, wing: &str) -> Result<SweepResult> {
+    assert!(
+        jsonl_path.exists(),
+        "sweep: path must exist: {}",
+        jsonl_path.display()
+    );
+    assert!(!wing.is_empty(), "sweep: wing must not be empty");
+
+    let messages = parse_claude_jsonl(jsonl_path)?;
+
+    // Bulk-load cursors with one DB round trip per unique session.
+    let session_ids: HashSet<String> = messages.iter().map(|m| m.session_id.clone()).collect();
+    let cursors = sweep_load_cursors(connection, &session_ids).await?;
+
+    let source_file = jsonl_path.to_str().unwrap_or("");
+    let mut drawers_added: usize = 0;
+    let mut drawers_already_present: usize = 0;
+
+    for (file_index, message) in messages.iter().enumerate() {
+        let already_swept = cursors
+            .get(&message.session_id)
+            .is_some_and(|uuids| uuids.contains(&message.uuid));
+
+        if already_swept {
+            drawers_already_present += 1;
+            continue;
+        }
+
+        let drawer_id = sweep_make_drawer_id(&message.session_id, &message.uuid);
+        let content = format!("{}: {}", message.role.to_uppercase(), message.content);
+
+        let inserted = drawer::add_drawer(
+            connection,
+            &DrawerParams {
+                id: &drawer_id,
+                wing,
+                room: "conversations",
+                content: &content,
+                source_file,
+                chunk_index: file_index,
+                added_by: "sweep",
+                ingest_mode: "sweep",
+                source_mtime: None,
+            },
+        )
+        .await?;
+
+        if inserted {
+            drawers_added += 1;
+        } else {
+            // Drawer exists; UUID pre-check may not cover concurrent inserts.
+            drawers_already_present += 1;
+        }
+    }
+
+    // Postcondition: every message was either inserted or counted as present.
+    assert!(
+        drawers_added + drawers_already_present == messages.len(),
+        "all messages must be accounted for: added={drawers_added} \
+         present={drawers_already_present} total={}",
+        messages.len()
+    );
+    Ok(SweepResult {
+        drawers_added,
+        drawers_already_present,
+    })
+}
+
+/// Collect all `.jsonl` files under `dir_path` up to `WALK_DEPTH_LIMIT` deep.
+/// Extracted from `sweep_directory` to keep that function within the 70-line limit.
+fn sweep_directory_collect_files(dir_path: &Path) -> Vec<PathBuf> {
+    assert!(
+        dir_path.is_dir(),
+        "sweep_directory_collect_files: path must be a directory: {}",
+        dir_path.display()
+    );
+
+    let mut files: Vec<PathBuf> = Vec::new();
+    let mut stack: Vec<(PathBuf, usize)> = vec![(dir_path.to_path_buf(), 0)];
+
+    while let Some((current_dir, depth)) = stack.pop() {
+        assert!(
+            depth <= WALK_DEPTH_LIMIT,
+            "depth must not exceed WALK_DEPTH_LIMIT"
+        );
+        if depth >= WALK_DEPTH_LIMIT {
+            continue;
+        }
+        let Ok(read_dir) = std::fs::read_dir(&current_dir) else {
+            continue;
+        };
+        for entry in read_dir.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push((path, depth + 1));
+            } else if path.extension().and_then(|e| e.to_str()) == Some("jsonl") {
+                files.push(path);
+            }
+        }
+    }
+
+    files.sort();
+
+    // Postcondition: all returned paths have the `.jsonl` extension.
+    debug_assert!(
+        files
+            .iter()
+            .all(|f| f.extension().and_then(|e| e.to_str()) == Some("jsonl")),
+        "all collected files must have .jsonl extension"
+    );
+    files
+}
+
+/// Sweep every `.jsonl` file in a directory tree into the palace.
+///
+/// Individual file failures are logged to stderr and do not abort the sweep —
+/// a partial failure still ingests whatever it can.  MCP servers must not
+/// pollute stdout, so error output goes to stderr.
+pub async fn sweep_directory(
+    connection: &Connection,
+    dir_path: &Path,
+    wing: &str,
+) -> Result<SweepDirectoryResult> {
+    assert!(
+        dir_path.is_dir(),
+        "sweep_directory: path must be a directory"
+    );
+    assert!(!wing.is_empty(), "sweep_directory: wing must not be empty");
+
+    let files = sweep_directory_collect_files(dir_path);
+
+    assert!(
+        files.len() <= FILES_MAX,
+        "sweep_directory: FILES_MAX ({FILES_MAX}) exceeded"
+    );
+
+    let mut drawers_added: usize = 0;
+    let mut drawers_already_present: usize = 0;
+    let mut files_succeeded: usize = 0;
+
+    for file in &files {
+        match sweep(connection, file, wing).await {
+            Ok(result) => {
+                drawers_added += result.drawers_added;
+                drawers_already_present += result.drawers_already_present;
+                files_succeeded += 1;
+            }
+            Err(error) => {
+                eprintln!("sweep: skipping {}: {error}", file.display());
+            }
+        }
+    }
+
+    // Postcondition: succeeded count cannot exceed attempted count.
+    assert!(
+        files_succeeded <= files.len(),
+        "files_succeeded must not exceed files_attempted"
+    );
+    Ok(SweepDirectoryResult {
+        files_attempted: files.len(),
+        files_succeeded,
+        drawers_added,
+        drawers_already_present,
+    })
+}

--- a/src/palace/sweeper.rs
+++ b/src/palace/sweeper.rs
@@ -260,13 +260,14 @@ fn sweep_make_drawer_id(session_id: &str, uuid: &str) -> String {
     drawer_id
 }
 
-/// Query the set of message UUIDs already swept for each session in `session_ids`.
+/// Query the set of drawer IDs already swept for each session in `session_ids`.
 ///
 /// Drawer IDs for swept messages follow the pattern `"sweep_{session_id}_{uuid}"`.
-/// Querying by that prefix and stripping it yields the stored UUIDs, letting the
-/// caller skip re-processing.  Results are fetched in keyset-paginated batches
-/// (100 000 rows each, matching `db::ROWS_MAX`) so sessions with arbitrarily
-/// many prior sweeps are handled without truncation or OOM.
+/// Full drawer IDs (not stripped UUIDs) are stored in the returned sets so that
+/// sessions whose IDs share a prefix cannot cause false already-swept matches.
+/// Results are fetched in keyset-paginated batches (100 000 rows each, matching
+/// `db::ROWS_MAX`) so sessions with arbitrarily many prior sweeps are handled
+/// without truncation or OOM.
 async fn sweep_load_cursors(
     connection: &Connection,
     session_ids: &HashSet<String>,
@@ -276,10 +277,9 @@ async fn sweep_load_cursors(
     for session_id in session_ids {
         assert!(!session_id.is_empty(), "session_id must not be empty");
 
-        let prefix = format!("sweep_{session_id}_");
-        let like_pattern = format!("{prefix}%");
+        let like_pattern = format!("sweep_{session_id}_%");
 
-        let mut uuids: HashSet<String> = HashSet::new();
+        let mut drawer_ids: HashSet<String> = HashSet::new();
         // Empty string sorts before all real IDs, making it a valid initial keyset cursor.
         let mut last_id = String::new();
 
@@ -301,27 +301,27 @@ async fn sweep_load_cursors(
 
             for row in &batch {
                 if let Ok(id) = row.get::<String>(0) {
-                    if let Some(uuid) = id.strip_prefix(&prefix) {
-                        uuids.insert(uuid.to_string());
-                    }
+                    // Store the full drawer id; stripping to UUID allows false
+                    // matches when one session_id is a prefix of another.
+                    drawer_ids.insert(id.clone());
                     // Always advance the cursor; rows are sorted ascending.
                     last_id = id;
                 }
             }
 
             // Stop when the batch was partial (last page) or the cap is reached.
-            if batch_len < 100_000 || uuids.len() >= MESSAGES_MAX {
+            if batch_len < 100_000 || drawer_ids.len() >= MESSAGES_MAX {
                 break;
             }
         }
 
-        // Pair assertion: all extracted UUIDs are non-empty strings.
+        // Pair assertion: all stored drawer ids are non-empty strings.
         debug_assert!(
-            uuids.iter().all(|u| !u.is_empty()),
-            "all extracted UUIDs must be non-empty"
+            drawer_ids.iter().all(|id| !id.is_empty()),
+            "all stored drawer ids must be non-empty"
         );
 
-        cursors.insert(session_id.clone(), uuids);
+        cursors.insert(session_id.clone(), drawer_ids);
     }
 
     // Postcondition: result has one entry per session queried.
@@ -351,21 +351,21 @@ pub async fn sweep(connection: &Connection, jsonl_path: &Path, wing: &str) -> Re
     let session_ids: HashSet<String> = messages.iter().map(|m| m.session_id.clone()).collect();
     let cursors = sweep_load_cursors(connection, &session_ids).await?;
 
-    let source_file = jsonl_path.to_str().unwrap_or("");
+    let source_file = jsonl_path.to_string_lossy().into_owned();
     let mut drawers_added: usize = 0;
     let mut drawers_already_present: usize = 0;
 
     for (file_index, message) in messages.iter().enumerate() {
+        // Compute before the cursor check; reused for the insert if not present.
+        let drawer_id = sweep_make_drawer_id(&message.session_id, &message.uuid);
         let already_swept = cursors
             .get(&message.session_id)
-            .is_some_and(|uuids| uuids.contains(&message.uuid));
+            .is_some_and(|drawer_ids| drawer_ids.contains(&drawer_id));
 
         if already_swept {
             drawers_already_present += 1;
             continue;
         }
-
-        let drawer_id = sweep_make_drawer_id(&message.session_id, &message.uuid);
         let content = format!("{}: {}", message.role.to_uppercase(), message.content);
 
         let inserted = drawer::add_drawer(
@@ -375,7 +375,7 @@ pub async fn sweep(connection: &Connection, jsonl_path: &Path, wing: &str) -> Re
                 wing,
                 room: "conversations",
                 content: &content,
-                source_file,
+                source_file: &source_file,
                 chunk_index: file_index,
                 added_by: "sweep",
                 ingest_mode: "sweep",
@@ -422,6 +422,11 @@ fn sweep_directory_collect_files(dir_path: &Path) -> Vec<PathBuf> {
             depth <= WALK_DEPTH_LIMIT,
             "depth must not exceed WALK_DEPTH_LIMIT"
         );
+        // Curtail traversal as soon as the cap is reached; remaining stack
+        // entries are abandoned rather than walked for nothing.
+        if files.len() >= FILES_MAX {
+            break;
+        }
         let Ok(read_dir) = std::fs::read_dir(&current_dir) else {
             continue;
         };
@@ -432,6 +437,10 @@ fn sweep_directory_collect_files(dir_path: &Path) -> Vec<PathBuf> {
                 stack.push((path, depth + 1));
             } else if path.extension().and_then(|e| e.to_str()) == Some("jsonl") {
                 files.push(path);
+                // Stop collecting from this directory once the cap is hit.
+                if files.len() >= FILES_MAX {
+                    break;
+                }
             }
         }
     }
@@ -909,9 +918,10 @@ mod tests {
             .expect("cursor load should succeed");
 
         assert_eq!(cursors.len(), 1);
+        // Cursor now stores full drawer ids, not stripped UUIDs.
         assert!(
-            cursors["sess1"].contains("uuid-abc"),
-            "prior UUID must be found in cursor"
+            cursors["sess1"].contains("sweep_sess1_uuid-abc"),
+            "prior drawer id must be found in cursor"
         );
     }
 

--- a/src/palace/sweeper.rs
+++ b/src/palace/sweeper.rs
@@ -21,6 +21,8 @@
 //!   drawers under different IDs.
 
 use std::collections::{HashMap, HashSet};
+use std::fs::File;
+use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
 use serde_json::{Map, Value};
@@ -167,17 +169,23 @@ fn parse_claude_jsonl_record(record: &Value) -> Option<SweepMessage> {
         .or_else(|| record.get("session_id"))?
         .as_str()?;
 
-    let content = flatten_content(msg.get("content").unwrap_or(&Value::Null));
+    // Absent or JSON-null content is not usable; skip rather than storing "null".
+    let content_value = msg.get("content")?;
+    if content_value.is_null() {
+        return None;
+    }
+    let content = flatten_content(content_value);
     if content.trim().is_empty() {
         return None;
     }
 
-    // Postcondition: all required fields are non-empty strings.
-    assert!(!uuid.is_empty(), "uuid must not be empty after filtering");
-    assert!(
-        !session_id.is_empty(),
-        "session_id must not be empty after filtering"
-    );
+    // Empty identifiers are input quality problems — return None rather than panic.
+    if uuid.is_empty() {
+        return None;
+    }
+    if session_id.is_empty() {
+        return None;
+    }
 
     Some(SweepMessage {
         session_id: session_id.to_string(),
@@ -198,15 +206,17 @@ fn parse_claude_jsonl(path: &Path) -> Result<Vec<SweepMessage>> {
         path.display()
     );
 
-    let file_content = std::fs::read_to_string(path)?;
+    // Stream line-by-line so MESSAGES_MAX is enforced before large allocations.
+    let reader = BufReader::new(File::open(path)?);
     let mut messages: Vec<SweepMessage> = Vec::new();
     let mut line_count: usize = 0;
 
-    for line in file_content.lines() {
+    for line_result in reader.lines() {
         line_count += 1;
         if line_count > MESSAGES_MAX {
             break;
         }
+        let line = line_result?;
         let line = line.trim();
         if line.is_empty() {
             continue;
@@ -254,8 +264,9 @@ fn sweep_make_drawer_id(session_id: &str, uuid: &str) -> String {
 ///
 /// Drawer IDs for swept messages follow the pattern `"sweep_{session_id}_{uuid}"`.
 /// Querying by that prefix and stripping it yields the stored UUIDs, letting the
-/// caller skip re-processing.  A `LIMIT` is applied to avoid hitting
-/// `query_all`'s `ROWS_MAX` guard on sessions with many prior sweeps.
+/// caller skip re-processing.  Results are fetched in keyset-paginated batches
+/// (100 000 rows each, matching `db::ROWS_MAX`) so sessions with arbitrarily
+/// many prior sweeps are handled without truncation or OOM.
 async fn sweep_load_cursors(
     connection: &Connection,
     session_ids: &HashSet<String>,
@@ -268,19 +279,39 @@ async fn sweep_load_cursors(
         let prefix = format!("sweep_{session_id}_");
         let like_pattern = format!("{prefix}%");
 
-        let rows = crate::db::query_all(
-            connection,
-            "SELECT id FROM drawers WHERE id LIKE ?1 AND ingest_mode = 'sweep' LIMIT 100000",
-            turso::params![like_pattern.as_str()],
-        )
-        .await?;
+        let mut uuids: HashSet<String> = HashSet::new();
+        // Empty string sorts before all real IDs, making it a valid initial keyset cursor.
+        let mut last_id = String::new();
 
-        let mut uuids: HashSet<String> = HashSet::with_capacity(rows.len());
-        for row in &rows {
-            if let Ok(id) = row.get::<String>(0)
-                && let Some(uuid) = id.strip_prefix(&prefix)
-            {
-                uuids.insert(uuid.to_string());
+        loop {
+            // Batch size matches db::ROWS_MAX; ORDER BY id enables keyset pagination.
+            let batch = crate::db::query_all(
+                connection,
+                "SELECT id FROM drawers WHERE id LIKE ?1 AND ingest_mode = 'sweep' \
+                 AND id > ?2 ORDER BY id LIMIT 100000",
+                turso::params![like_pattern.as_str(), last_id.as_str()],
+            )
+            .await?;
+
+            if batch.is_empty() {
+                break;
+            }
+
+            let batch_len = batch.len();
+
+            for row in &batch {
+                if let Ok(id) = row.get::<String>(0) {
+                    if let Some(uuid) = id.strip_prefix(&prefix) {
+                        uuids.insert(uuid.to_string());
+                    }
+                    // Always advance the cursor; rows are sorted ascending.
+                    last_id = id;
+                }
+            }
+
+            // Stop when the batch was partial (last page) or the cap is reached.
+            if batch_len < 100_000 || uuids.len() >= MESSAGES_MAX {
+                break;
             }
         }
 
@@ -706,6 +737,44 @@ mod tests {
         let record = serde_json::json!({
             "type": "user", "sessionId": "s1", "uuid": "u1",
             "message": { "role": "user", "content": "   " }
+        });
+        assert!(parse_claude_jsonl_record(&record).is_none());
+    }
+
+    #[test]
+    fn parse_record_null_content_returns_none() {
+        // JSON null content must yield None, not the string literal "null".
+        let record = serde_json::json!({
+            "type": "user", "sessionId": "s1", "uuid": "u1",
+            "message": { "role": "user", "content": null }
+        });
+        assert!(parse_claude_jsonl_record(&record).is_none());
+    }
+
+    #[test]
+    fn parse_record_missing_content_returns_none() {
+        // Absent content field must yield None, not the string literal "null".
+        let record = serde_json::json!({
+            "type": "user", "sessionId": "s1", "uuid": "u1",
+            "message": { "role": "user" }
+        });
+        assert!(parse_claude_jsonl_record(&record).is_none());
+    }
+
+    #[test]
+    fn parse_record_empty_uuid_returns_none() {
+        let record = serde_json::json!({
+            "type": "user", "sessionId": "s1", "uuid": "",
+            "message": { "role": "user", "content": "text" }
+        });
+        assert!(parse_claude_jsonl_record(&record).is_none());
+    }
+
+    #[test]
+    fn parse_record_empty_session_id_returns_none() {
+        let record = serde_json::json!({
+            "type": "user", "sessionId": "", "uuid": "u1",
+            "message": { "role": "user", "content": "text" }
         });
         assert!(parse_claude_jsonl_record(&record).is_none());
     }

--- a/src/palace/sweeper.rs
+++ b/src/palace/sweeper.rs
@@ -471,3 +471,557 @@ pub async fn sweep_directory(
         drawers_already_present,
     })
 }
+
+#[cfg(test)]
+// Test code — .expect() is acceptable with a descriptive message.
+#[allow(clippy::expect_used)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    // ── Fixtures ─────────────────────────────────────────────────────────────
+
+    /// Write `lines` to a temp file named `name` in `dir` and return the path.
+    fn write_jsonl(dir: &Path, name: &str, lines: &[&str]) -> PathBuf {
+        let path = dir.join(name);
+        fs::write(&path, lines.join("\n")).expect("write test JSONL");
+        path
+    }
+
+    /// Build a minimal valid Claude Code user record as a JSON string.
+    fn user_record(session_id: &str, uuid: &str, content: &str) -> String {
+        serde_json::json!({
+            "type": "user",
+            "sessionId": session_id,
+            "uuid": uuid,
+            "timestamp": "2024-01-01T00:00:00Z",
+            "message": { "role": "user", "content": content }
+        })
+        .to_string()
+    }
+
+    /// Build a minimal valid Claude Code assistant record with a text block.
+    fn assistant_record(session_id: &str, uuid: &str, text: &str) -> String {
+        serde_json::json!({
+            "type": "assistant",
+            "sessionId": session_id,
+            "uuid": uuid,
+            "timestamp": "2024-01-01T00:00:01Z",
+            "message": {
+                "role": "assistant",
+                "content": [{ "type": "text", "text": text }]
+            }
+        })
+        .to_string()
+    }
+
+    // ── flatten_content_block ────────────────────────────────────────────────
+
+    #[test]
+    fn flatten_content_block_text_returns_text_field() {
+        let block = serde_json::json!({ "type": "text", "text": "hello world" });
+        let block_map = block.as_object().expect("must be object");
+        let result = flatten_content_block("text", block_map, &block);
+        assert_eq!(result, "hello world");
+        assert!(!result.contains('\0'));
+    }
+
+    #[test]
+    fn flatten_content_block_text_missing_field_returns_empty() {
+        let block = serde_json::json!({ "type": "text" });
+        let block_map = block.as_object().expect("must be object");
+        let result = flatten_content_block("text", block_map, &block);
+        assert!(
+            result.is_empty(),
+            "missing text field must yield empty string"
+        );
+    }
+
+    #[test]
+    fn flatten_content_block_tool_use_includes_name_and_input() {
+        let block = serde_json::json!({
+            "type": "tool_use",
+            "name": "Read",
+            "input": { "file": "foo.rs" }
+        });
+        let block_map = block.as_object().expect("must be object");
+        let result = flatten_content_block("tool_use", block_map, &block);
+        assert!(result.starts_with("[tool_use: Read input="));
+        assert!(result.contains("foo.rs"));
+    }
+
+    #[test]
+    fn flatten_content_block_tool_use_missing_name_falls_back_to_question_mark() {
+        let block = serde_json::json!({ "type": "tool_use", "input": {} });
+        let block_map = block.as_object().expect("must be object");
+        let result = flatten_content_block("tool_use", block_map, &block);
+        assert!(result.contains('?'), "missing name must fall back to '?'");
+    }
+
+    #[test]
+    fn flatten_content_block_tool_result_includes_content() {
+        let block = serde_json::json!({ "type": "tool_result", "content": "result text" });
+        let block_map = block.as_object().expect("must be object");
+        let result = flatten_content_block("tool_result", block_map, &block);
+        assert!(result.starts_with("[tool_result:"));
+        assert!(result.contains("result text"));
+    }
+
+    #[test]
+    fn flatten_content_block_tool_result_missing_content_returns_empty_brackets() {
+        let block = serde_json::json!({ "type": "tool_result" });
+        let block_map = block.as_object().expect("must be object");
+        let result = flatten_content_block("tool_result", block_map, &block);
+        assert_eq!(result, "[tool_result: ]");
+    }
+
+    #[test]
+    fn flatten_content_block_unknown_type_formats_generic() {
+        let block = serde_json::json!({ "type": "thinking", "data": "..." });
+        let block_map = block.as_object().expect("must be object");
+        let result = flatten_content_block("thinking", block_map, &block);
+        assert!(
+            result.starts_with("[thinking:"),
+            "unknown type must use generic format"
+        );
+    }
+
+    // ── flatten_content ──────────────────────────────────────────────────────
+
+    #[test]
+    fn flatten_content_string_returns_the_string_unchanged() {
+        let content = Value::String("hello".to_string());
+        assert_eq!(flatten_content(&content), "hello");
+    }
+
+    #[test]
+    fn flatten_content_array_joins_non_empty_block_parts() {
+        let content = serde_json::json!([
+            { "type": "text", "text": "part one" },
+            { "type": "text", "text": "part two" }
+        ]);
+        let result = flatten_content(&content);
+        assert!(result.contains("part one"));
+        assert!(result.contains("part two"));
+        assert!(
+            result.contains('\n'),
+            "multiple parts must be newline-joined"
+        );
+    }
+
+    #[test]
+    fn flatten_content_array_skips_non_object_elements() {
+        let content = serde_json::json!([
+            { "type": "text", "text": "real" },
+            "not an object",
+            42
+        ]);
+        let result = flatten_content(&content);
+        assert_eq!(
+            result, "real",
+            "non-object elements must be silently skipped"
+        );
+    }
+
+    #[test]
+    fn flatten_content_array_empty_returns_empty_string() {
+        let content = serde_json::json!([]);
+        assert!(flatten_content(&content).is_empty());
+    }
+
+    #[test]
+    fn flatten_content_null_returns_string_representation() {
+        let result = flatten_content(&Value::Null);
+        assert_eq!(result, "null");
+        assert!(!result.is_empty());
+    }
+
+    // ── parse_claude_jsonl_record ────────────────────────────────────────────
+
+    #[test]
+    fn parse_record_valid_user_message() {
+        let record: Value =
+            serde_json::from_str(&user_record("s1", "u1", "Hello")).expect("parse fixture");
+        let msg = parse_claude_jsonl_record(&record).expect("must parse");
+        assert_eq!(msg.session_id, "s1");
+        assert_eq!(msg.uuid, "u1");
+        assert_eq!(msg.role, "user");
+        assert!(msg.content.contains("Hello"));
+    }
+
+    #[test]
+    fn parse_record_valid_assistant_array_content() {
+        let record: Value =
+            serde_json::from_str(&assistant_record("s2", "u2", "Hi")).expect("parse fixture");
+        let msg = parse_claude_jsonl_record(&record).expect("must parse");
+        assert_eq!(msg.role, "assistant");
+        assert!(msg.content.contains("Hi"));
+    }
+
+    #[test]
+    fn parse_record_wrong_type_returns_none() {
+        let record = serde_json::json!({
+            "type": "progress",
+            "sessionId": "s1", "uuid": "u1",
+            "message": { "role": "user", "content": "text" }
+        });
+        assert!(parse_claude_jsonl_record(&record).is_none());
+    }
+
+    #[test]
+    fn parse_record_wrong_role_returns_none() {
+        let record = serde_json::json!({
+            "type": "user",
+            "sessionId": "s1", "uuid": "u1",
+            "message": { "role": "system", "content": "text" }
+        });
+        assert!(parse_claude_jsonl_record(&record).is_none());
+    }
+
+    #[test]
+    fn parse_record_missing_message_returns_none() {
+        let record = serde_json::json!({ "type": "user", "sessionId": "s1", "uuid": "u1" });
+        assert!(parse_claude_jsonl_record(&record).is_none());
+    }
+
+    #[test]
+    fn parse_record_missing_uuid_returns_none() {
+        let record = serde_json::json!({
+            "type": "user", "sessionId": "s1",
+            "message": { "role": "user", "content": "text" }
+        });
+        assert!(parse_claude_jsonl_record(&record).is_none());
+    }
+
+    #[test]
+    fn parse_record_missing_session_id_returns_none() {
+        let record = serde_json::json!({
+            "type": "user", "uuid": "u1",
+            "message": { "role": "user", "content": "text" }
+        });
+        assert!(parse_claude_jsonl_record(&record).is_none());
+    }
+
+    #[test]
+    fn parse_record_empty_content_returns_none() {
+        let record = serde_json::json!({
+            "type": "user", "sessionId": "s1", "uuid": "u1",
+            "message": { "role": "user", "content": "   " }
+        });
+        assert!(parse_claude_jsonl_record(&record).is_none());
+    }
+
+    #[test]
+    fn parse_record_uses_snake_case_session_id_fallback() {
+        let record = serde_json::json!({
+            "type": "user", "session_id": "fallback", "uuid": "u1",
+            "message": { "role": "user", "content": "text" }
+        });
+        let msg = parse_claude_jsonl_record(&record)
+            .expect("must parse when session_id snake_case key is used");
+        assert_eq!(msg.session_id, "fallback");
+        assert!(!msg.session_id.is_empty());
+    }
+
+    // ── parse_claude_jsonl ───────────────────────────────────────────────────
+
+    #[test]
+    fn parse_jsonl_valid_file_returns_all_messages() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = write_jsonl(
+            dir.path(),
+            "session.jsonl",
+            &[
+                &user_record("s1", "u1", "Hello"),
+                &assistant_record("s1", "u2", "Hi"),
+            ],
+        );
+        let messages = parse_claude_jsonl(&path).expect("parse should succeed");
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].role, "user");
+        assert_eq!(messages[1].role, "assistant");
+    }
+
+    #[test]
+    fn parse_jsonl_malformed_lines_are_silently_skipped() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = write_jsonl(
+            dir.path(),
+            "session.jsonl",
+            &["not json {{{", &user_record("s1", "u1", "Valid"), ""],
+        );
+        let messages = parse_claude_jsonl(&path).expect("parse should succeed");
+        assert_eq!(messages.len(), 1, "only the valid record must be parsed");
+        assert_eq!(messages[0].uuid, "u1");
+    }
+
+    #[test]
+    fn parse_jsonl_empty_file_returns_empty_vec() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = write_jsonl(dir.path(), "empty.jsonl", &[]);
+        let messages = parse_claude_jsonl(&path).expect("parse should succeed");
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn parse_jsonl_non_message_records_are_filtered_out() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let progress = serde_json::json!({"type": "progress", "data": "..."}).to_string();
+        let path = write_jsonl(
+            dir.path(),
+            "session.jsonl",
+            &[&progress, &user_record("s1", "u1", "Real message")],
+        );
+        let messages = parse_claude_jsonl(&path).expect("parse should succeed");
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].uuid, "u1");
+    }
+
+    // ── sweep_make_drawer_id ─────────────────────────────────────────────────
+
+    #[test]
+    fn make_drawer_id_starts_with_sweep_prefix_and_encodes_both_fields() {
+        let id = sweep_make_drawer_id("sess-abc", "msg-123");
+        assert!(id.starts_with("sweep_"), "must start with sweep_");
+        assert!(id.contains("sess-abc"), "must contain session_id");
+        assert!(id.contains("msg-123"), "must contain uuid");
+    }
+
+    #[test]
+    fn make_drawer_id_is_deterministic_for_same_inputs() {
+        let id_a = sweep_make_drawer_id("sess-abc", "msg-123");
+        let id_b = sweep_make_drawer_id("sess-abc", "msg-123");
+        assert_eq!(id_a, id_b, "same inputs must always produce the same ID");
+        assert!(!id_a.contains('\0'));
+    }
+
+    // ── sweep_load_cursors ───────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn load_cursors_returns_empty_set_for_fresh_session() {
+        let (_db, connection) = crate::test_helpers::test_db().await;
+        let session_ids: HashSet<String> = ["sess1".to_string(), "sess2".to_string()].into();
+        let cursors = sweep_load_cursors(&connection, &session_ids)
+            .await
+            .expect("cursor load should succeed");
+        assert_eq!(cursors.len(), 2, "one entry per session");
+        assert!(
+            cursors["sess1"].is_empty(),
+            "fresh session must have empty cursor"
+        );
+        assert!(cursors["sess2"].is_empty());
+    }
+
+    #[tokio::test]
+    async fn load_cursors_finds_previously_swept_uuids() {
+        let (_db, connection) = crate::test_helpers::test_db().await;
+        // Seed a sweeper drawer directly.
+        connection
+            .execute(
+                "INSERT INTO drawers \
+                 (id, wing, room, content, source_file, chunk_index, added_by, ingest_mode) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                turso::params![
+                    "sweep_sess1_uuid-abc",
+                    "conversations",
+                    "conversations",
+                    "USER: hello",
+                    "test.jsonl",
+                    0_i32,
+                    "sweep",
+                    "sweep"
+                ],
+            )
+            .await
+            .expect("direct insert should succeed");
+
+        let session_ids: HashSet<String> = ["sess1".to_string()].into();
+        let cursors = sweep_load_cursors(&connection, &session_ids)
+            .await
+            .expect("cursor load should succeed");
+
+        assert_eq!(cursors.len(), 1);
+        assert!(
+            cursors["sess1"].contains("uuid-abc"),
+            "prior UUID must be found in cursor"
+        );
+    }
+
+    // ── sweep ────────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn sweep_new_file_inserts_all_messages() {
+        let (_db, connection) = crate::test_helpers::test_db().await;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = write_jsonl(
+            dir.path(),
+            "session.jsonl",
+            &[
+                &user_record("s1", "u1", "Hello"),
+                &assistant_record("s1", "u2", "Hi"),
+            ],
+        );
+
+        let result = sweep(&connection, &path, "test_wing")
+            .await
+            .expect("sweep should succeed");
+
+        assert_eq!(result.drawers_added, 2, "both messages must be inserted");
+        assert_eq!(result.drawers_already_present, 0);
+    }
+
+    #[tokio::test]
+    async fn sweep_rerun_counts_everything_as_already_present() {
+        let (_db, connection) = crate::test_helpers::test_db().await;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = write_jsonl(
+            dir.path(),
+            "session.jsonl",
+            &[&user_record("s1", "u1", "Hello")],
+        );
+
+        // First run.
+        sweep(&connection, &path, "test_wing")
+            .await
+            .expect("first sweep should succeed");
+
+        // Second run — cursor finds the UUID; nothing new.
+        let result = sweep(&connection, &path, "test_wing")
+            .await
+            .expect("second sweep should succeed");
+
+        assert_eq!(result.drawers_added, 0, "nothing new on re-run");
+        assert_eq!(result.drawers_already_present, 1);
+    }
+
+    #[tokio::test]
+    async fn sweep_empty_file_returns_zero_counts() {
+        let (_db, connection) = crate::test_helpers::test_db().await;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = write_jsonl(dir.path(), "empty.jsonl", &[]);
+
+        let result = sweep(&connection, &path, "test_wing")
+            .await
+            .expect("sweep empty file should succeed");
+
+        assert_eq!(result.drawers_added, 0);
+        assert_eq!(result.drawers_already_present, 0);
+    }
+
+    #[tokio::test]
+    async fn sweep_filters_non_message_records() {
+        let (_db, connection) = crate::test_helpers::test_db().await;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let progress = serde_json::json!({"type": "progress", "data": "..."}).to_string();
+        let path = write_jsonl(
+            dir.path(),
+            "session.jsonl",
+            &[&progress, &user_record("s1", "u1", "Only message")],
+        );
+
+        let result = sweep(&connection, &path, "test_wing")
+            .await
+            .expect("sweep should succeed");
+
+        assert_eq!(
+            result.drawers_added, 1,
+            "only the message record must be inserted"
+        );
+        assert_eq!(result.drawers_already_present, 0);
+    }
+
+    // ── sweep_directory_collect_files ────────────────────────────────────────
+
+    #[test]
+    fn collect_files_empty_directory_returns_empty_vec() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let files = sweep_directory_collect_files(dir.path());
+        assert!(files.is_empty());
+    }
+
+    #[test]
+    fn collect_files_finds_jsonl_files_in_root() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        fs::write(dir.path().join("a.jsonl"), "").expect("write a.jsonl");
+        fs::write(dir.path().join("b.jsonl"), "").expect("write b.jsonl");
+        let files = sweep_directory_collect_files(dir.path());
+        assert_eq!(files.len(), 2);
+        assert!(
+            files
+                .iter()
+                .all(|f| f.extension().and_then(|e| e.to_str()) == Some("jsonl"))
+        );
+    }
+
+    #[test]
+    fn collect_files_excludes_non_jsonl_files() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        fs::write(dir.path().join("a.json"), "").expect("write a.json");
+        fs::write(dir.path().join("b.txt"), "").expect("write b.txt");
+        fs::write(dir.path().join("c.jsonl"), "").expect("write c.jsonl");
+        let files = sweep_directory_collect_files(dir.path());
+        assert_eq!(files.len(), 1, "only .jsonl files must be collected");
+    }
+
+    #[test]
+    fn collect_files_recurses_into_subdirectories() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let subdir = dir.path().join("subdir");
+        fs::create_dir(&subdir).expect("mkdir subdir");
+        fs::write(dir.path().join("root.jsonl"), "").expect("write root");
+        fs::write(subdir.join("nested.jsonl"), "").expect("write nested");
+        let files = sweep_directory_collect_files(dir.path());
+        assert_eq!(files.len(), 2, "root and nested .jsonl must both be found");
+    }
+
+    #[test]
+    fn collect_files_returns_sorted_paths() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        fs::write(dir.path().join("z.jsonl"), "").expect("write z");
+        fs::write(dir.path().join("a.jsonl"), "").expect("write a");
+        let files = sweep_directory_collect_files(dir.path());
+        assert_eq!(files.len(), 2);
+        assert!(
+            files[0] < files[1],
+            "files must be returned in sorted order"
+        );
+    }
+
+    // ── sweep_directory ──────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn sweep_directory_aggregates_results_across_files() {
+        let (_db, connection) = crate::test_helpers::test_db().await;
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_jsonl(dir.path(), "a.jsonl", &[&user_record("s1", "u1", "Hello")]);
+        write_jsonl(dir.path(), "b.jsonl", &[&user_record("s2", "u2", "World")]);
+
+        let result = sweep_directory(&connection, dir.path(), "test_wing")
+            .await
+            .expect("directory sweep should succeed");
+
+        assert_eq!(result.files_attempted, 2);
+        assert_eq!(result.files_succeeded, 2);
+        assert_eq!(
+            result.drawers_added, 2,
+            "one drawer per message across two files"
+        );
+        assert_eq!(result.drawers_already_present, 0);
+    }
+
+    #[tokio::test]
+    async fn sweep_directory_empty_dir_returns_all_zero() {
+        let (_db, connection) = crate::test_helpers::test_db().await;
+        let dir = tempfile::tempdir().expect("tempdir");
+
+        let result = sweep_directory(&connection, dir.path(), "test_wing")
+            .await
+            .expect("empty directory sweep should succeed");
+
+        assert_eq!(result.files_attempted, 0);
+        assert_eq!(result.files_succeeded, 0);
+        assert_eq!(result.drawers_added, 0);
+        assert_eq!(result.drawers_already_present, 0);
+    }
+}

--- a/src/palace/sweeper.rs
+++ b/src/palace/sweeper.rs
@@ -143,7 +143,11 @@ fn flatten_content(content: &Value) -> String {
 /// `"user"` and `"assistant"`.  Malformed fields produce `None` — transcript
 /// quality is the writer's responsibility.
 fn parse_claude_jsonl_record(record: &Value) -> Option<SweepMessage> {
-    assert!(record.is_object(), "record must be a JSON object");
+    // A JSONL line can parse as any JSON value (array, string, etc.) — return
+    // None for non-objects rather than panicking; transcript quality varies.
+    if !record.is_object() {
+        return None;
+    }
 
     // Only user and assistant type records carry conversation content.
     let rtype = record.get("type")?.as_str()?;
@@ -391,15 +395,13 @@ fn sweep_directory_collect_files(dir_path: &Path) -> Vec<PathBuf> {
             depth <= WALK_DEPTH_LIMIT,
             "depth must not exceed WALK_DEPTH_LIMIT"
         );
-        if depth >= WALK_DEPTH_LIMIT {
-            continue;
-        }
         let Ok(read_dir) = std::fs::read_dir(&current_dir) else {
             continue;
         };
         for entry in read_dir.flatten() {
             let path = entry.path();
-            if path.is_dir() {
+            // Read files at WALK_DEPTH_LIMIT but do not recurse deeper.
+            if path.is_dir() && depth < WALK_DEPTH_LIMIT {
                 stack.push((path, depth + 1));
             } else if path.extension().and_then(|e| e.to_str()) == Some("jsonl") {
                 files.push(path);

--- a/src/palace/sweeper.rs
+++ b/src/palace/sweeper.rs
@@ -203,10 +203,6 @@ fn parse_claude_jsonl(path: &Path) -> Result<Vec<SweepMessage>> {
     let mut line_count: usize = 0;
 
     for line in file_content.lines() {
-        assert!(
-            line_count < MESSAGES_MAX,
-            "parse_claude_jsonl: MESSAGES_MAX exceeded"
-        );
         line_count += 1;
         if line_count > MESSAGES_MAX {
             break;

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -92,6 +92,23 @@ CREATE INDEX IF NOT EXISTS idx_tunnels_source ON explicit_tunnels(source_wing, s
 CREATE INDEX IF NOT EXISTS idx_tunnels_target ON explicit_tunnels(target_wing, target_room);
 ";
 
+/// Suppress the benign `SQLite` error that occurs when an `ALTER TABLE ADD COLUMN`
+/// targets a column that already exists (idempotent migration).
+///
+/// Any other error is propagated unchanged so startup is aborted rather than
+/// silently continuing with an inconsistent schema.
+fn ignore_duplicate_column(result: turso::Result<u64>) -> Result<()> {
+    if let Err(e) = result {
+        let message = e.to_string();
+        // SQLite message for adding an existing column: "duplicate column name: col"
+        // or "table T already has a column named col" (libsql variant).
+        if !message.contains("duplicate column name") && !message.contains("already has a column") {
+            return Err(e.into());
+        }
+    }
+    Ok(())
+}
+
 /// Create all tables and indexes if they don't already exist.
 ///
 /// Also runs lightweight migrations for existing databases (columns that were
@@ -102,20 +119,26 @@ pub async fn ensure_schema(connection: &Connection) -> Result<()> {
     connection.execute_batch(SCHEMA).await?;
 
     // Migration: add source_mtime column (introduced to support re-mining
-    // modified files).  Silently ignored for databases that already have it.
-    let _ = connection
-        .execute("ALTER TABLE drawers ADD COLUMN source_mtime REAL", ())
-        .await;
+    // modified files).  SQLite errors when the column already exists — only
+    // that benign case is suppressed; all other errors abort startup.
+    ignore_duplicate_column(
+        connection
+            .execute("ALTER TABLE drawers ADD COLUMN source_mtime REAL", ())
+            .await,
+    )?;
 
     // Migration: add RFC 002 §5.5 provenance columns to triples.  Fresh
     // databases get them from the DDL above; older databases need ALTER TABLE.
-    // SQLite returns an error when the column already exists — we discard it.
-    let _ = connection
-        .execute("ALTER TABLE triples ADD COLUMN source_drawer_id TEXT", ())
-        .await;
-    let _ = connection
-        .execute("ALTER TABLE triples ADD COLUMN adapter_name TEXT", ())
-        .await;
+    ignore_duplicate_column(
+        connection
+            .execute("ALTER TABLE triples ADD COLUMN source_drawer_id TEXT", ())
+            .await,
+    )?;
+    ignore_duplicate_column(
+        connection
+            .execute("ALTER TABLE triples ADD COLUMN adapter_name TEXT", ())
+            .await,
+    )?;
 
     // Pair assertion: verify all six core tables were created.
     let rows = crate::db::query_all(

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -53,6 +53,8 @@ CREATE TABLE IF NOT EXISTS triples (
     confidence REAL DEFAULT 1.0,
     source_closet TEXT,
     source_file TEXT,
+    source_drawer_id TEXT,
+    adapter_name TEXT,
     extracted_at TEXT DEFAULT (datetime('now'))
 );
 
@@ -103,6 +105,16 @@ pub async fn ensure_schema(connection: &Connection) -> Result<()> {
     // modified files).  Silently ignored for databases that already have it.
     let _ = connection
         .execute("ALTER TABLE drawers ADD COLUMN source_mtime REAL", ())
+        .await;
+
+    // Migration: add RFC 002 §5.5 provenance columns to triples.  Fresh
+    // databases get them from the DDL above; older databases need ALTER TABLE.
+    // SQLite returns an error when the column already exists — we discard it.
+    let _ = connection
+        .execute("ALTER TABLE triples ADD COLUMN source_drawer_id TEXT", ())
+        .await;
+    let _ = connection
+        .execute("ALTER TABLE triples ADD COLUMN adapter_name TEXT", ())
         .await;
 
     // Pair assertion: verify all six core tables were created.

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -23,6 +23,8 @@ CREATE INDEX IF NOT EXISTS idx_drawers_wing ON drawers(wing);
 CREATE INDEX IF NOT EXISTS idx_drawers_room ON drawers(room);
 CREATE INDEX IF NOT EXISTS idx_drawers_wing_room ON drawers(wing, room);
 CREATE INDEX IF NOT EXISTS idx_drawers_source ON drawers(source_file);
+-- Covers the sweeper keyset pagination query: ingest_mode = 'sweep' AND id > ? ORDER BY id
+CREATE INDEX IF NOT EXISTS idx_drawers_ingest_mode_id ON drawers(ingest_mode, id);
 
 -- Inverted index for keyword search (replaces FTS5 which turso doesn't support)
 CREATE TABLE IF NOT EXISTS drawer_words (

--- a/tests/kg_workflow.rs
+++ b/tests/kg_workflow.rs
@@ -29,6 +29,8 @@ async fn entity_triple_query_lifecycle() {
             confidence: 1.0,
             source_closet: None,
             source_file: None,
+            source_drawer_id: None,
+            adapter_name: None,
         },
     )
     .await
@@ -66,6 +68,8 @@ async fn invalidate_updates_timeline() {
             confidence: 0.9,
             source_closet: None,
             source_file: None,
+            source_drawer_id: None,
+            adapter_name: None,
         },
     )
     .await
@@ -134,6 +138,8 @@ async fn stats_reflect_operations() {
             confidence: 1.0,
             source_closet: None,
             source_file: None,
+            source_drawer_id: None,
+            adapter_name: None,
         },
     )
     .await
@@ -197,6 +203,8 @@ async fn multiple_triples_same_entities() {
                 confidence: 1.0,
                 source_closet: None,
                 source_file: None,
+                source_drawer_id: None,
+                adapter_name: None,
             },
         )
         .await


### PR DESCRIPTION
## Summary

- Bump `FILE_SIZE_MAX` from 10 MiB to 500 MiB in `miner.rs` and `convo_miner.rs`
- Add `"jsonl"` to `READABLE_EXTENSIONS` in `miner.rs`
- Add `source_drawer_id` and `adapter_name` columns to the `triples` table (RFC 002 §5.5 provenance), including idempotent `ALTER TABLE` migrations
- Add matching fields to `TripleParams` and update all 13 call sites
- Add new `sweep` command: ingests Claude `.jsonl` conversation exports as drawers, with UUID-presence cursor for idempotency
- Add 38 tests for `palace/sweeper.rs` and `cli/sweep.rs`; final coverage 96.00% total

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a sweep CLI to ingest Claude Code .jsonl files or directories idempotently, with a --wing option and per-file/directory summaries.

* **Improvements**
  * Raised per-file processing cap (10 MB → 500 MB) and added JSONL to supported formats.
  * Database schema extended with two provenance columns and safer migration handling.
  * New idempotent message-level ingestion with deterministic drawer tracking.

* **Documentation**
  * Usage docs updated for the new command and schema.

* **Tests**
  * Added tests for sweep parsing, idempotency, directory handling, and related flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->