### PR TITLE
Isolate tests that leaked to ~/.local/share/mempalace

### DIFF
--- a/src/cli/diary_ingest.rs
+++ b/src/cli/diary_ingest.rs
@@ -47,15 +47,25 @@ mod tests {
     #[tokio::test]
     async fn run_empty_diary_dir_prints_no_new_sections() {
         // A directory with no matching diary files must return Ok without creating drawers.
+        // MEMPALACE_DIR is redirected because ingest_diaries always writes diary_cursors.json
+        // to config_dir(), which defaults to ~/.local/share/mempalace when unset.
         let diary_dir =
             tempfile::tempdir().expect("failed to create temp dir for empty diary-ingest test");
+        let cursor_dir =
+            tempfile::tempdir().expect("failed to create cursor dir for empty diary-ingest test");
         let (_db, connection) = crate::test_helpers::test_db().await;
-        run(
-            &connection,
-            diary_dir.path(),
-            "journal",
-            "test_agent",
-            false,
+        temp_env::async_with_vars(
+            [(
+                "MEMPALACE_DIR",
+                Some(cursor_dir.path().to_str().expect("utf-8")),
+            )],
+            run(
+                &connection,
+                diary_dir.path(),
+                "journal",
+                "test_agent",
+                false,
+            ),
         )
         .await
         .expect("run must succeed on empty diary directory");
@@ -64,8 +74,12 @@ mod tests {
     #[tokio::test]
     async fn run_with_diary_file_creates_drawers() {
         // A valid diary file must produce at least one drawer.
+        // MEMPALACE_DIR is redirected because ingest_diaries always writes diary_cursors.json
+        // to config_dir(), which defaults to ~/.local/share/mempalace when unset.
         let diary_dir =
             tempfile::tempdir().expect("failed to create temp dir for diary-ingest run test");
+        let cursor_dir =
+            tempfile::tempdir().expect("failed to create cursor dir for diary-ingest run test");
         std::fs::write(
             diary_dir.path().join("2024-05-01.md"),
             "## Morning\n\nHad coffee and planned the sprint.\n\n## Evening\n\nCompleted the review.",
@@ -73,14 +87,25 @@ mod tests {
         .expect("failed to write test diary file");
 
         let (_db, connection) = crate::test_helpers::test_db().await;
-        run(
-            &connection,
-            diary_dir.path(),
-            "journal",
-            "test_agent",
-            false,
+        temp_env::async_with_vars(
+            [(
+                "MEMPALACE_DIR",
+                Some(cursor_dir.path().to_str().expect("utf-8")),
+            )],
+            run(
+                &connection,
+                diary_dir.path(),
+                "journal",
+                "test_agent",
+                false,
+            ),
         )
         .await
         .expect("run must succeed with a valid diary file");
+        // Pair assertion: cursor must be written to the isolated dir, not to the real config.
+        assert!(
+            cursor_dir.path().join("diary_cursors.json").exists(),
+            "diary_cursors.json must land in the redirected MEMPALACE_DIR"
+        );
     }
 }

--- a/src/cli/hook.rs
+++ b/src/cli/hook.rs
@@ -1470,21 +1470,34 @@ mod tests {
     #[tokio::test]
     async fn run_with_json_returns_err_for_unknown_hook() {
         // An unrecognised hook name must return Err with the name in the message.
-        let result = run_with_json("bad-hook", "claude-code", json!({})).await;
-        assert!(result.is_err());
-        let error_text = result
-            .expect_err("must be Err for unknown hook")
-            .to_string();
+        // MEMPALACE_DIR is redirected because run_with_json creates hook_state before
+        // dispatching, so the unknown-hook error path still touches the filesystem.
+        let dir = tempfile::tempdir().expect("must create temp dir");
+        let error_text = temp_env::async_with_vars(
+            [("MEMPALACE_DIR", Some(dir.path().to_str().expect("utf-8")))],
+            async {
+                run_with_json("bad-hook", "claude-code", json!({}))
+                    .await
+                    .expect_err("must be Err for unknown hook")
+                    .to_string()
+            },
+        )
+        .await;
         assert!(error_text.contains("bad-hook"), "{error_text}");
     }
 
     #[tokio::test]
     async fn run_with_json_dispatches_session_start_successfully() {
         // session-start with a valid claude-code harness must return Ok.
-        let result = run_with_json(
-            "session-start",
-            "claude-code",
-            json!({"session_id": "test-sid"}),
+        // MEMPALACE_DIR is redirected because run_with_json creates hook_state on disk.
+        let dir = tempfile::tempdir().expect("must create temp dir");
+        let result = temp_env::async_with_vars(
+            [("MEMPALACE_DIR", Some(dir.path().to_str().expect("utf-8")))],
+            run_with_json(
+                "session-start",
+                "claude-code",
+                json!({"session_id": "test-sid"}),
+            ),
         )
         .await;
         assert!(result.is_ok(), "session-start must succeed: {result:?}");
@@ -1493,14 +1506,26 @@ mod tests {
     #[tokio::test]
     async fn run_with_json_dispatches_precompact_successfully() {
         // precompact with no transcript must return Ok (logs and exits early).
-        let result = run_with_json("precompact", "claude-code", json!({"session_id": "sid"})).await;
+        // MEMPALACE_DIR is redirected because run_with_json creates hook_state on disk.
+        let dir = tempfile::tempdir().expect("must create temp dir");
+        let result = temp_env::async_with_vars(
+            [("MEMPALACE_DIR", Some(dir.path().to_str().expect("utf-8")))],
+            run_with_json("precompact", "claude-code", json!({"session_id": "sid"})),
+        )
+        .await;
         assert!(result.is_ok(), "precompact must succeed: {result:?}");
     }
 
     #[tokio::test]
     async fn run_with_json_dispatches_stop_successfully() {
         // stop with exchange_count=0 must return Ok (exits at the threshold check).
-        let result = run_with_json("stop", "claude-code", json!({"session_id": "sid"})).await;
+        // MEMPALACE_DIR is redirected because run_with_json creates hook_state on disk.
+        let dir = tempfile::tempdir().expect("must create temp dir");
+        let result = temp_env::async_with_vars(
+            [("MEMPALACE_DIR", Some(dir.path().to_str().expect("utf-8")))],
+            run_with_json("stop", "claude-code", json!({"session_id": "sid"})),
+        )
+        .await;
         assert!(result.is_ok(), "stop must succeed: {result:?}");
     }
 

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -827,10 +827,14 @@ mod tests {
     #[test]
     fn run_confirm_and_save_writes_entities_json_when_entities_confirmed() {
         // With yes=true and high-confidence people, entities.json must be written.
+        // MEMPALACE_DIR is redirected because add_to_known_entities writes
+        // known_entities.json to config_dir(), which defaults to ~/.local/share/mempalace.
         use crate::palace::entities::DetectedEntity;
         use crate::palace::project_scanner::DetectedDict;
         let temp_dir =
             tempfile::tempdir().expect("must create temp dir for run_confirm_and_save test");
+        let registry_dir =
+            tempfile::tempdir().expect("must create registry dir for run_confirm_and_save test");
         let detected = DetectedDict {
             people: vec![DetectedEntity {
                 name: "Alice".to_string(),
@@ -842,8 +846,10 @@ mod tests {
             projects: vec![],
             uncertain: vec![],
         };
-        run_confirm_and_save(&detected, true, temp_dir.path())
-            .expect("run_confirm_and_save must succeed");
+        temp_env::with_var("MEMPALACE_DIR", Some(registry_dir.path()), || {
+            run_confirm_and_save(&detected, true, temp_dir.path())
+                .expect("run_confirm_and_save must succeed");
+        });
         let entities_path = temp_dir.path().join("entities.json");
         assert!(entities_path.exists(), "entities.json must be written");
         let content =
@@ -853,6 +859,11 @@ mod tests {
             "entities.json must name the confirmed person"
         );
         assert!(!content.is_empty());
+        // Pair assertion: known_entities.json must be in the isolated registry dir.
+        assert!(
+            registry_dir.path().join("known_entities.json").exists(),
+            "known_entities.json must land in the redirected MEMPALACE_DIR"
+        );
     }
 
     #[test]
@@ -885,9 +896,13 @@ mod tests {
     #[test]
     fn run_confirm_and_save_writes_both_people_and_projects() {
         // When both people and projects are confirmed, both categories appear in entities.json.
+        // MEMPALACE_DIR is redirected because add_to_known_entities writes
+        // known_entities.json to config_dir(), which defaults to ~/.local/share/mempalace.
         use crate::palace::entities::DetectedEntity;
         use crate::palace::project_scanner::DetectedDict;
         let temp_dir = tempfile::tempdir().expect("must create temp dir for both-categories test");
+        let registry_dir =
+            tempfile::tempdir().expect("must create registry dir for both-categories test");
         let detected = DetectedDict {
             people: vec![DetectedEntity {
                 name: "Alice".to_string(),
@@ -905,8 +920,10 @@ mod tests {
             }],
             uncertain: vec![],
         };
-        run_confirm_and_save(&detected, true, temp_dir.path())
-            .expect("run_confirm_and_save must succeed");
+        temp_env::with_var("MEMPALACE_DIR", Some(registry_dir.path()), || {
+            run_confirm_and_save(&detected, true, temp_dir.path())
+                .expect("run_confirm_and_save must succeed");
+        });
         let entities_path = temp_dir.path().join("entities.json");
         assert!(entities_path.exists(), "entities.json must be written");
         let content =


### PR DESCRIPTION
## Summary

- Seven tests in `cli::hook`, `cli::init`, and `cli::diary_ingest` wrote real files to `~/.local/share/mempalace` because they called `config_dir()`-dependent functions without redirecting `MEMPALACE_DIR` via `temp_env`
- `cli::hook`: five `run_with_json_*` tests created `hook_state/` — `run_with_json` calls `config_dir()` before dispatching to any hook handler
- `cli::init`: two `run_confirm_and_save_writes_*` tests wrote `known_entities.json` via `add_to_known_entities` when high-confidence entities were auto-confirmed
- `cli::diary_ingest`: both `run_*` tests wrote `diary_cursors.json` because `ingest_diaries` calls `diary_ingest_save_cursor` unconditionally, even for empty directories
- Each leaking test now redirects `MEMPALACE_DIR` to a `tempfile::tempdir()`, and the two tests with meaningful write-side effects gain pair assertions confirming the file landed in the isolated directory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure isolation across diary management, hook handling, and system initialization modules by implementing temporary directory redirection for configuration file operations. This prevents test execution from inadvertently writing to or modifying the user's configuration directories and persistent data, ensuring improved test stability and reliability overall.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->