### PR TITLE
Add per-file progress output to sweep command

### DIFF
--- a/src/palace/sweeper.rs
+++ b/src/palace/sweeper.rs
@@ -484,12 +484,21 @@ pub async fn sweep_directory(
     let mut drawers_already_present: usize = 0;
     let mut files_succeeded: usize = 0;
 
-    for file in &files {
+    println!("  Sweeping {} files...", files.len());
+
+    for (index, file) in files.iter().enumerate() {
         match sweep(connection, file, wing).await {
             Ok(result) => {
                 drawers_added += result.drawers_added;
                 drawers_already_present += result.drawers_already_present;
                 files_succeeded += 1;
+                println!(
+                    "  [{:4}/{}] {:50} +{}",
+                    index + 1,
+                    files.len(),
+                    file.file_name().unwrap_or_default().to_string_lossy(),
+                    result.drawers_added,
+                );
             }
             Err(error) => {
                 eprintln!("sweep: skipping {}: {error}", file.display());


### PR DESCRIPTION
## Summary

- `sweep_directory` was silent until completion, giving no indication of activity on large inputs
- Now prints a file count header before the loop and a per-file progress line inside the `Ok` branch, matching the format used by `mine`:
  ```
  Sweeping 42 files...
    [   1/42] session_abc.jsonl                        +12
    [   2/42] session_def.jsonl                        +0
  ```
- The final summary printed by `cli/sweep.rs` is unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added real-time progress reporting when processing files, displaying current file index, total file count, filename, and count of newly added items for improved operational visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->