### PR TITLE
Delete bunfig.toml

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,3 +1,0 @@
-[install]
-# 7 days in seconds
-minimumReleaseAge = 604800


### PR DESCRIPTION
Bun is used by Mise to install `markdownlint-cli`
The minimum release age is enforced by mise, making `bunfig.toml` unneeded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Removed the minimum release age constraint from package installation configuration, allowing dependencies to be installed with greater flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->