### PR TITLE
Rename install_before to minimum_release_age in mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 # https://mise.jdx.dev/
 [settings]
 experimental = true
-install_before = "7d"
+minimum_release_age = "7d"
 npm.package_manager = "bun"
 
 [tools]


### PR DESCRIPTION
## Summary

- `install_before` is deprecated in mise and will be removed in a future version
- Renamed to `minimum_release_age`, which preserves the same 7-day hold on new tool releases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configuration settings updated to improve release version management handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->