### PR TITLE
Document macOS quarantine step for prebuilt binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,23 @@ cp target/release/mempalace ~/.local/bin/mempalace
 
 ### Precompiled binaries (GitHub Actions Artifacts)
 
-If you download a precompiled binary from the GitHub Actions Artifacts for this
-repository, macOS will quarantine the file because it was not distributed through
-the App Store or a notarised installer. Before running the binary, remove the
-quarantine attribute:
+Each artifact on the GitHub Actions page lists a `sha256` digest. Verify the
+downloaded zip against that digest before extracting:
+
+```bash
+# macOS
+shasum -a 256 mempalace-macos-<git-short-sha>.zip
+
+# Linux
+sha256sum mempalace-linux-<git-short-sha>.zip
+```
+
+The output should match the digest shown on the Artifacts page (strip the
+leading `sha256:` prefix before comparing).
+
+On macOS, the extracted binary will also be quarantined because it was not
+distributed through the App Store or a notarised installer. After extracting,
+remove the quarantine attribute before running:
 
 ```bash
 xattr -d com.apple.quarantine ./mempalace

--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ Optionally copy to a location on your PATH:
 cp target/release/mempalace ~/.local/bin/mempalace
 ```
 
+### Precompiled binaries (GitHub Actions Artifacts)
+
+If you download a precompiled binary from the GitHub Actions Artifacts for this
+repository, macOS will quarantine the file because it was not distributed through
+the App Store or a notarised installer. Before running the binary, remove the
+quarantine attribute:
+
+```bash
+xattr -d com.apple.quarantine ./mempalace
+```
+
 ---
 
 ## MCP Setup (Claude Code)


### PR DESCRIPTION
## Summary

- Adds a `Precompiled binaries` subsection under `Installation` in `README.md`
- Instructs users to verify the `sha256` digest shown on the Artifacts page before extracting the zip
- Explains that macOS quarantines unsigned binaries and instructs users to run `xattr -d com.apple.quarantine ./mempalace` after extracting